### PR TITLE
Fix bug in pppd_run forking code

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -144,7 +144,8 @@ static int pppd_run(struct tunnel *tunnel)
 
 		close(tunnel->ssl_socket);
 		execvp(args[0], args);
-		exit(errno);
+		fprintf(stderr, "execvp: %s\n", strerror(errno));
+		exit(EXIT_FAILURE);
 	}
 
 	// Set non-blocking

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -143,10 +143,8 @@ static int pppd_run(struct tunnel *tunnel)
 		assert (i < sizeof (args) / sizeof (*args));
 
 		close(tunnel->ssl_socket);
-		if (execvp(args[0], args) == -1) {
-			log_error("execvp: %s\n", strerror(errno));
-			return 1;
-		}
+		execvp(args[0], args);
+		exit(errno);
 	}
 
 	// Set non-blocking

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -167,7 +167,14 @@ static int pppd_terminate(struct tunnel *tunnel)
 	close(tunnel->pppd_pty);
 
 	log_debug("Waiting for pppd to exit...\n");
-	waitpid(tunnel->pppd_pid, NULL, 0);
+	int status;
+	if (waitpid(tunnel->pppd_pid, &status, 0) == -1) {
+		log_error("waitpid: %s\n", strerror(errno));
+		return 1;
+	}
+	if (WIFEXITED(status)) {
+		log_debug("waitpid: exit status code %d", WEXITSTATUS(status));
+	}
 
 	return 0;
 }


### PR DESCRIPTION
The error handling of execvp in the forked child is bad.
Instead of returning into the original forked process, it should
exit immediately after execvp. This only happens if execvp fails
for some reason, which is probably a very rare situation.
But anyway it is better to be fixed.