### PR TITLE
Add script option

### DIFF
--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -22,6 +22,7 @@ openfortivpn \- Client for PPP+SSL VPN tunnel services
 [\fB\-\-pppd-log=\fI<file>\fR]
 [\fB\-\-pppd-plugin=\fI<file>\fR]
 [\fB\-\-pppd-ipparam=\fI<string>\fR]
+[\fB\-\-script=\fI<path to script>\fR]
 [\fB\-c\fR \fI<file>\fR]
 [\fB\-v|\-q\fR]
 .br
@@ -113,6 +114,11 @@ directly.
 Provides an extra parameter to the ip-up, ip-pre-up and ip-down scripts. see man
 .BR pppd(8)
 for further details
+.TP
+\fB\-\-script=\fI<path to script>\fR
+Execute the specified script after tunnel setup and before teardown.
+Script will be called with "up" and "down" as first argument respectively.
+Environment variables named VPN_* will be setup and can be used by the script.
 .TP
 \fB\-v\fR
 Increase verbosity. Can be used multiple times to be even more verbose.

--- a/src/config.c
+++ b/src/config.c
@@ -201,6 +201,8 @@ int load_config(struct vpn_config *cfg, const char *filename)
 			cfg->pppd_plugin = strdup(val);
 		} else if (strcmp(key, "pppd-ipparam") == 0) {
 			cfg->pppd_ipparam = strdup(val);
+		} else if (strcmp(key, "script") == 0) {
+			cfg->script = strdup(val);
 		} else if (strcmp(key, "use-syslog") == 0) {
 			int use_syslog = strtob(val);
 			if (use_syslog < 0) {

--- a/src/config.h
+++ b/src/config.h
@@ -110,7 +110,7 @@ struct vpn_config {
 	free((cfg)->pppd_log); \
 	free((cfg)->pppd_ipparam); \
 	free((cfg)->pppd_plugin); \
-	if((cfg)->script != NULL) { free((cfg)->script); }; \
+	if ((cfg)->script != NULL) { free((cfg)->script); }; \
 	free((cfg)->ca_file); \
 	free((cfg)->user_cert); \
 	free((cfg)->user_key); \

--- a/src/config.h
+++ b/src/config.h
@@ -70,6 +70,7 @@ struct vpn_config {
 	char	*pppd_log;
 	char	*pppd_plugin;
 	char	*pppd_ipparam;
+	char	*script;
 
 	char	                *ca_file;
 	char	                *user_cert;
@@ -91,6 +92,7 @@ struct vpn_config {
 		(cfg)->pppd_log = NULL; \
 		(cfg)->pppd_plugin = NULL; \
 		(cfg)->pppd_ipparam = NULL; \
+		(cfg)->script = NULL; \
 		(cfg)->ca_file = NULL; \
 		(cfg)->user_cert = NULL; \
 		(cfg)->user_key = NULL; \
@@ -108,6 +110,7 @@ struct vpn_config {
 	free((cfg)->pppd_log); \
 	free((cfg)->pppd_ipparam); \
 	free((cfg)->pppd_plugin); \
+	if((cfg)->script != NULL) { free((cfg)->script); }; \
 	free((cfg)->ca_file); \
 	free((cfg)->user_cert); \
 	free((cfg)->user_key); \

--- a/src/main.c
+++ b/src/main.c
@@ -82,8 +82,8 @@
 "                                resolver and routes directly.\n" \
 "  --pppd-ipparam=<string>       Provides  an extra parameter to the ip-up, ip-pre-up\n" \
 "                                and ip-down scripts. see man (8) pppd\n" \
-"  --script=<path to script>     This script will be executed after tunnel setup and before\n" \
-"                                teardown\n" \
+"  --script=<path to script>     This script will be executed after tunnel setup\n" \
+"                                and before teardown\n" \
 "  -v                            Increase verbosity. Can be used multiple times\n" \
 "                                to be even more verbose.\n" \
 "  -q                            Decrease verbosity. Can be used multiple times\n" \

--- a/src/main.c
+++ b/src/main.c
@@ -27,6 +27,7 @@
 "                    [--realm=<realm>] [--otp=<otp>] [--no-routes]\n" \
 "                    [--no-dns] [--pppd-no-peerdns] [--pppd-log=<file>]\n" \
 "                    [--pppd-ipparam=<string>] [--pppd-plugin=<file>]\n" \
+"                    [--script=<path to script>]\n" \
 "                    [--ca-file=<file>] [--user-cert=<file>]\n" \
 "                    [--user-key=<file>] [--trusted-cert=<digest>]\n" \
 "                    [--use-syslog] [-c <file>] [-v|-q]\n" \
@@ -81,6 +82,8 @@
 "                                resolver and routes directly.\n" \
 "  --pppd-ipparam=<string>       Provides  an extra parameter to the ip-up, ip-pre-up\n" \
 "                                and ip-down scripts. see man (8) pppd\n" \
+"  --script=<path to script>     This script will be executed after tunnel setup and before\n" \
+"                                teardown\n" \
 "  -v                            Increase verbosity. Can be used multiple times\n" \
 "                                to be even more verbose.\n" \
 "  -q                            Decrease verbosity. Can be used multiple times\n" \
@@ -144,6 +147,7 @@ int main(int argc, char **argv)
 		{"pppd-log",        required_argument, 0, 0},
 		{"pppd-plugin",     required_argument, 0, 0},
 		{"pppd-ipparam",    required_argument, 0, 0},
+		{"script",          required_argument, 0, 0},
 		{"plugin",          required_argument, 0, 0}, // deprecated
 		{0, 0, 0, 0}
 	};
@@ -183,6 +187,11 @@ int main(int argc, char **argv)
 			if (strcmp(long_options[option_index].name,
 			           "pppd-ipparam") == 0) {
 				cfg.pppd_ipparam = optarg;
+				break;
+			}
+			if (strcmp(long_options[option_index].name,
+			           "script") == 0) {
+				cfg.script = strdup(optarg);
 				break;
 			}
 			// --plugin is deprecated, --pppd-plugin should be used

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -79,7 +79,8 @@ static int run_script(struct tunnel *tunnel)
 			          "exit code: %d\n", argv[0], WEXITSTATUS(wst));
 			return 1;
 		} else {
-			log_info("run_script: successfully executed script %s\n", argv[0]);
+			log_info("run_script: successfully executed script "
+			         "%s\n", argv[0]);
 		}
 	}
 	return 0;

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -76,7 +76,7 @@ static int run_script(struct tunnel *tunnel)
 		waitpid(pid, &wst, 0);
 		if (WIFEXITED(wst) && WEXITSTATUS(wst)) {
 			log_error("run_script: failed to execute script %s, "
-				  "exit code: %d\n", argv[0], WEXITSTATUS(wst));
+			          "exit code: %d\n", argv[0], WEXITSTATUS(wst));
 			return 1;
 		} else {
 			log_info("run_script: successfully executed script %s\n", argv[0]);

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -55,8 +55,10 @@ static int run_script(struct tunnel *tunnel)
 		argv[1] = "up";
 		setenv("VPN_INTERFACE", tunnel->ppp_iface, 1);
 		setenv("VPN_INTERFACE_IP", inet_ntoa(tunnel->ipv4.ip_addr), 1);
-		if (tunnel->ipv4.ns1_addr.s_addr != 0) setenv("VPN_NS1_IP", inet_ntoa(tunnel->ipv4.ns1_addr),1);
-		if (tunnel->ipv4.ns2_addr.s_addr != 0) setenv("VPN_NS2_IP", inet_ntoa(tunnel->ipv4.ns2_addr),1);
+		if (tunnel->ipv4.ns1_addr.s_addr != 0)
+			setenv("VPN_NS1_IP", inet_ntoa(tunnel->ipv4.ns1_addr),1);
+		if (tunnel->ipv4.ns2_addr.s_addr != 0)
+			setenv("VPN_NS2_IP", inet_ntoa(tunnel->ipv4.ns2_addr),1);
 	} else {
 		argv[1] = "down";
 	}
@@ -73,7 +75,8 @@ static int run_script(struct tunnel *tunnel)
 		int wst;
 		waitpid(pid, &wst, 0);
 		if (WIFEXITED(wst) && WEXITSTATUS(wst)) {
-			log_error("run_script: failed to execute script %s, exit code: %d\n", argv[0], WEXITSTATUS(wst));
+			log_error("run_script: failed to execute script %s, "
+				  "exit code: %d\n", argv[0], WEXITSTATUS(wst));
 			return 1;
 		} else {
 			log_info("run_script: successfully executed script %s\n", argv[0]);

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -49,14 +49,14 @@ static int run_script(struct tunnel *tunnel)
 	char *argv[] = { NULL, NULL, NULL };
 	argv[0] = tunnel->config->script;
 
-	if( argv[0] == NULL ) return 0;
+	if (argv[0] == NULL) return 0;
 
 	if (tunnel->state == STATE_CONNECTING) {
 		argv[1] = "up";
 		setenv("VPN_INTERFACE", tunnel->ppp_iface, 1);
 		setenv("VPN_INTERFACE_IP", inet_ntoa(tunnel->ipv4.ip_addr), 1);
-		if(tunnel->ipv4.ns1_addr.s_addr != 0) setenv("VPN_NS1_IP", inet_ntoa(tunnel->ipv4.ns1_addr),1);
-		if(tunnel->ipv4.ns2_addr.s_addr != 0) setenv("VPN_NS2_IP", inet_ntoa(tunnel->ipv4.ns2_addr),1);
+		if (tunnel->ipv4.ns1_addr.s_addr != 0) setenv("VPN_NS1_IP", inet_ntoa(tunnel->ipv4.ns1_addr),1);
+		if (tunnel->ipv4.ns2_addr.s_addr != 0) setenv("VPN_NS2_IP", inet_ntoa(tunnel->ipv4.ns2_addr),1);
 	} else {
 		argv[1] = "down";
 	}
@@ -72,7 +72,7 @@ static int run_script(struct tunnel *tunnel)
 	} else {
 		int wst;
 		waitpid(pid, &wst, 0);
-		if( WIFEXITED(wst) && WEXITSTATUS(wst) ) {
+		if (WIFEXITED(wst) && WEXITSTATUS(wst)) {
 			log_error("run_script: failed to execute script %s, exit code: %d\n", argv[0], WEXITSTATUS(wst));
 			return 1;
 		} else {


### PR DESCRIPTION
The script specified will be run after tunnel buildup and before teardown. Very similar to OpenVPN's up/down options.
The script will receive info about the tunnel as VPN_* environment variables.
Use cases are implementing split DNS, and/or overriding gateway specified routes.

After implementing this feature for myself, I noticed #101, and the option to use pppd ip-up/ip-down scripts for this task. So this is an alternative to that.