### PR TITLE
Understand split VPN routes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ bin_PROGRAMS = openfortivpn
 openfortivpn_SOURCES = src/config.c src/config.h src/hdlc.c src/hdlc.h \
 		       src/http.c src/http.h src/io.c src/io.h src/ipv4.c \
 		       src/ipv4.h src/log.c src/log.h src/tunnel.c \
-		       src/tunnel.h src/main.c src/ssl.h
+		       src/tunnel.h src/main.c src/ssl.h src/xml.c src/xml.h
 openfortivpn_CFLAGS = -Wall --pedantic -std=gnu99
 
 confdir=$(sysconfdir)/openfortivpn

--- a/src/http.c
+++ b/src/http.c
@@ -16,8 +16,10 @@
  */
 
 #include "http.h"
+#include "xml.h"
 #include "log.h"
 #include "ssl.h"
+#include "ipv4.h"
 
 #define BUFSZ 0x8000
 
@@ -204,7 +206,7 @@ static int do_http_request(struct tunnel *tunnel, const char *method,
  * @return     1         in case of success
  *             < 0       in case of error
  */
-int http_request(struct tunnel *tunnel, const char *method,
+static int http_request(struct tunnel *tunnel, const char *method,
 			const char *uri, const char *data, char **response)
 {
 	int ret = do_http_request (tunnel, method, uri, data, response);
@@ -285,4 +287,51 @@ int auth_request_vpn_allocation(struct tunnel *tunnel)
 		return ret;
 
 	return http_request(tunnel, "GET", "/remote/fortisslvpn", "", NULL);
+}
+
+int auth_get_config(struct tunnel *tunnel)
+{
+	char *buffer;
+	char *val;
+	char *dest, *mask, *gateway;
+	int ret;
+
+	ret = http_request(tunnel, "GET", "/remote/fortisslvpn_xml", "", &buffer);
+	if (ret != 1)
+		return ret;
+
+	// Skip the HTTP header
+	buffer = strstr(buffer, "\r\n\r\n");
+
+	// The address of a local end of a router
+	val = xml_find('<', "assigned-addr", buffer, 1);
+	gateway = xml_get(xml_find(' ', "ipv4=", val, 1));
+	if (!gateway) {
+		log_warn("No gateway address\n");
+		return ret;
+	}
+
+	// Routes the tunnel wants to push
+	val = xml_find('<', "split-tunnel-info", buffer, 1);
+	while ((val = xml_find('<', "addr", val, 2))) {
+		dest = xml_get(xml_find(' ', "ip=", val, 1));
+		if (!dest) {
+			log_warn("No ip address for a route\n");
+			continue;
+		}
+
+		mask = xml_get(xml_find(' ', "mask=", val, 1));
+		if (!mask) {
+			log_warn("No mask for a route\n");
+			free(dest);
+			continue;
+		}
+
+		ipv4_add_split_vpn_route(tunnel, dest, mask, gateway);
+		free(dest);
+		free(mask);
+	}
+
+	free(gateway);
+	return ret;
 }

--- a/src/http.c
+++ b/src/http.c
@@ -294,7 +294,9 @@ int auth_get_config(struct tunnel *tunnel)
 	char *buffer;
 	char *val;
 	char *dest, *mask, *gateway;
+	char env_var[21];
 	int ret;
+	int i = 0;
 
 	ret = http_request(tunnel, "GET", "/remote/fortisslvpn_xml", "", &buffer);
 	if (ret != 1)
@@ -328,9 +330,22 @@ int auth_get_config(struct tunnel *tunnel)
 		}
 
 		ipv4_add_split_vpn_route(tunnel, dest, mask, gateway);
+
+		if (i < 100) {
+			sprintf(env_var, "VPN_ROUTE_DEST_%d", i);
+			setenv(env_var, dest, 0);
+			sprintf(env_var, "VPN_ROUTE_MASK_%d", i);
+			setenv(env_var, mask, 0);
+			sprintf(env_var, "VPN_ROUTE_GATEWAY_%d", i);
+			setenv(env_var, gateway, 0);
+			i++;
+		}
+
 		free(dest);
 		free(mask);
 	}
+	if (i >= 100)
+		log_warn("Too many routes\n");
 
 	free(gateway);
 	return ret;

--- a/src/http.h
+++ b/src/http.h
@@ -49,10 +49,10 @@ static inline const char *err_http_str(int code)
 
 int http_send(struct tunnel *tunnel, const char *request, ...);
 int http_receive(struct tunnel *tunnel, char **response);
-int http_request(struct tunnel *tunnel, const char *method, const char *uri, const char *data, char **response);
 
 int auth_log_in(struct tunnel *tunnel);
 int auth_log_out(struct tunnel *tunnel);
 int auth_request_vpn_allocation(struct tunnel *tunnel);
+int auth_get_config(struct tunnel *tunnel);
 
 #endif

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -42,6 +42,7 @@ static inline const char *err_ipv4_str(int code)
 }
 
 #define ROUTE_IFACE_LEN 32
+#define MAX_SPLIT_ROUTES 32
 
 struct ipv4_config {
 	struct in_addr	ip_addr;
@@ -49,10 +50,12 @@ struct ipv4_config {
 	struct in_addr	ns1_addr;
 	struct in_addr	ns2_addr;
 	int		ns_are_new; // were ns already in /etc/resolv.conf?
+	int		split_routes;
 
 	struct rtentry	def_rt; // default route
 	struct rtentry	gtw_rt; // route to access VPN gateway
 	struct rtentry	ppp_rt; // new default route through VPN
+	struct rtentry	split_rt[MAX_SPLIT_ROUTES]; // split VPN routes
 };
 
 #define route_dest(route) \
@@ -66,6 +69,7 @@ struct ipv4_config {
 
 struct tunnel;
 
+int ipv4_add_split_vpn_route(struct tunnel *tunnel, char *dest, char *mask, char *gateway);
 int ipv4_set_tunnel_routes(struct tunnel *tunnel);
 int ipv4_restore_routes(struct tunnel *tunnel);
 

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -415,15 +415,14 @@ int run_tunnel(struct vpn_config *config)
 	if (ret)
 		goto err_tunnel;
 
-	// Step 4: ask gateway to start tunneling
 	ret = ssl_connect(&tunnel);
 	if (ret)
 		goto err_tunnel;
 
-        ret = http_request(&tunnel, "GET", "/remote/fortisslvpn_xml", "", NULL);
-        if (ret != 1)
-                return ret;
+	// Step 4: get configuration
+	auth_get_config(&tunnel);
 
+	// Step 5: ask gateway to start tunneling
 	ret = http_send(&tunnel, "GET /remote/sslvpn-tunnel HTTP/1.1\n"
 				 "Host: sslvpn\n"
 				 "Cookie: %s\n\n%c",
@@ -437,7 +436,7 @@ int run_tunnel(struct vpn_config *config)
 	tunnel.state = STATE_CONNECTING;
 	ret = 0;
 
-	// Step 5: perform io between pppd and the gateway, while tunnel is up
+	// Step 6: perform io between pppd and the gateway, while tunnel is up
 	io_loop(&tunnel);
 
 	if (tunnel.state == STATE_UP)

--- a/src/xml.c
+++ b/src/xml.c
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (C) 2015 Lubomir Rintel
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+
+#include "xml.h"
+#include "log.h"
+
+/*
+ * Poor man's XML parser. Looks for given tag or attribute. Assumes
+ * there's no CDATA or text content and does not recognize strings:
+ * it would mess up the parsing if they contain '<' or '/'.
+ *
+ * @t		'<' if we're looking for a tag, ' ' if we're looking
+ * 		for an attribute.
+ * @needle	name of a tag or attribute (end and attribute with a
+ * 		'=' to swallow	it).
+ * @buf		a NUL terminated buffer to look in.
+ * @nest	do not escape more than @nest levels of nesting
+ * 		(1 == look for kids, 2 == look for siblings).
+ * @return	a string immediately following the needle if found,
+ * 		%NULL otherwise.
+ */
+char *
+xml_find(char t, char *needle, char *buf, int nest)
+{
+	int i;
+
+	if (!buf)
+		return NULL;
+	for (i = 0; buf[i]; i++) {
+		if (buf[i] == '<' && buf[i + 1] != '/')
+			nest++;
+		if (buf[i] == '/')
+			nest--;
+		if (!nest)
+			return NULL;
+		if (&buf[i+1] == strstr(&buf[i], needle) &&
+		    buf[i] == t) {
+			return &buf[i + 1 + strlen(needle)];
+		}
+	}
+	return NULL;
+}
+
+/*
+ * Poor man's XML attribute parser. Takes the first string as a quoting
+ * character and consumes characters until the next occurence or an end
+ * of the buffer. Doesn't return more than 15 characters (enough for an
+ * IPv4 address textural form).
+ *
+ * @buf		a NUL terminated buffer to look in.
+ * @return	%NULL in case of an error, a character string with
+ * 		ownership passed upon success
+ */
+char *
+xml_get(char *buf)
+{
+	char val[16];	// Just enough to hold an IPv4 address
+	char quote;
+	int i;
+
+	if (!buf)
+		return NULL;
+	quote = buf[0];
+	if (!quote) {
+		log_warn("Short read while getting value in config XML\n");
+		return NULL;
+	}
+	for (i = 1; buf[i]; i++) {
+		if (buf[i] == quote)
+			break;
+		if (i == 15) {
+			log_warn("Value too long in config XML\n");
+			break;
+		}
+		val[i - 1] = buf[i];
+	}
+	if (buf[i] != quote) {
+		log_warn("Could not read out an attribute value in config XML\n");
+		return NULL;
+	}
+	val[i - 1] = '\0';
+
+	return strdup(val);
+}

--- a/src/xml.h
+++ b/src/xml.h
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (C) 2015 Lubomir Rintel
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _XML_H
+#define _XML_H
+
+#include "tunnel.h"
+
+char *xml_find (char t, char *tag, char *buf, int nest);
+char *xml_get (char *buf);
+
+#endif


### PR DESCRIPTION
Only supports FortiOS 5 with /remote/fortisslvpn_xml resource. For FortiOS we'd need to parse the /remote/fortisslvpn response it seems.

Adds some hooks for NetworkManager to manage the routes too.