### PR TITLE
README.md: Change CodingStyle Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,4 @@ Contributing
 
 Feel free to make pull requests!
 
-C coding style should follow the [Linux kernel Documentation/CodingStyle](http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle?id=refs/heads/master).
+C coding style should follow the [Linux kernel Documentation/CodingStyle](http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/process/coding-style.rst?id=refs/heads/master).


### PR DESCRIPTION
'KernelRepo/Documentation/CodingStyle' has moved to 'KernelRepo/Documentation/process/coding-style.rst'

http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle?id=refs/heads/master