### PR TITLE
honor --sysconfdir during runtime

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,5 +36,9 @@ AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([bzero gethostbyname inet_ntoa memmove memset memmem select socket strerror strstr strtol])
 
+AC_DEFINE_UNQUOTED([SYSCONFDIR],["`eval echo $sysconfdir`"])
+AC_SUBST([SYSCONFDIR],["`eval echo $sysconfdir`"])
+AC_CONFIG_FILES([doc/openfortivpn.1])
+
 #AC_CONFIG_FILES([Makefile])
 AC_OUTPUT(Makefile)

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -1,4 +1,4 @@
-.TH OPENFORTIVPN 1 "September 28, 2016" ""
+.TH OPENFORTIVPN 1 "November 10, 2016" ""
 
 .SH NAME
 openfortivpn \- Client for PPP+SSL VPN tunnel services
@@ -43,7 +43,7 @@ Show this help message and exit.
 Show version and exit.
 .TP
 \fB\-c \fI<file>\fR, \fB\-\-config=\fI<file>\fR
-Specify a custom config file (default: /etc/openfortivpn/config).
+Specify a custom config file (default: @SYSCONFDIR@/openfortivpn/config).
 .TP
 \fB\-u \fI<user>\fR, \fB\-\-username=\fI<user>\fR
 VPN account username.
@@ -94,7 +94,7 @@ $ openssl s_client -connect \fI<host:port>\fR
 (default: HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4)
 .TP
 \fB\-\-pppd-no-peerdns\fR
-Do not ask peer ppp server for DNS addresses and do not make pppd rewrite 
+Do not ask peer ppp server for DNS addresses and do not make pppd rewrite
 /etc/resolv.conf.
 .TP
 \fB\-\-pppd-log=\fI<file>\fR
@@ -113,7 +113,7 @@ Decrease verbosity. Can be used multiple times to be even less verbose.
 .SH CONFIG FILE
 Options can be taken from a configuration file. Options passed in the command
 line will override those from the config file, though. The default config file
-is /etc/openfortivpn/config, but this can be set using the \fB\-c\fR option.
+is @SYSCONFDIR@/openfortivpn/config, but this can be set using the \fB\-c\fR option.
 .TP
 A config file looks like:
 # this is a comment
@@ -126,17 +126,17 @@ username = foo
 .br
 password = bar
 .br
-user-cert = /etc/openfortivpn/user-cert.pem
+user-cert = @SYSCONFDIR@/openfortivpn/user-cert.pem
 .br
-user-key =/etc/openfortivpn/user-key.pem
+user-key = @SYSCONFDIR@/openfortivpn/user-key.pem
 .br
 trusted-cert = certificatedigest4daa8c5fe6c...
 .br
 trusted-cert = othercertificatedigest6631bf...
 .br
-# This would specify a ca bundle instead of system-wide store 
+# This would specify a ca bundle instead of system-wide store
 .br
-# ca-file = /etc/openfortivpn/ca-bundle.pem
+# ca-file = @SYSCONFDIR@/openfortivpn/ca-bundle.pem
 .br
 set-dns = 1
 .br

--- a/src/main.c
+++ b/src/main.c
@@ -43,7 +43,7 @@
 "  -h --help                     Show this help message and exit.\n" \
 "  --version                     Show version and exit.\n" \
 "  -c <file>, --config=<file>    Specify a custom config file (default:\n" \
-"                                /etc/openfortivpn/config).\n" \
+"                                "SYSCONFDIR"/openfortivpn/config).\n" \
 "  -u <user>, --username=<user>  VPN account username.\n" \
 "  -p <pass>, --password=<pass>  VPN account password.\n" \
 "  --realm=<realm>               Use specified authentication realm on VPN gateway\n" \
@@ -85,8 +85,9 @@
 "Config file:\n" \
 "  Options can be taken from a configuration file. Options passed in the\n" \
 "  command line will override those from the config file, though. The default\n" \
-"  config file is /etc/openfortivpn/config, but this can be set using the -c\n" \
-"  option. A simple config file example looks like:\n" \
+"  config file is "SYSCONFDIR"/openfortivpn/config,\n" \
+"  but this can be set using the -c option.\n" \
+"  A simple config file example looks like:\n" \
 "      # this is a comment\n" \
 "      host = vpn-gateway\n" \
 "      port = 8443\n" \
@@ -100,7 +101,7 @@ int main(int argc, char **argv)
 {
 	int ret = EXIT_FAILURE;
 	struct vpn_config cfg;
-	char *config_file = "/etc/openfortivpn/config";
+	char *config_file = SYSCONFDIR"/openfortivpn/config";
 	char *host, *username = NULL, *password = NULL;
 	char *port_str;
 	long int port;


### PR DESCRIPTION
as already mentioned in issue https://github.com/adrienverge/openfortivpn/issues/75 when running openfortivpn without any arguments it always searched the config file at the hard coded location /etc/openfortivpn/config
This pull request inserts the values for prefix and sysconfdir from configure time into the code via preprocessor defines. 
Previously, I have merged back the update to the man page etc. into my master branch, hoping that this doesn't disturb merging in the new changes. If it is better to delete this branch and fork again for the next pull-request, just drop me a message.