### PR TITLE
Fix off-by-one error in trusted-cert

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -37,6 +37,7 @@ int add_trusted_cert(struct vpn_config *cfg, const char *digest)
 
 	new->next = NULL;
 	strncpy(new->data, digest, SHA256STRLEN - 1);
+	new->data [SHA256STRLEN - 1] = '\0';
 
 	if (cfg->cert_whitelist == NULL) {
 		cfg->cert_whitelist = new;

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -251,10 +251,11 @@ static int ssl_verify_cert(struct tunnel *tunnel)
 	// Encode digest in base16
 	for (i = 0; i < SHA256LEN; i++)
 		sprintf(&digest_str[2 * i], "%02x", digest[i]);
+	digest_str [SHA256STRLEN - 1] = '\0';
 	// Is it in whitelist?
 	for (elem = tunnel->config->cert_whitelist; elem != NULL;
 	     elem = elem->next)
-		if (memcmp(digest_str, elem->data, SHA256STRLEN) == 0)
+		if (memcmp(digest_str, elem->data, SHA256STRLEN - 1) == 0)
 			break;
 	if (elem != NULL) { // break before end of loop
 		log_debug("Gateway certificate digest found in white list.\n");


### PR DESCRIPTION
Now we compare only the contents of the certificate hash (without the
trailing 0-byte) and when copying it we add a 0-byte, not the other way
round.