### PR TITLE
Fix buffer overrun

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -511,7 +511,7 @@ int ipv4_add_split_vpn_route(struct tunnel *tunnel, char *dest, char *mask,
                              char *gateway)
 {
 	struct rtentry *route;
-	char env_var[21];
+	char env_var[22];
 
 	if (tunnel->ipv4.split_routes == MAX_SPLIT_ROUTES)
 		return ERR_IPV4_NO_MEM;


### PR DESCRIPTION
Increasing MAX_SPLIT_ROUTES from 64 to 128 also increased the potential
number of digits in ipv4_config.split_routes from 2 to 3. Part of the
code expected the number of digits of ipv4_config.split_routes to be 2.
Increase to 3 to avoid buffer overrun and memory corruption.

Fixes #140.

At some point such well hidden dependencies will have to be removed for better maintainability. For now let's just fix this buffer overrun issue.