### PR TITLE
Increase COOKIE_SIZE (again)

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -49,7 +49,7 @@ struct x509_digest {
 };
 
 #define FIELD_SIZE	64
-#define COOKIE_SIZE	240
+#define COOKIE_SIZE	300
 
 struct vpn_config {
 	char 		gateway_host[FIELD_SIZE];


### PR DESCRIPTION
COOKIE_SIZE was recently changed from 213 to 240 to support newer VPN versions.

It seems that it was still not enough for some versions. This patchs sets it to 300 bytes.

References:
* https://github.com/adrienverge/openfortivpn/issues/18#issuecomment-158406434
* https://github.com/adrienverge/openfortivpn/pull/23#issuecomment-161621177