### PR TITLE
fix for #85 diagnostic message colors invisible

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -42,7 +42,7 @@ static struct log_param_s log_params [OFV_LOG_DEBUG_PACKETS + 1] = {
 	{ "        ", "",           LOG_ERR},
 	{ "ERROR:  ", "\033[0;31m", LOG_ERR},
 	{ "WARN:   ", "\033[0;33m", LOG_WARNING},
-	{ "INFO:   ", "\033[0;97m", LOG_INFO},
+	{ "INFO:   ", "",           LOG_INFO},
 	{ "DEBUG:  ", "\033[0;90m", LOG_DEBUG},
 	{ "DEBUG:  ", "\033[0;90m", LOG_DEBUG},
 };


### PR DESCRIPTION
switching the foreground color to white might not be a good idea on a bright background. Switching to bold looks nearly the same on a dark background and the characters stay visible on bright background as a fix for issue #85 