### PR TITLE
http: auth_log_in: Initialize res to avoid crash on http_request() error

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -339,7 +339,7 @@ int auth_log_in(struct tunnel *tunnel)
 	char realm[3 * FIELD_SIZE + 1];
 	char reqid[32], polid[32], group[128];
 	char data[256], token[128], tokenresponse[256];
-	char *res;
+	char *res = NULL;
 
 	url_encode(username, tunnel->config->username);
 	url_encode(password, tunnel->config->password);


### PR DESCRIPTION
Misconfiguration from my part triggered a code path which causes a crash. This is a fix for that.

The crash is caused by freeing of an uninitialized pointer, the fix simply initializes it.


This also shows up when running with clang scan-build for those that are interested!