### PR TITLE
Option: --pppd-no-peerdns cfg: pppd-use-peerdns

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -187,6 +187,14 @@ int load_config(struct vpn_config *cfg, const char *filename)
 				continue;
 			}
 			cfg->set_routes = set_routes;
+		} else if (strcmp(key, "pppd-use-peerdns") == 0) {
+			int pppd_use_peerdns = strtob(val);
+			if (pppd_use_peerdns < 0) {
+				log_warn("Bad pppd-use-peerdns in config file: \"%s\".\n",
+				         val);
+				continue;
+			}
+			cfg->pppd_use_peerdns = pppd_use_peerdns;
 		} else if (strcmp(key, "trusted-cert") == 0) {
 			if (strlen(val) != SHA256STRLEN - 1) {
 				log_warn("Bad certificate sha256 digest in "

--- a/src/config.h
+++ b/src/config.h
@@ -62,6 +62,7 @@ struct vpn_config {
 
 	int	set_routes;
 	int	set_dns;
+	int     pppd_use_peerdns;
 
 	char	*pppd_log;
 	char	*pppd_plugin;

--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,8 @@
 
 #define USAGE \
 "Usage: openfortivpn [<host>:<port>] [-u <user>] [-p <pass>]\n" \
-"                    [--realm=<realm>] [--no-routes] [--no-dns]\n" \
+"                    [--realm=<realm>] [--no-routes]\n" \
+"                    [--no-dns] [--pppd-no-peerdns]\n" \
 "                    [--pppd-log=<file>] [--pppd-plugin=<file>]\n" \
 "                    [--ca-file=<file>] [--user-cert=<file>]\n" \
 "                    [--user-key=<file>] [--trusted-cert=<digest>]\n" \
@@ -65,6 +66,8 @@ USAGE \
 "                                <digest> is the X509 certificate's sha256 sum.\n" \
 "                                This option can be used multiple times to trust\n" \
 "                                several certificates.\n" \
+"  --pppd-no-peerdns             Do not ask peer ppp server for DNS addresses\n" \
+"                                and do not make pppd rewrite /etc/resolv.conf\n" \
 "  --pppd-log=<file>             Set pppd in debug mode and save its logs into\n" \
 "                                <file>.\n" \
 "  --pppd-plugin=<file>          Use specified pppd plugin instead of configuring\n"\
@@ -103,23 +106,25 @@ int main(int argc, char **argv)
 	cfg.set_routes = 1;
 	cfg.set_dns = 1;
 	cfg.verify_cert = 1;
+	cfg.pppd_use_peerdns = 1;
 
 	struct option long_options[] = {
-		{"help",          no_argument,       0, 'h'},
-		{"version",       no_argument,       0, 0},
-		{"config",        required_argument, 0, 'c'},
-		{"realm",         required_argument, 0, 0},
-		{"username",      required_argument, 0, 'u'},
-		{"password",      required_argument, 0, 'p'},
-		{"no-routes",     no_argument, &cfg.set_routes, 0},
-		{"no-dns",        no_argument, &cfg.set_dns, 0},
-		{"ca-file",       required_argument, 0, 0},
-		{"user-cert",     required_argument, 0, 0},
-		{"user-key",      required_argument, 0, 0},
-		{"trusted-cert",  required_argument, 0, 0},
-		{"pppd-log",      required_argument, 0, 0},
-		{"pppd-plugin",   required_argument, 0, 0},
-		{"plugin",        required_argument, 0, 0}, // deprecated
+		{"help",            no_argument,       0, 'h'},
+		{"version",         no_argument,       0, 0},
+		{"config",          required_argument, 0, 'c'},
+		{"realm",           required_argument, 0, 0},
+		{"username",        required_argument, 0, 'u'},
+		{"password",        required_argument, 0, 'p'},
+		{"no-routes",       no_argument, &cfg.set_routes, 0},
+		{"no-dns",          no_argument, &cfg.set_dns, 0},
+		{"pppd-no-peerdns", no_argument, &cfg.pppd_use_peerdns, 0},
+		{"ca-file",         required_argument, 0, 0},
+		{"user-cert",       required_argument, 0, 0},
+		{"user-key",        required_argument, 0, 0},
+		{"trusted-cert",    required_argument, 0, 0},
+		{"pppd-log",        required_argument, 0, 0},
+		{"pppd-plugin",     required_argument, 0, 0},
+		{"plugin",          required_argument, 0, 0}, // deprecated
 		{0, 0, 0, 0}
 	};
 


### PR DESCRIPTION
Sometimes we don't want pppd to change /etc/resolv.conf
so we have an option to turn this off and a config-file
variable which by default is on.