### PR TITLE
split routes: Use interface if assigned-addr is missing in XML

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -436,8 +436,7 @@ static int parse_xml_config(struct tunnel *tunnel, const char *buffer)
 	val = xml_find('<', "assigned-addr", buffer, 1);
 	gateway = xml_get(xml_find(' ', "ipv4=", val, 1));
 	if (!gateway) {
-		log_warn("No gateway address\n");
-		return 1;
+		log_warn("No gateway address, using interface for routing\n");
 	}
 
 	// Routes the tunnel wants to push
@@ -503,7 +502,7 @@ int parse_config(struct tunnel *tunnel, const char *buffer)
 		mask[c - buffer] = '\0';
 		buffer = c + 1;
 
-		ipv4_add_split_vpn_route(tunnel, dest, mask, "");
+		ipv4_add_split_vpn_route(tunnel, dest, mask, NULL);
 
 	} while (*c == ',');
 

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -212,7 +212,7 @@ int ipv4_add_split_vpn_route(struct tunnel *tunnel, char *dest, char *mask,
 	setenv(env_var, dest, 0);
 	sprintf(env_var, "VPN_ROUTE_MASK_%d", tunnel->ipv4.split_routes);
 	setenv(env_var, mask, 0);
-	if (*gateway) {
+	if (gateway != NULL) {
 		sprintf(env_var, "VPN_ROUTE_GATEWAY_%d",
 		        tunnel->ipv4.split_routes);
 		setenv(env_var, gateway, 0);
@@ -223,8 +223,12 @@ int ipv4_add_split_vpn_route(struct tunnel *tunnel, char *dest, char *mask,
 	route_init(route);
 	route_dest(route).s_addr = inet_addr(dest);
 	route_mask(route).s_addr = inet_addr(mask);
-	route_gtw(route).s_addr = inet_addr(gateway);
-	route->rt_flags |= RTF_GATEWAY;
+	if (gateway != NULL) {
+		route_gtw(route).s_addr = inet_addr(gateway);
+		route->rt_flags |= RTF_GATEWAY;
+	} else {
+		strncpy(route_iface(route), tunnel->ppp_iface, ROUTE_IFACE_LEN - 1);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Some VPNs do not have "assigned-addr" set in the configuration XML
file, but still supply split route information. In this case, set
up routes using the interface instead of a gateway address.