### PR TITLE
userinput: fix compiler warning

### DIFF
--- a/src/userinput.c
+++ b/src/userinput.c
@@ -37,10 +37,10 @@ void read_password(const char *prompt, char *pass, size_t len)
 	}
 
 	for (i = 0; i < len; i++) {
-		char c = getchar();
+		int c = getchar();
 		if (c == '\n' || c == EOF)
 			break;
-		pass[i] = c;
+		pass[i] = (char) c;
 	}
 	pass[i] = '\0';
 


### PR DESCRIPTION
Note that getchar() returns an unsigned char cast to an int,
which we cast back to a char.

Fixes: #30