### PR TITLE
ipv4: Fix non null-terminated buffer write

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -435,7 +435,7 @@ int ipv4_add_nameservers_to_resolv_conf(struct tunnel *tunnel)
 		strcat(ns2, "\n");
 		fputs(ns2, file);
 	}
-	fputs(buffer, file);
+	fwrite(buffer, stat.st_size, 1, file);
 
 	ret = 0;
 


### PR DESCRIPTION
In `ipv4_add_nameservers_to_resolv_conf()` the initial content was got,
then rewritten using:

    fread(buffer, stat.st_size, 1, file)
    fputs(buffer, file);

This assumes the buffer is terminated by `\0`, which is not necessarily
the case.

Fixes: #44