### PR TITLE
Add support for realm authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Examples
   openfortivpn vpn-gateway:8443 --username=foo
   ```
 
+* Connect to a VPN using an authentication realm:
+
+  ```
+  openfortivpn vpn-gateway:8443 --username=foo --realm=bar
+  ```
+
 * Don't set IP routes and don't add VPN nameservers to `/etc/resolv.conf`:
 
   ```

--- a/doc/openfortivpn.1
+++ b/doc/openfortivpn.1
@@ -44,6 +44,10 @@ VPN account username.
 \fB\-p \fI<pass>\fR, \fB\-\-password=\fI<pass>\fR
 VPN account password.
 .TP
+\fB\-\-realm=\fI<realm>\fR
+Connect to the specified authentication realm. Defaults to empty, which
+is usually what you want.
+.TP
 \fB\-\-no-routes\fR
 Do not try to configure IP routes through the VPN when tunnel is up.
 .TP

--- a/src/config.h
+++ b/src/config.h
@@ -58,6 +58,7 @@ struct vpn_config {
 	char		username[FIELD_SIZE];
 	char		password[FIELD_SIZE];
 	char		cookie[COOKIE_SIZE + 1];
+	char            realm[FIELD_SIZE];
 
 	int	set_routes;
 	int	set_dns;
@@ -76,6 +77,7 @@ struct vpn_config {
 	do { \
 		(cfg)->gateway_host[0] = '\0'; \
 		(cfg)->gateway_port = 0; \
+		(cfg)->realm[0] = '\0'; \
 		(cfg)->username[0] = '\0'; \
 		(cfg)->password[0] = '\0'; \
 		(cfg)->pppd_log = NULL; \

--- a/src/main.c
+++ b/src/main.c
@@ -24,10 +24,11 @@
 
 #define USAGE \
 "Usage: openfortivpn [<host>:<port>] [-u <user>] [-p <pass>]\n" \
-"                    [--no-routes] [--no-dns] [--pppd-log=<file>]\n" \
-"                    [--pppd-plugin=<file>] [--ca-file=<file>]\n" \
-"                    [--user-cert=<file>] [--user-key=<file>]\n" \
-"                    [--trusted-cert=<digest>] [-c <file>] [-v|-q]\n" \
+"                    [--realm=<realm>] [--no-routes] [--no-dns]\n" \
+"                    [--pppd-log=<file>] [--pppd-plugin=<file>]\n" \
+"                    [--ca-file=<file>] [--user-cert=<file>]\n" \
+"                    [--user-key=<file>] [--trusted-cert=<digest>]\n" \
+"                    [-c <file>] [-v|-q]\n" \
 "       openfortivpn --help\n" \
 "       openfortivpn --version\n"
 
@@ -49,6 +50,7 @@ USAGE \
 "  --no-routes                   Do not try to configure IP routes through the\n" \
 "                                VPN when tunnel is up.\n" \
 "  --no-dns                      Do not add VPN nameservers in /etc/resolv.conf\n" \
+"  --realm=<realm>               Use specified authentication realm on VPN gateway\n" \
 "                                when tunnel is up.\n" \
 "  --ca-file=<file>              Use specified PEM-encoded certificate bundle\n" \
 "                                instead of system-wide store to verify the gateway\n" \
@@ -106,6 +108,7 @@ int main(int argc, char **argv)
 		{"help",          no_argument,       0, 'h'},
 		{"version",       no_argument,       0, 0},
 		{"config",        required_argument, 0, 'c'},
+		{"realm",         required_argument, 0, 0},
 		{"username",      required_argument, 0, 'u'},
 		{"password",      required_argument, 0, 'p'},
 		{"no-routes",     no_argument, &cfg.set_routes, 0},
@@ -172,6 +175,11 @@ int main(int argc, char **argv)
 			if (strcmp(long_options[option_index].name,
 			           "user-key") == 0) {
 				cfg.user_key = optarg;
+				break;
+			}
+			if (strcmp(long_options[option_index].name,
+			           "realm") == 0) {
+				strncpy(cfg.realm, optarg, FIELD_SIZE - 1);
 				break;
 			}
 			if (strcmp(long_options[option_index].name,
@@ -269,6 +277,7 @@ int main(int argc, char **argv)
 	}
 
 	log_debug("Config host = \"%s\"\n", cfg.gateway_host);
+	log_debug("Config realm = \"%s\"\n", cfg.realm);
 	log_debug("Config port = \"%d\"\n", cfg.gateway_port);
 	log_debug("Config username = \"%s\"\n", cfg.username);
 	log_debug("Config password = \"%s\"\n", "********");


### PR DESCRIPTION
The official fortinet client accepts a connection string of the form:

    https://<vpnhost>:<port>/<realm>

Most VPN setups do not use the realm, so it's empty. It's only used
to provide multiple VPNs with different configuration on the same gateway.

This commit adds a --realm option to specify an authentication realm
to authenticate to. It defaults to empty.