### PR TITLE
Small improvements

### DIFF
--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -151,3 +151,9 @@ pppd-use-peerdns = 1
 insecure-ssl = 0
 .br
 cipher-list = HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4
+.br
+# These specify a script to run on VPN up/down events
+.br
+up-script = /usr/local/bin/custom_up.sh
+.br
+down-script = /usr/local/bin/custom_down.sh

--- a/src/config.c
+++ b/src/config.c
@@ -229,6 +229,10 @@ int load_config(struct vpn_config *cfg, const char *filename)
 			cfg->insecure_ssl = insecure_ssl;
 		} else if (strcmp(key, "cipher-list") == 0) {
 			cfg->cipher_list = strdup(val);
+		} else if (strcmp(key, "up-script") == 0) {
+			cfg->up_script = strdup(val);
+		} else if (strcmp(key, "down-script") == 0) {
+			cfg->down_script = strdup(val);
 		} else {
 			log_warn("Bad key in config file: \"%s\".\n", key);
 			goto err_free;

--- a/src/config.h
+++ b/src/config.h
@@ -76,6 +76,8 @@ struct vpn_config {
 	int			verify_cert;
 	int			insecure_ssl;
 	char			*cipher_list;
+	char			*up_script;
+	char			*down_script;
 	struct x509_digest	*cert_whitelist;
 };
 
@@ -95,6 +97,8 @@ struct vpn_config {
 		(cfg)->cipher_list = NULL; \
 		(cfg)->cert_whitelist = NULL; \
 		(cfg)->use_syslog = 0; \
+		(cfg)->up_script = NULL; \
+		(cfg)->down_script = NULL; \
 	} while (0)
 
 #define destroy_vpn_config(cfg) \
@@ -106,7 +110,9 @@ struct vpn_config {
 	free((cfg)->ca_file); \
 	free((cfg)->user_cert); \
 	free((cfg)->user_key); \
-	free((cfg)->cipher_list);
+	free((cfg)->cipher_list); \
+	free((cfg)->up_script); \
+	free((cfg)->down_script);
 
 int add_trusted_cert(struct vpn_config *cfg, const char *digest);
 

--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,7 @@
 
 #define USAGE \
 "Usage: openfortivpn [<host>:<port>] [-u <user>] [-p <pass>]\n" \
-"                    [--realm=<realm>] [--no-routes]\n" \
+"                    [--realm=<realm>] [--otp=<otp>] [--no-routes]\n" \
 "                    [--no-dns] [--pppd-no-peerdns]\n" \
 "                    [--pppd-log=<file>] [--pppd-plugin=<file>]\n" \
 "                    [--ca-file=<file>] [--user-cert=<file>]\n" \
@@ -149,7 +149,7 @@ int main(int argc, char **argv)
 		/* getopt_long stores the option index here. */
 		int c, option_index = 0;
 
-		c = getopt_long(argc, argv, "hvqc:u:p:",
+		c = getopt_long(argc, argv, "hvqc:u:p:o:",
 		                long_options, &option_index);
 
 		/* Detect the end of the options. */

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -97,7 +97,8 @@ static int on_ppp_if_down(struct tunnel *tunnel)
         if (tunnel->config->down_script) {
                 int ret;
 
-                log_info("Running script on interface down: %s\n", tunnel->config->down_script);
+                log_info("Running script on interface down: %s\n",
+                         tunnel->config->down_script);
                 ret = run_script(tunnel->config->down_script, "down");
                 if (ret != 0) {
                         log_warn("Failed to run external script on down event\n");
@@ -635,4 +636,3 @@ int run_script (char *script_path, char *event_name)
 
         return ret;
 }
-

--- a/src/tunnel.h
+++ b/src/tunnel.h
@@ -83,4 +83,6 @@ int ssl_connect(struct tunnel *tunnel);
 
 int run_tunnel(struct vpn_config *config);
 
+int run_script(char *script_path, char *event_name);
+
 #endif


### PR DESCRIPTION
Hi, 

Great tool... thanks for sharing it.

This PR offers some small improvements I made in response to issues I had getting up and running.

Firstly, I was also confused by the OTP handling as in adrienverge/openfortivpn#104. It turns out the documentation mentions both "-o" and "--otp" switches, but only the latter was implemented in the code. I have added handling for the short option here. This may possibly close issue #104 as one option literally didn't exist and there is a spelling mistake in the second option in his example.

Secondly, I was having DNS issues due to the search option of resolv.conf not being supported. This information doesn't come back from my VPN end-point when the tunnel is established so it seems right that the client doesn't set it. As a workaround I added support to the configuration file for defining custom scripts to call on tunnel up and interface down events. For my case I manipulate this search parameter from a shell script called by openfortivpn when these events occur. I'm sure there would be other use cases; It seems to be a feature present in other VPN clients.

Please consider these for inclusion. C is not my most comfortable language so hopefully it is acceptable. It has tested okay over a few days on my machine.

Thanks