### PR TITLE
Up COOKIE_SIZE to 240 as the SVPNCOOKIE is longer in newer FortiOS ve…

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -49,7 +49,7 @@ struct x509_digest {
 };
 
 #define FIELD_SIZE	64
-#define COOKIE_SIZE	(12 + 3 * (64 + 3))
+#define COOKIE_SIZE	240
 
 struct vpn_config {
 	char 		gateway_host[FIELD_SIZE];


### PR DESCRIPTION
…rsions

The previous value of COOKIE_SIZE resulted in the cookie being cut off at
least for FortiOS 5.2.x. Most likely they use a longer hash. This patch
allows connecting to these versions.