### PR TITLE
fix detecting new connection bug when ppp connections are existed.

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -165,6 +165,8 @@ int ppp_interface_is_up(struct tunnel *tunnel)
 {
 	struct ifaddrs *ifap, *ifa;
 
+	log_debug("Got Address: %s\n", inet_ntoa(tunnel->ipv4.ip_addr));
+
 	if (getifaddrs(&ifap)) {
 		log_error("getifaddrs: %s\n", strerror(errno));
 		return 0;
@@ -173,10 +175,21 @@ int ppp_interface_is_up(struct tunnel *tunnel)
 	for (ifa = ifap; ifa != NULL; ifa = ifa->ifa_next) {
 		if (strstr(ifa->ifa_name, "ppp") != NULL
 		    && ifa->ifa_flags & IFF_UP) {
-			strncpy(tunnel->ppp_iface, ifa->ifa_name,
-			        ROUTE_IFACE_LEN - 1);
-			freeifaddrs(ifap);
-			return 1;
+			if (&(ifa->ifa_addr->sa_family) != NULL
+			    && ifa->ifa_addr->sa_family == AF_INET) {
+				struct in_addr if_ip_addr =
+				        cast_addr(ifa->ifa_addr)->sin_addr;
+
+				log_debug("Interface Name: %s\n", ifa->ifa_name);
+				log_debug("Interface Addr: %s\n", inet_ntoa(if_ip_addr));
+
+				if (tunnel->ipv4.ip_addr.s_addr == if_ip_addr.s_addr) {
+					strncpy(tunnel->ppp_iface, ifa->ifa_name,
+					        ROUTE_IFACE_LEN - 1);
+					freeifaddrs(ifap);
+					return 1;
+				}
+			}
 		}
 	}
 	freeifaddrs(ifap);


### PR DESCRIPTION
When ppp connections are existed before connect with openfortivpn, openfortivpn use only 'ppp0'.
So, after connect vpn with openfortivpn that situation, routing table get tangled.

There is also same situation when connecting one more vpn with only openfortivpn.

So, I changed checking new connection logic.