### PR TITLE
tunnel: disable insecure openssl default protocols/ciphers

### DIFF
--- a/doc/openfortivpn.1
+++ b/doc/openfortivpn.1
@@ -1,4 +1,4 @@
-.TH OPENFORTIVPN 1 "January 26, 2015" ""
+.TH OPENFORTIVPN 1 "September 28, 2016" ""
 
 .SH NAME
 openfortivpn \- Client for PPP+SSL VPN tunnel services
@@ -72,6 +72,20 @@ gateway certificate will be matched against this value. \fI<digest>\fR is the
 X509 certificate's sha256 sum. This option can be used multiple times to trust
 several certificates.
 .TP
+\fB\-\-insecure-ssl\fR
+Do not disable insecure SSL protocols/ciphers.
+If your server requires a specific cipher, consider using \fB\-\-cipher-list\fR
+instead.
+.TP
+\fB\-\-cipher-list=\fI<ciphers>\fR
+Openssl ciphers to use. If default does not work, you can try alternatives
+such as HIGH:!MD5:!RC4 or as suggested by the Cipher: line in the output of
+\fBopenssl\fP(1) (e.g. AES256-GCM-SHA384):
+
+$ openssl s_client -connect \fI<host:port>\fR
+
+(default: HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4)
+.TP
 \fB\-\-pppd-log=\fI<file>\fR
 Set pppd in debug mode and save its logs into \fI<file>\fR.
 .TP
@@ -108,3 +122,7 @@ trusted-cert = othercertificatedigest6631bf...
 set-dns = 1
 .br
 set-routes = 1
+.br
+insecure-ssl = 0
+.br
+cipher-list = HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4

--- a/src/config.c
+++ b/src/config.c
@@ -211,6 +211,16 @@ int load_config(struct vpn_config *cfg, const char *filename)
 			cfg->user_cert = strdup(val);
 		} else if (strcmp(key, "user-key") == 0) {
 			cfg->user_key = strdup(val);
+		} else if (strcmp(key, "insecure-ssl") == 0) {
+			int insecure_ssl = strtob(val);
+			if (insecure_ssl < 0) {
+				log_warn("Bad insecure-ssl in config file: \"%s\".\n",
+				         val);
+				continue;
+			}
+			cfg->insecure_ssl = insecure_ssl;
+		} else if (strcmp(key, "cipher-list") == 0) {
+			cfg->cipher_list = strdup(val);
 		} else {
 			log_warn("Bad key in config file: \"%s\".\n", key);
 			goto err_free;

--- a/src/config.h
+++ b/src/config.h
@@ -72,6 +72,8 @@ struct vpn_config {
 	char	                *user_cert;
 	char	                *user_key;
 	int			verify_cert;
+	int			insecure_ssl;
+	char			*cipher_list;
 	struct x509_digest	*cert_whitelist;
 };
 
@@ -87,6 +89,7 @@ struct vpn_config {
 		(cfg)->ca_file = NULL; \
 		(cfg)->user_cert = NULL; \
 		(cfg)->user_key = NULL; \
+		(cfg)->cipher_list = NULL; \
 		(cfg)->cert_whitelist = NULL; \
 	} while (0)
 
@@ -98,7 +101,8 @@ struct vpn_config {
 	} \
 	free((cfg)->ca_file); \
 	free((cfg)->user_cert); \
-	free((cfg)->user_key);
+	free((cfg)->user_key); \
+	free((cfg)->cipher_list);
 
 int add_trusted_cert(struct vpn_config *cfg, const char *digest);
 

--- a/src/main.c
+++ b/src/main.c
@@ -66,6 +66,13 @@ USAGE \
 "                                <digest> is the X509 certificate's sha256 sum.\n" \
 "                                This option can be used multiple times to trust\n" \
 "                                several certificates.\n" \
+"  --insecure-ssl                Do not disable insecure SSL protocols/ciphers.\n" \
+"                                If your server requires a specific cipher, consider\n" \
+"                                using --cipher-list instead.\n" \
+"  --cipher-list=<ciphers>       Openssl ciphers to use. If default does not work\n" \
+"                                you can try with the cipher suggested in the output\n" \
+"                                of 'openssl s_client -connect <host:port>'\n" \
+"                                (e.g. AES256-GCM-SHA384)\n" \
 "  --pppd-no-peerdns             Do not ask peer ppp server for DNS addresses\n" \
 "                                and do not make pppd rewrite /etc/resolv.conf\n" \
 "  --pppd-log=<file>             Set pppd in debug mode and save its logs into\n" \
@@ -106,6 +113,7 @@ int main(int argc, char **argv)
 	cfg.set_routes = 1;
 	cfg.set_dns = 1;
 	cfg.verify_cert = 1;
+	cfg.insecure_ssl = 0;
 	cfg.pppd_use_peerdns = 1;
 
 	struct option long_options[] = {
@@ -122,6 +130,8 @@ int main(int argc, char **argv)
 		{"user-cert",       required_argument, 0, 0},
 		{"user-key",        required_argument, 0, 0},
 		{"trusted-cert",    required_argument, 0, 0},
+		{"insecure-ssl",    no_argument, &cfg.insecure_ssl, 1},
+		{"cipher-list",     required_argument, 0, 0},
 		{"pppd-log",        required_argument, 0, 0},
 		{"pppd-plugin",     required_argument, 0, 0},
 		{"plugin",          required_argument, 0, 0}, // deprecated
@@ -193,6 +203,11 @@ int main(int argc, char **argv)
 				if (add_trusted_cert(&cfg, optarg))
 					log_warn("Could not add certificate "
 					         "digest to whitelist.\n");
+				break;
+			}
+			if (strcmp(long_options[option_index].name,
+			           "cipher-list") == 0) {
+				cfg.cipher_list = strdup(optarg);
 				break;
 			}
 			goto user_error;


### PR DESCRIPTION
It is still possible to re-enable SSLv3/compression through --insecure-ssl
or config file, or to specify a different cipher-list.

The insecure-ssl option covers both the option and cipher list as it is
more accessible, and if SSLv3 is allowed then weak ciphers probably aren't
too high on priority list...

If the server does not accept either TLS protocols or cipher the user will
get a message similar to this one:

ERROR:  SSL_connect: error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure
You might want to try --insecure-ssl or specify a different --cipher-list

Closes #69.