### PR TITLE
quick fix #35

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,7 @@ AC_CHECK_LIB([crypto], [ERR_peek_last_error], [], [AC_MSG_ERROR([Cannot find lib
 AC_CHECK_LIB([pthread], [pthread_create], [], [AC_MSG_ERROR([Cannot find libpthread.])])
 AC_CHECK_LIB([ssl], [SSL_connect], [], [AC_MSG_ERROR([Cannot find libssl.])])
 AC_CHECK_LIB([util], [forkpty], [], [AC_MSG_ERROR([Cannot find libutil.])])
+AC_CHECK_LIB([curl], [curl_global_init], [], [AC_MSG_ERROR([Cannot find libcurl.])])
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stddef.h stdint.h stdlib.h string.h strings.h sys/ioctl.h sys/socket.h unistd.h])

--- a/src/config.h
+++ b/src/config.h
@@ -52,11 +52,11 @@ struct x509_digest {
 #define COOKIE_SIZE	300
 
 struct vpn_config {
-	char 		gateway_host[FIELD_SIZE];
+	char 		gateway_host[FIELD_SIZE + 1];
 	struct in_addr	gateway_ip;
 	uint16_t	gateway_port;
-	char		username[FIELD_SIZE];
-	char		password[FIELD_SIZE];
+	char		username[FIELD_SIZE + 1];
+	char		password[FIELD_SIZE + 1];
 	char		cookie[COOKIE_SIZE + 1];
 	char            realm[FIELD_SIZE];
 

--- a/src/main.c
+++ b/src/main.c
@@ -142,37 +142,6 @@ static int sanitize_web_param_buf(char *config_str) {
 	return ret_val;
 }
 
-static void read_password(const char *prompt, char *pass, size_t len)
-{
-	int masked = 0;
-	struct termios oldt, newt;
-	int i;
-
-	printf("%s", prompt);
-
-	// Try to hide user input
-	if (tcgetattr(STDIN_FILENO, &oldt) == 0) {
-		newt = oldt;
-		newt.c_lflag &= ~(ICANON | ECHO);
-		tcsetattr(STDIN_FILENO, TCSANOW, &newt);
-		masked = 1;
-	}
-
-	for (i = 0; i < len - 1; i++) {
-		char c = getchar();
-		if (c == '\n' || c == EOF)
-			break;
-		pass[i] = c;
-	}
-	pass[i] = '\0';
-
-	if (masked) {
-		tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
-	}
-
-	printf("\n");
-}
-
 int main(int argc, char **argv)
 {
 	int ret = EXIT_FAILURE;

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,9 @@
  */
 
 #include <getopt.h>
-
+#include <termios.h>
+#include <stdio.h>
+#include <curl/curl.h>
 #include "config.h"
 #include "log.h"
 #include "tunnel.h"
@@ -86,6 +88,90 @@ USAGE \
 "      password = bar\n" \
 "      trusted-cert = certificatedigest4daa8c5fe6c...\n" \
 "      trusted-cert = othercertificatedigest6631bf...\n"
+
+
+/**
+ * fixes #35 in a patchy way without flow change.
+ * "introduces" libcurl, so the packaging requirements are made,
+ * and further development can be started without that plumbing stuff
+ * to eventually migrate http operations to be done via libcurl
+ *
+ * TODO: obsolete this function after the migration
+ */
+static void url_encode_str(const char* src, char* dest){
+	CURL *curl = NULL;
+	size_t len = -1;
+	log_debug("URL-encoding strings with CURL\n");
+	len = strnlen(src, FIELD_SIZE);
+	curl = curl_easy_init();
+	if (!curl) {
+		log_warn("CURL failed string was not URL-encoded\n");
+		strncpy(dest, src, len);
+		return;
+	}
+	char *output = curl_easy_escape(curl, src, len);
+	if(!output) {
+		log_warn("curl_easy_escape() failed string was not URL-encoded\n");
+		strncpy(dest, src, len);
+		return;
+	}
+	/* assuming output is good here */
+	/* every char in src can become 3 chars in output */
+	strncpy(dest, output, len*3);
+	curl_free(output);
+	return;
+}
+
+
+static int sanitize_web_param_buf(char *config_str) {
+	int ret_val = -1;
+	char * str_safe = (char*)malloc((FIELD_SIZE*3)+1);
+	if (!str_safe) {
+		log_error("Failed to allocate buffer for URL escaped string.\n");
+		return ret_val;
+	}
+	url_encode_str(config_str, str_safe);
+	/* replace data in current config */
+	/* NOTE: still possible problems with long passwords */
+	ret_val = 0;
+	if (config_str != strncpy(config_str, str_safe, FIELD_SIZE)){
+		log_error("Failed to copy escaped buffer back");
+		ret_val = -2;
+	}
+	free(str_safe);
+	return ret_val;
+}
+
+static void read_password(const char *prompt, char *pass, size_t len)
+{
+	int masked = 0;
+	struct termios oldt, newt;
+	int i;
+
+	printf("%s", prompt);
+
+	// Try to hide user input
+	if (tcgetattr(STDIN_FILENO, &oldt) == 0) {
+		newt = oldt;
+		newt.c_lflag &= ~(ICANON | ECHO);
+		tcsetattr(STDIN_FILENO, TCSANOW, &newt);
+		masked = 1;
+	}
+
+	for (i = 0; i < len - 1; i++) {
+		char c = getchar();
+		if (c == '\n' || c == EOF)
+			break;
+		pass[i] = c;
+	}
+	pass[i] = '\0';
+
+	if (masked) {
+		tcsetattr(STDIN_FILENO, TCSANOW, &oldt);
+	}
+
+	printf("\n");
+}
 
 int main(int argc, char **argv)
 {
@@ -274,6 +360,13 @@ int main(int argc, char **argv)
 	if (cfg.password[0] == '\0') {
 		log_error("Specify a password.\n");
 		goto user_error;
+	}
+	/* url escape username and password: */
+	if (0 != sanitize_web_param_buf(cfg.username)) {
+		goto exit;
+	}
+	if (0 != sanitize_web_param_buf(cfg.password)) {
+		goto exit;
 	}
 
 	log_debug("Config host = \"%s\"\n", cfg.gateway_host);


### PR DESCRIPTION
- don't touch cookie size bug #32
- use curl for url escaping
- url escaping is happening right before calling to tunnel setup routine.
- maintainer: new dependency here: libcurl (runtime), libcurl-devel (build)

Signed-off-by: Max Kovgan <kovganm@gmail.com>
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1290902