### PR TITLE
Perform 2FA auth with zero-length tokeninfo

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -374,7 +374,7 @@ int auth_log_in(struct tunnel *tunnel)
 		 */
 
 		ret = get_value_from_response(res, "tokeninfo=", token, 128);
-		if (ret != 1 || strlen(token) < 1) {
+		if (ret != 1) {
 			// No SVPNCOOKIE and no tokeninfo, return error.
 			ret = ERR_HTTP_NO_COOKIE;
 			goto end;


### PR DESCRIPTION
Previously, we assumed that the tokeninfo parameter must be present and
contain data if we are to perform two-factor authentication. Based on
GitHub issue #41, in some cases, the tokeninfo parameter will be present
but contain an empty string.

This commit removes the check for string length, as it was not needed.