### PR TITLE
fix lock status when fail to spawn pppd in macOS.

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -295,6 +295,9 @@ static void *pppd_write(void *arg)
 			          len - written);
 			if (n == -1) {
 				log_error("write: %s\n", strerror(errno));
+#ifdef __APPLE__
+				sem_post(&sem_if_config);
+#endif
 				goto err_free_buf;
 			}
 			written += n;


### PR DESCRIPTION
When I run openfortivpn without elevate privileges in Linux,
it is finished normally but not in macOS.

It showed `INFO:   Cancelling threads...` and locked.
It didn't response when I push `Ctrl + C`

This is full message.
```
$ ./openfortivpn -c connect_info.config -v
DEBUG:  Loaded config file "connect_info.config".
VPN account password: 
DEBUG:  Config host = "123.123.123.123"
DEBUG:  Config realm = ""
DEBUG:  Config port = "443"
DEBUG:  Config username = "username"
DEBUG:  Config password = "********"
WARN:   This process was not spawned with root privileges, this will probably not work.
DEBUG:  Gateway certificate validation failed.
DEBUG:  Gateway certificate digest found in white list.
INFO:   Connected to gateway.
INFO:   Authenticated.
DEBUG:  Cookie: SVPNCOOKIE=[COOKIE]
INFO:   Remote gateway has allocated a VPN.
DEBUG:  Gateway certificate validation failed.
DEBUG:  Gateway certificate digest found in white list.
WARN:   No gateway address, using interface for routing
DEBUG:  pppd_read_thread
DEBUG:  ssl_read_thread
DEBUG:  ssl_write_thread
DEBUG:  if_config thread
DEBUG:  gateway ---> pppd (12 bytes)
DEBUG:  pppd_write thread
DEBUG:  pppd ---> gateway (12 bytes)
WARN:   read returned 0
WARN:   read returned 0
WARN:   read returned 0

(repeat about 940 times...)

WARN:   read returned 0
WARN:   read returned 0
WARN:   read returned 0
DEBUG:  gateway ---> pppd (12 bytes)
WARN:   read returned 0
WARN:   read returned 0
WARN:   read returned 0
WARN:   read returned 0
WARN:   read returned 0
WARN:   read returned 0
WARN:   read returned 0
WARN:   read returned 0
WARN:   read returned 0
WARN:   read returned 0
WARN:   read returned 0
WARN:   read returned 0
ERROR:  write: Input/output error
WARN:   read returned 0
INFO:   Cancelling threads...
WARN:   read returned 0

(Not response)

^C^C 

(Not response)

(I just ran `kill pid` in another terminal)

[1]    2201 terminated  ./openfortivpn -c connect_info.config -v
```

I checked something, and I found that `pppd` zombie process...
```
$ ps aux |grep ppp
username          2286   0.0  0.0        0      0   ??  Z     2:22PM   0:00.00 (pppd)
username          2288   0.0  0.0  2432804    780 s005  S+    2:22PM   0:00.00 grep --color=auto --exclude-dir=.bzr --exclude-dir=CVS --exclude-dir=.git --exclude-dir=.hg --exclude-dir=.svn ppp
```
The 2286 process was remained until openfortivpn was killed.