### PR TITLE
minor fixes to documentation, command line argument handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Cmnd_Alias  OPENFORTIVPN = /usr/bin/openfortivpn
 ```
 
 **Warning**: Make sure only trusted users can run openfortivpn as root! As
-described in #54, a malicious user could use `--ppp-plugin` and `--ppd-log`
+described in #54, a malicious user could use `--pppd-plugin` and `--pppd-log`
 options to divert the program's behaviour.
 
 Contributing

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -148,6 +148,14 @@ set-routes = 1
 .br
 pppd-use-peerdns = 1
 .br
+# aternatively, use a specific pppd plugin instead
+.br
+# pppd-plugin = /usr/lib/pppd/default/some-plugin.so
+.br
+# for debugging pppd write logs here
+.br
+# pppd-log = /var/log/pppd.log
+.br
 insecure-ssl = 0
 .br
 cipher-list = HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4

--- a/src/config.c
+++ b/src/config.c
@@ -195,6 +195,10 @@ int load_config(struct vpn_config *cfg, const char *filename)
 				continue;
 			}
 			cfg->pppd_use_peerdns = pppd_use_peerdns;
+		} else if (strcmp(key, "pppd-log") == 0) {
+			cfg->pppd_log = strdup(val);
+		} else if (strcmp(key, "pppd-plugin") == 0) {
+			cfg->pppd_plugin = strdup(val);
 		} else if (strcmp(key, "use-syslog") == 0) {
 			int use_syslog = strtob(val);
 			if (use_syslog < 0) {

--- a/src/config.h
+++ b/src/config.h
@@ -103,6 +103,8 @@ struct vpn_config {
 		free((cfg)->cert_whitelist); \
 		(cfg)->cert_whitelist = tmp; \
 	} \
+	free((cfg)->pppd_log); \
+	free((cfg)->pppd_plugin); \
 	free((cfg)->ca_file); \
 	free((cfg)->user_cert); \
 	free((cfg)->user_key); \

--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,7 @@
 
 #define USAGE \
 "Usage: openfortivpn [<host>:<port>] [-u <user>] [-p <pass>]\n" \
-"                    [--realm=<realm>] [--no-routes]\n" \
+"                    [--realm=<realm>] [--otp=<otp>] [--no-routes]\n" \
 "                    [--no-dns] [--pppd-no-peerdns]\n" \
 "                    [--pppd-log=<file>] [--pppd-plugin=<file>]\n" \
 "                    [--ca-file=<file>] [--user-cert=<file>]\n" \
@@ -77,7 +77,7 @@
 "                                and do not make pppd rewrite /etc/resolv.conf\n" \
 "  --pppd-log=<file>             Set pppd in debug mode and save its logs into\n" \
 "                                <file>.\n" \
-"  --pppd-plugin=<file>          Use specified pppd plugin instead of configuring\n"\
+"  --pppd-plugin=<file>          Use specified pppd plugin instead of configuring\n" \
 "                                resolver and routes directly.\n" \
 "  -v                            Increase verbosity. Can be used multiple times\n" \
 "                                to be even more verbose.\n" \
@@ -149,7 +149,7 @@ int main(int argc, char **argv)
 		/* getopt_long stores the option index here. */
 		int c, option_index = 0;
 
-		c = getopt_long(argc, argv, "hvqc:u:p:",
+		c = getopt_long(argc, argv, "hvqc:u:p:o:",
 		                long_options, &option_index);
 
 		/* Detect the end of the options. */


### PR DESCRIPTION
(-o was not recognized before), and free all pointers in destroy_vpn_config