### PR TITLE
config: Rename --plugin to --pppd-plugin

### DIFF
--- a/doc/openfortivpn.1
+++ b/doc/openfortivpn.1
@@ -12,7 +12,7 @@ openfortivpn \- Client for PPP+SSL VPN tunnel services
 [\fB\-\-no-dns\fR]
 [\fB\-\-trusted-cert=\fI<digest>\fR]
 [\fB\-\-pppd-log=\fI<file>\fR]
-[\fB\-\-plugin=\fI<file>\fR]
+[\fB\-\-pppd-plugin=\fI<file>\fR]
 [\fB\-c\fR \fI<file>\fR]
 [\fB\-v|\-q\fR]
 .br
@@ -71,7 +71,7 @@ several certificates.
 \fB\-\-pppd-log=\fI<file>\fR
 Set pppd in debug mode and save its logs into \fI<file>\fR.
 .TP
-\fB\-\-plugin=\fI<file>\fR
+\fB\-\-pppd-plugin=\fI<file>\fR
 Use specified pppd plugin instead of configuring the resolver and routes
 directly.
 .TP

--- a/src/config.h
+++ b/src/config.h
@@ -63,7 +63,7 @@ struct vpn_config {
 	int	set_dns;
 
 	char	*pppd_log;
-	char	*plugin;
+	char	*pppd_plugin;
 
 	char	                *ca_file;
 	char	                *user_cert;
@@ -79,7 +79,7 @@ struct vpn_config {
 		(cfg)->username[0] = '\0'; \
 		(cfg)->password[0] = '\0'; \
 		(cfg)->pppd_log = NULL; \
-		(cfg)->plugin = NULL; \
+		(cfg)->pppd_plugin = NULL; \
 		(cfg)->ca_file = NULL; \
 		(cfg)->user_cert = NULL; \
 		(cfg)->user_key = NULL; \

--- a/src/main.c
+++ b/src/main.c
@@ -25,7 +25,7 @@
 #define USAGE \
 "Usage: openfortivpn [<host>:<port>] [-u <user>] [-p <pass>]\n" \
 "                    [--no-routes] [--no-dns] [--pppd-log=<file>]\n" \
-"                    [--plugin=<file>] [--ca-file=<file>]\n" \
+"                    [--pppd-plugin=<file>] [--ca-file=<file>]\n" \
 "                    [--user-cert=<file>] [--user-key=<file>]\n" \
 "                    [--trusted-cert=<digest>] [-c <file>] [-v|-q]\n" \
 "       openfortivpn --help\n" \
@@ -65,7 +65,7 @@ USAGE \
 "                                several certificates.\n" \
 "  --pppd-log=<file>             Set pppd in debug mode and save its logs into\n" \
 "                                <file>.\n" \
-"  --plugin=<file>               Use specified pppd plugin instead of configuring\n"\
+"  --pppd-plugin=<file>          Use specified pppd plugin instead of configuring\n"\
 "                                resolver and routes directly.\n" \
 "  -v                            Increase verbosity. Can be used multiple times\n" \
 "                                to be even more verbose.\n" \
@@ -146,7 +146,8 @@ int main(int argc, char **argv)
 		{"user-key",      required_argument, 0, 0},
 		{"trusted-cert",  required_argument, 0, 0},
 		{"pppd-log",      required_argument, 0, 0},
-		{"plugin",        required_argument, 0, 0},
+		{"pppd-plugin",   required_argument, 0, 0},
+		{"plugin",        required_argument, 0, 0}, // deprecated
 		{0, 0, 0, 0}
 	};
 
@@ -178,8 +179,15 @@ int main(int argc, char **argv)
 				break;
 			}
 			if (strcmp(long_options[option_index].name,
+				   "pppd-plugin") == 0) {
+				cfg.pppd_plugin = optarg;
+				break;
+			}
+			// --plugin is deprecated, --pppd-plugin should be used
+			if (cfg.pppd_plugin == NULL &&
+			    strcmp(long_options[option_index].name,
 				   "plugin") == 0) {
-				cfg.plugin = optarg;
+				cfg.pppd_plugin = optarg;
 				break;
 			}
 			if (strcmp(long_options[option_index].name,

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -103,9 +103,9 @@ static int pppd_run(struct tunnel *tunnel)
 			args[i++] = "logfile";
 			args[i++] = tunnel->config->pppd_log;
 		}
-		if (tunnel->config->plugin) {
+		if (tunnel->config->pppd_plugin) {
 			args[i++] = "plugin";
-			args[i++] = tunnel->config->plugin;
+			args[i++] = tunnel->config->pppd_plugin;
 		}
 
 		close(tunnel->ssl_socket);


### PR DESCRIPTION
For consistency with other pppd-related options, and to preserve the
ability to add a plugin system to openfortivpn in the future, rename
the pppd plugin option to --pppd-plugin.