### PR TITLE
Option: --pppd-no-peerdns cfg: pppd-use-peerdns

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -187,6 +187,14 @@ int load_config(struct vpn_config *cfg, const char *filename)
 				continue;
 			}
 			cfg->set_routes = set_routes;
+		} else if (strcmp(key, "pppd-use-peerdns") == 0) {
+			int pppd_use_peerdns = strtob(val);
+			if (pppd_use_peerdns < 0) {
+				log_warn("Bad pppd-use-peerdns in config file: \"%s\".\n",
+				         val);
+				continue;
+			}
+			cfg->pppd_use_peerdns = pppd_use_peerdns;
 		} else if (strcmp(key, "trusted-cert") == 0) {
 			if (strlen(val) != SHA256STRLEN - 1) {
 				log_warn("Bad certificate sha256 digest in "

--- a/src/config.h
+++ b/src/config.h
@@ -62,6 +62,7 @@ struct vpn_config {
 
 	int	set_routes;
 	int	set_dns;
+	int     pppd_use_peerdns;
 
 	char	*pppd_log;
 	char	*pppd_plugin;

--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,8 @@
 
 #define USAGE \
 "Usage: openfortivpn [<host>:<port>] [-u <user>] [-p <pass>]\n" \
-"                    [--realm=<realm>] [--no-routes] [--no-dns]\n" \
+"                    [--realm=<realm>] [--no-routes]\n" \
+"                    [--no-dns] [--pppd-no-peerdns]\n" \
 "                    [--pppd-log=<file>] [--pppd-plugin=<file>]\n" \
 "                    [--ca-file=<file>] [--user-cert=<file>]\n" \
 "                    [--user-key=<file>] [--trusted-cert=<digest>]\n" \
@@ -65,6 +66,8 @@ USAGE \
 "                                <digest> is the X509 certificate's sha256 sum.\n" \
 "                                This option can be used multiple times to trust\n" \
 "                                several certificates.\n" \
+"  --pppd-no-peerdns             Do not ask peer ppp server for DNS addresses\n" \
+"                                and do not make pppd rewrite /etc/resolv.conf\n" \
 "  --pppd-log=<file>             Set pppd in debug mode and save its logs into\n" \
 "                                <file>.\n" \
 "  --pppd-plugin=<file>          Use specified pppd plugin instead of configuring\n"\
@@ -103,23 +106,25 @@ int main(int argc, char **argv)
 	cfg.set_routes = 1;
 	cfg.set_dns = 1;
 	cfg.verify_cert = 1;
+	cfg.pppd_use_peerdns = 1;
 
 	struct option long_options[] = {
-		{"help",          no_argument,       0, 'h'},
-		{"version",       no_argument,       0, 0},
-		{"config",        required_argument, 0, 'c'},
-		{"realm",         required_argument, 0, 0},
-		{"username",      required_argument, 0, 'u'},
-		{"password",      required_argument, 0, 'p'},
-		{"no-routes",     no_argument, &cfg.set_routes, 0},
-		{"no-dns",        no_argument, &cfg.set_dns, 0},
-		{"ca-file",       required_argument, 0, 0},
-		{"user-cert",     required_argument, 0, 0},
-		{"user-key",      required_argument, 0, 0},
-		{"trusted-cert",  required_argument, 0, 0},
-		{"pppd-log",      required_argument, 0, 0},
-		{"pppd-plugin",   required_argument, 0, 0},
-		{"plugin",        required_argument, 0, 0}, // deprecated
+		{"help",            no_argument,       0, 'h'},
+		{"version",         no_argument,       0, 0},
+		{"config",          required_argument, 0, 'c'},
+		{"realm",           required_argument, 0, 0},
+		{"username",        required_argument, 0, 'u'},
+		{"password",        required_argument, 0, 'p'},
+		{"no-routes",       no_argument, &cfg.set_routes, 0},
+		{"no-dns",          no_argument, &cfg.set_dns, 0},
+		{"pppd-no-peerdns", no_argument, &cfg.pppd_use_peerdns, 0},
+		{"ca-file",         required_argument, 0, 0},
+		{"user-cert",       required_argument, 0, 0},
+		{"user-key",        required_argument, 0, 0},
+		{"trusted-cert",    required_argument, 0, 0},
+		{"pppd-log",        required_argument, 0, 0},
+		{"pppd-plugin",     required_argument, 0, 0},
+		{"plugin",          required_argument, 0, 0}, // deprecated
 		{0, 0, 0, 0}
 	};
 

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -34,6 +34,7 @@
 #include <openssl/err.h>
 #include <pty.h>
 #include <sys/wait.h>
+#include <assert.h>
 
 #include "http.h"
 #include "log.h"
@@ -89,16 +90,24 @@ static int pppd_run(struct tunnel *tunnel)
 		log_error("forkpty: %s\n", strerror(errno));
 		return 1;
 	} else if (pid == 0) {
-		int i = 16;
-
 		char *args[] = {
 			"/usr/sbin/pppd", "38400", "noipdefault", "noaccomp",
 			"noauth", "default-asyncmap", "nopcomp", "receive-all",
 			"nodefaultroute", ":1.1.1.1", "nodetach",
-			"lcp-max-configure", "40", "usepeerdns", "mru", "1354",
-			NULL, NULL, NULL,
+			"lcp-max-configure", "40", "mru", "1354",
+			NULL, NULL, NULL, NULL,
 			NULL, NULL, NULL
 		};
+		// Dynamically get first NULL pointer so that changes of
+		// args above don't need code changes here
+		int i = sizeof (args) / sizeof (*args) - 1;
+		for (; args [i] == NULL; i--)
+			;
+		i++;
+
+		if (tunnel->config->pppd_use_peerdns) {
+			args[i++] = "usepeerdns";
+		}
 		if (tunnel->config->pppd_log) {
 			args[i++] = "debug";
 			args[i++] = "logfile";
@@ -108,6 +117,8 @@ static int pppd_run(struct tunnel *tunnel)
 			args[i++] = "plugin";
 			args[i++] = tunnel->config->pppd_plugin;
 		}
+		// Assert that we didn't use up all NULL pointers above
+		assert (i < sizeof (args) / sizeof (*args));
 
 		close(tunnel->ssl_socket);
 		if (execvp(args[0], args) == -1) {


### PR DESCRIPTION
Sometimes we don't want pppd to change /etc/resolv.conf
so we have an option to turn this off and a config-file
variable which by default is on.