### PR TITLE
Handle SIGTERM as SIGINT and ignore SIGHUP

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -588,6 +588,10 @@ int io_loop(struct tunnel *tunnel)
 	    signal(SIGTERM, sig_handler) == SIG_ERR)
 		goto err_signal;
 
+	// Ignore SIGHUP
+	if (signal(SIGHUP, SIG_IGN) == SIG_ERR)
+		goto err_signal;
+
 	if (pthread_create(&pty_read_thread, NULL, pppd_read, tunnel))
 		goto err_thread;
 	if (pthread_create(&pty_write_thread, NULL, pppd_write, tunnel))

--- a/src/io.c
+++ b/src/io.c
@@ -536,7 +536,7 @@ error:
 
 static void sig_handler(int signo)
 {
-	if (signo == SIGINT)
+	if (signo == SIGINT || signo == SIGTERM)
 		sem_post(&sem_stop_io);
 }
 
@@ -575,15 +575,17 @@ int io_loop(struct tunnel *tunnel)
 
 // on osx this prevents the program from being stopped with ctrl-c
 #ifndef __APPLE__
-	// Disable SIGINT for the future spawned threads
+	// Disable SIGINT and SIGTERM for the future spawned threads
 	sigset_t sigset, oldset;
 	sigemptyset(&sigset);
 	sigaddset(&sigset, SIGINT);
+	sigaddset(&sigset, SIGTERM);
 	pthread_sigmask(SIG_BLOCK, &sigset, &oldset);
 #endif
 
 	// Set signal handler
-	if (signal(SIGINT, sig_handler) == SIG_ERR)
+	if (signal(SIGINT, sig_handler) == SIG_ERR ||
+	    signal(SIGTERM, sig_handler) == SIG_ERR)
 		goto err_signal;
 
 	if (pthread_create(&pty_read_thread, NULL, pppd_read, tunnel))


### PR DESCRIPTION
Not sure about this one:
- Why do we avoid calling _pthread_sigmask()_ on MacOS X to disable signal handling in future threads?
- Why are we using C's _signal()_ instead of POSIX _sigaction()_?

See for example:
- [What is the difference between sigaction and signal?](https://stackoverflow.com/questions/231912/what-is-the-difference-between-sigaction-and-signal#232711)

Fixes #78.