### PR TITLE
At least for openwrt this needs unistd.h

### DIFF
--- a/src/hdlc.h
+++ b/src/hdlc.h
@@ -20,6 +20,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #define ERR_HDLC_BUFFER_TOO_SMALL	-1
 #define ERR_HDLC_NO_FRAME_FOUND		-2


### PR DESCRIPTION
I'm in the process of porting this to OpenWRT -- The ssize_t type seems to be defined only when including unistd.h.