### PR TITLE
Implement --pppd-no-peerdns option

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -186,6 +186,14 @@ int load_config(struct vpn_config *cfg, const char *filename)
 				continue;
 			}
 			cfg->set_routes = set_routes;
+		} else if (strcmp(key, "pppd-use-peerdns") == 0) {
+			int pppd_use_peerdns = strtob(val);
+			if (pppd_use_peerdns < 0) {
+				log_warn("Bad pppd-use-peerdns in config file: \"%s\".\n",
+				         val);
+				continue;
+			}
+			cfg->pppd_use_peerdns = pppd_use_peerdns;
 		} else if (strcmp(key, "trusted-cert") == 0) {
 			if (strlen(val) != SHA256STRLEN - 1) {
 				log_warn("Bad certificate sha256 digest in "

--- a/src/config.h
+++ b/src/config.h
@@ -62,6 +62,7 @@ struct vpn_config {
 
 	int	set_routes;
 	int	set_dns;
+	int     pppd_use_peerdns;
 
 	char	*pppd_log;
 	char	*pppd_plugin;

--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,8 @@
 
 #define USAGE \
 "Usage: openfortivpn [<host>:<port>] [-u <user>] [-p <pass>]\n" \
-"                    [--realm=<realm>] [--no-routes] [--no-dns]\n" \
+"                    [--realm=<realm>] [--no-routes]\n" \
+"                    [--no-dns] [--pppd-no-peerdns]\n" \
 "                    [--pppd-log=<file>] [--pppd-plugin=<file>]\n" \
 "                    [--ca-file=<file>] [--user-cert=<file>]\n" \
 "                    [--user-key=<file>] [--trusted-cert=<digest>]\n" \
@@ -65,6 +66,8 @@ USAGE \
 "                                <digest> is the X509 certificate's sha256 sum.\n" \
 "                                This option can be used multiple times to trust\n" \
 "                                several certificates.\n" \
+"  --pppd-no-peerdns             Do not ask peer ppp server for DNS addresses\n" \
+"                                and do not make pppd rewrite /etc/resolv.conf\n" \
 "  --pppd-log=<file>             Set pppd in debug mode and save its logs into\n" \
 "                                <file>.\n" \
 "  --pppd-plugin=<file>          Use specified pppd plugin instead of configuring\n"\
@@ -113,6 +116,7 @@ int main(int argc, char **argv)
 		{"password",      required_argument, 0, 'p'},
 		{"no-routes",     no_argument, &cfg.set_routes, 0},
 		{"no-dns",        no_argument, &cfg.set_dns, 0},
+		{"pppd-no-peerdns", no_argument, &cfg.pppd_use_peerdns, 0},
 		{"ca-file",       required_argument, 0, 0},
 		{"user-cert",     required_argument, 0, 0},
 		{"user-key",      required_argument, 0, 0},

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -95,7 +95,9 @@ static int pppd_run(struct tunnel *tunnel)
 			"/usr/sbin/pppd", "38400", "noipdefault", "noaccomp",
 			"noauth", "default-asyncmap", "nopcomp", "receive-all",
 			"nodefaultroute", ":1.1.1.1", "nodetach",
-			"lcp-max-configure", "40", "usepeerdns", "mru", "1354",
+			"lcp-max-configure", "40", "mru", "1354",
+			tunnel->config->pppd_use_peerdns ?
+			    "usepeerdns" : NULL,
 			NULL, NULL, NULL,
 			NULL, NULL, NULL
 		};


### PR DESCRIPTION
.. and pppd-use-peerdns config-file option.
Sometimes we don't want pppd to change /etc/resolv.conf (e.g. because we frequently connect to the peer and already have a working dnsmasq config)