### PR TITLE
fixes #35

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,16 +10,32 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_PROG_CC
 AC_GNU_SOURCE
 
-AM_SILENT_RULES([yes])
+
+AM_SILENT_RULES
 
 # Checks for libraries.
 AC_CHECK_LIB([crypto], [ERR_peek_last_error], [], [AC_MSG_ERROR([Cannot find libcrypto.])])
 AC_CHECK_LIB([pthread], [pthread_create], [], [AC_MSG_ERROR([Cannot find libpthread.])])
 AC_CHECK_LIB([ssl], [SSL_connect], [], [AC_MSG_ERROR([Cannot find libssl.])])
 AC_CHECK_LIB([util], [forkpty], [], [AC_MSG_ERROR([Cannot find libutil.])])
+AC_CHECK_LIB([curl], [curl_global_init], [], [AC_MSG_ERROR([Cannot find libcurl.])])
 
 # Checks for header files.
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stddef.h stdint.h stdlib.h string.h strings.h sys/ioctl.h sys/socket.h unistd.h])
+AC_CHECK_HEADERS [\
+	arpa/inet.h \
+	fcntl.h \
+	netdb.h \
+	netinet/in.h \
+	stddef.h \
+	stdint.h \
+	stdlib.h \
+	string.h \
+	strings.h \
+	sys/ioctl.h \
+	sys/socket.h \
+	unistd.h\
+	]
+#([arpa/inet.h fcntl.h netdb.h netinet/in.h stddef.h stdint.h stdlib.h string.h strings.h sys/ioctl.h sys/socket.h unistd.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,8 @@
  */
 
 #include <getopt.h>
-
+#include <stdio.h>
+#include <curl/curl.h>
 #include "config.h"
 #include "log.h"
 #include "tunnel.h"
@@ -86,6 +87,60 @@ USAGE \
 "      password = bar\n" \
 "      trusted-cert = certificatedigest4daa8c5fe6c...\n" \
 "      trusted-cert = othercertificatedigest6631bf...\n"
+
+
+/**
+ * fixes #35 in a patchy way without flow change.
+ * "introduces" libcurl, so the packaging requirements are made,
+ * and further development can be started without that plumbing stuff
+ * to eventually migrate http operations to be done via libcurl
+ *
+ * TODO: obsolete this function after the migration
+ */
+static void url_encode_str(const char* src, char* dest)
+{
+	CURL *curl = NULL;
+	size_t len = -1;
+	log_debug("URL-encoding strings with CURL\n");
+	len = strnlen(src, FIELD_SIZE);
+	curl = curl_easy_init();
+	if (!curl) {
+		log_warn("Failed at curl_easy_init(), no URL encoding.\n");
+		goto url_enc_exit;
+	}
+	char *output = curl_easy_escape(curl, src, len);
+	if (!output) {
+		log_warn("Failed at curl_easy_escape(), no URL encoded\n");
+		goto url_enc_exit;
+	}
+	/* assuming output is good here, 1 char can tripple on output */
+	strncpy(dest, output, len*3);
+	curl_free(output);
+url_enc_exit:
+	curl_easy_cleanup(curl);
+	return;
+}
+
+
+static int sanitize_web_param_buf(char *config_str)
+{
+	int ret_val = -1;
+	char * str_safe = (char*)malloc((FIELD_SIZE*3)+1);
+	if (!str_safe) {
+		log_error("Failed to allocate buffer for URL escaped string.\n");
+		return ret_val;
+	}
+	url_encode_str(config_str, str_safe);
+	/* replace data in current config */
+	/* NOTE: still possible problems with long passwords */
+	ret_val = 0;
+	if (config_str != strncpy(config_str, str_safe, FIELD_SIZE)) {
+		log_error("Failed to copy escaped buffer back");
+		ret_val = -2;
+	}
+	free(str_safe);
+	return ret_val;
+}
 
 int main(int argc, char **argv)
 {
@@ -274,6 +329,13 @@ int main(int argc, char **argv)
 	if (cfg.password[0] == '\0') {
 		log_error("Specify a password.\n");
 		goto user_error;
+	}
+	/* url escape username and password: */
+	if (0 != sanitize_web_param_buf(cfg.username)) {
+		goto exit;
+	}
+	if (0 != sanitize_web_param_buf(cfg.password)) {
+		goto exit;
 	}
 
 	log_debug("Config host = \"%s\"\n", cfg.gateway_host);


### PR DESCRIPTION
- use libcurl to escape string as url
- warning: password/usernam buffers are prone to overrun
- new dependency: libcurl

Signed-off-by: Max Kovgan <kovganm@gmail.com>