### PR TITLE
Add initial support for two-factor authentication.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -85,7 +85,7 @@ USAGE \
 "      trusted-cert = certificatedigest4daa8c5fe6c...\n" \
 "      trusted-cert = othercertificatedigest6631bf...\n"
 
-static void read_password(const char *prompt, char *pass, size_t len)
+void read_password(const char *prompt, char *pass, size_t len)
 {
 	int masked = 0;
 	struct termios oldt, newt;

--- a/src/main.h
+++ b/src/main.h
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (C) 2015 Adrien Vergé
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _MAIN_H
+#define _MAIN_H
+
+void read_password(const char *prompt, char *pass, size_t len);
+
+#endif
+


### PR DESCRIPTION
This commit adds initial support for two-factor authentication, where
the FortiGate sends a challenge through email/SMS after initial
user/password login and expects the user to provide the challenge
as a second authentication method.

This is tested working on FortiOS 5.2, with SMS tokens. It's very likely
that not all possible token authentication setups are supported (not sure
what the "code2=" parameter does, for example).
