### PR TITLE
README.md: modify 'macOS' part in 'Installing' Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ For other distros, you'll need to build and install from source:
 
   On macOS :
   ```
-  brew install automake autoconf homebrew/versions/openssl101
+  brew install automake autoconf openssl@1.0
   aclocal && autoconf && automake --add-missing
-  export CPPFLAGS="-I/usr/local/opt/openssl101/include"
-  export LDFLAGS="-L/usr/local/opt/openssl101/lib"
+  export CPPFLAGS="-I/usr/local/opt/openssl/include"
+  export LDFLAGS="-L/usr/local/opt/openssl/lib"
   ./configure --prefix=/usr/local --sysconfdir=/etc
   make
   sudo make install


### PR DESCRIPTION
'brew' usage is changed.

When I ran 'brew install automake autoconf homebrew/versions/openssl101', brew showed this messages.
```
$ brew install automake autoconf homebrew/versions/openssl101
Updating Homebrew...
Error: No available formula with the name "homebrew/versions/openssl101" 
==> Searching for a previously deleted formula...
homebrew/versions/openssl101 was deleted from homebrew/versions in commit 4d7efbf:
  openssl101: remove "unacceptable" old version (https://github.com/Homebrew/homebrew-versions/issues/1528)

To show the formula before removal run:
  git -C "$(brew --repo homebrew/versions)" show 4d7efbf^:openssl101.rb

If you still use this formula consider creating your own tap:
  http://docs.brew.sh/How-to-Create-and-Maintain-a-Tap.html
```

I found that ['homebrew/versions'](https://github.com/Homebrew/homebrew-versions) is deprecated so I modified to possible to work.