### PR TITLE
README.md: add 'Known Issue'

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ Cmnd_Alias  OPENFORTIVPN = /usr/bin/openfortivpn
 described in #54, a malicious user could use `--ppp-plugin` and `--ppd-log`
 options to divert the program's behaviour.
 
+
+Known Issue
+-----------
+
+* 'Default Route Mode' doesn't work in Mac OS X
+
+
 Contributing
 ------------
 


### PR DESCRIPTION
Since started support MacOSX, 'default route mode' isn't supported in MacOSX but it isn't noticed.