### PR TITLE
Add half-internet-routes as an option to influence how default routing is handled

### DIFF
--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -1,4 +1,4 @@
-.TH OPENFORTIVPN 1 "November 10, 2016" ""
+.TH OPENFORTIVPN 1 "July 27, 2017" ""
 
 .SH NAME
 openfortivpn \- Client for PPP+SSL VPN tunnel services
@@ -12,6 +12,7 @@ openfortivpn \- Client for PPP+SSL VPN tunnel services
 [\fB\-\-set-routes=<bool>\fR]
 [\fB\-\-no-routes\fR]
 [\fB\-\-set-dns=<bool>\fR]
+[\fB\-\-half-internet-routes=<bool>\fR]
 [\fB\-\-no-dns\fR]
 [\fB\-\-ca-file=\fI<file>\fR]
 [\fB\-\-user-cert=\fI<file>\fR]
@@ -63,6 +64,9 @@ is usually what you want.
 Set if we should try to configure IP routes through the VPN when tunnel is up. If used multiple times, the last one takes priority.
 
 \fB\-\-no-routes\fR is the same as \fB\-\-set-routes=\fI0\fR.
+.TP
+\fB\-\-half-internet-routes=\fI<bool>\fR, if set to 1, tells openfortivpn not to 
+replace the default route by a different one, but set up two separate /1-routes instead.
 .TP
 \fB\-\-set-dns=\fI<bool>\fR, \fB\-\-no-dns\fR
 Set if we should add VPN nameservers in /etc/resolv.conf when tunnel is up. If used multiple times, the last one takes priority.
@@ -146,6 +150,10 @@ user-cert = @SYSCONFDIR@/openfortivpn/user-cert.pem
 .br
 user-key = @SYSCONFDIR@/openfortivpn/user-key.pem
 .br
+# the sha256 digest of the trusted host certs obtained by
+.br
+# openssl dgst -sha256 server-cert.pem:
+.br
 trusted-cert = certificatedigest4daa8c5fe6c...
 .br
 trusted-cert = othercertificatedigest6631bf...
@@ -158,6 +166,8 @@ set-dns = 1
 .br
 set-routes = 1
 .br
+half-internet-routes = 0
+.br
 pppd-use-peerdns = 1
 .br
 # aternatively, use a specific pppd plugin instead
@@ -169,7 +179,9 @@ pppd-use-peerdns = 1
 # pppd-log = /var/log/pppd.log
 .br
 # pass an ipparam string to pppd
+.br
 # pppd-ipparam = somestringtopasstopppd
+.br
 insecure-ssl = 0
 .br
 cipher-list = HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4

--- a/src/config.c
+++ b/src/config.c
@@ -190,6 +190,15 @@ int load_config(struct vpn_config *cfg, const char *filename)
 				continue;
 			}
 			cfg->set_routes = set_routes;
+		} else if (strcmp(key, "half-internet-routes") == 0) {
+			int half_internet_routes = strtob(val);
+			if (half_internet_routes < 0) {
+				log_warn("Bad half-internet-routes in config file:" \
+				         " \"%s\".\n",
+				         val);
+				continue;
+			}
+			cfg->half_internet_routes = half_internet_routes;
 		} else if (strcmp(key, "pppd-use-peerdns") == 0) {
 			int pppd_use_peerdns = strtob(val);
 			if (pppd_use_peerdns < 0) {

--- a/src/config.h
+++ b/src/config.h
@@ -66,6 +66,7 @@ struct vpn_config {
 	int	set_dns;
 	int     pppd_use_peerdns;
 	int     use_syslog;
+	int	half_internet_routes;
 
 	char	*pppd_log;
 	char	*pppd_plugin;

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -566,31 +566,33 @@ static int ipv4_set_split_routes(struct tunnel *tunnel)
 static int ipv4_set_default_routes(struct tunnel *tunnel)
 {
 	int ret;
-	struct rtentry *def_rt = &tunnel->ipv4.def_rt;
 	struct rtentry *ppp_rt = &tunnel->ipv4.ppp_rt;
 
 	route_init(ppp_rt);
 
-	// Delete the current default route
-	log_debug("Deleting the current default route...\n");
-	ret = ipv4_del_route(def_rt);
-	if (ret != 0)
-		log_warn("Could not delete the current default route (%s).\n",
-		         err_ipv4_str(ret));
-
 	// Set the new default route
-	// ip route add to 0/0 dev ppp0
+	// Emulate default routes as two "half internet" routes
+	// This allows for e.g. DHCP renewing default routes without
+	// breaking the tunnel
+	log_debug("Setting new half-internet routes...\n");
 	route_dest(ppp_rt).s_addr = inet_addr("0.0.0.0");
-	route_mask(ppp_rt).s_addr = inet_addr("0.0.0.0");
-	route_gtw(ppp_rt).s_addr = inet_addr("0.0.0.0");
+	route_mask(ppp_rt).s_addr = inet_addr("128.0.0.0");
 	strncpy(route_iface(ppp_rt), tunnel->ppp_iface, ROUTE_IFACE_LEN - 1);
 
-	log_debug("Setting new default route...\n");
 	ret = ipv4_set_route(ppp_rt);
 	if (ret == ERR_IPV4_SEE_ERRNO && errno == EEXIST) {
-		log_warn("Default route exists already.\n");
+		log_warn("0.0.0.0/1 route exists already.\n");
 	} else if (ret != 0) {
-		log_warn("Could not set the new default route (%s).\n",
+		log_warn("Could not set the new 0.0.0.0/1 route (%s).\n",
+		         err_ipv4_str(ret));
+	}
+
+	route_dest(ppp_rt).s_addr = inet_addr("128.0.0.0");
+	ret = ipv4_set_route(ppp_rt);
+	if (ret == ERR_IPV4_SEE_ERRNO && errno == EEXIST) {
+		log_warn("128.0.0.0/1 route exists already.\n");
+	} else if (ret != 0) {
+		log_warn("Could not set the new 128.0.0.0/1 route (%s).\n",
 		         err_ipv4_str(ret));
 	}
 
@@ -623,23 +625,6 @@ int ipv4_restore_routes(struct tunnel *tunnel)
 		if (ret != 0)
 			log_warn("Could not delete route to vpn server (%s).\n",
 			         err_ipv4_str(ret));
-
-		if (tunnel->ipv4.split_routes==0) {
-			ret = ipv4_del_route(ppp_rt);
-			if (ret != 0)
-				log_warn("Could not delete route through tunnel (%s).\n",
-				         err_ipv4_str(ret));
-
-			// Restore the default route. It seems not to be
-			// automatically restored on all linux distributions
-			ret = ipv4_set_route(def_rt);
-			if (ret != 0) {
-				log_warn("Could not restore default route (%s). "
-				         "Already restored?\n",
-				         err_ipv4_str(ret));
-			}
-
-		}
 	} else {
 		log_debug("Route to vpn server was not added\n");
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -25,11 +25,12 @@
 #define usage \
 "Usage: openfortivpn [<host>:<port>] [-u <user>] [-p <pass>]\n" \
 "                    [--realm=<realm>] [--otp=<otp>] [--set-routes=<0|1>]\n" \
-"                    [--set-dns=<0|1>] [--pppd-no-peerdns] [--pppd-log=<file>]\n" \
+"                    [--half_internet_routes=<0|1>] [--set-dns=<0|1>]\n" \
+"                    [--pppd-no-peerdns] [--pppd-log=<file>]\n" \
 "                    [--pppd-ipparam=<string>] [--pppd-plugin=<file>]\n" \
-"                    [--ca-file=<file>] [--user-cert=<file>]\n" \
-"                    [--user-key=<file>] [--trusted-cert=<digest>]\n" \
-"                    [--use-syslog] [-c <file>] [-v|-q]\n" \
+"                    [--ca-file=<file>] [--user-cert=<file>] [--user-key=<file>] \n" \
+"                    [--trusted-cert=<digest>] [--use-syslog] \n" \
+"                    [-c <file>] [-v|-q]\n" \
 "       openfortivpn --help\n" \
 "       openfortivpn --version\n" \
 "\n"
@@ -53,6 +54,7 @@
 "  --set-routes=[01]             Set if we should configure output roues through\n" \
 "                                the VPN when tunnel is up.\n" \
 "  --no-routes                   Do not configure routes, same as --set-routes=0.\n" \
+"  --half-internet-routes=[01]   Add /1-routes instead of replacing the default route\n" \
 "  --set-dns=[01]                Set if we should add VPN name servers in\n" \
 "                                /etc/resolv.conf\n" \
 "  --no-dns                      Do not reconfigure DNS, same as --set-dns=0\n" \
@@ -140,6 +142,7 @@ int main(int argc, char **argv)
 		{"otp",             required_argument, 0, 'o'},
 		{"set-routes",	    required_argument, 0, 0},
 		{"no-routes",       no_argument, &cfg.set_routes, 0},
+		{"half-internet-routes", required_argument, 0, 0},
 		{"set-dns",	    required_argument, 0, 0},
 		{"no-dns",          no_argument, &cfg.set_dns, 0},
 		{"pppd-no-peerdns", no_argument, &cfg.pppd_use_peerdns, 0},
@@ -243,6 +246,17 @@ int main(int argc, char **argv)
 					break;
 				}
 				cfg.set_routes = set_routes;
+				break;
+			}
+			if (strcmp(long_options[option_index].name,
+			           "half-internet-routes") == 0) {
+				int half_internet_routes = strtob(optarg);
+				if (half_internet_routes < 0) {
+					log_warn("Bad half-internet-routes options: " \
+					         "\"%s\"\n", optarg);
+					break;
+				}
+				cfg.half_internet_routes = half_internet_routes;
 				break;
 			}
 			if (strcmp(long_options[option_index].name,


### PR DESCRIPTION
This merges the routing improvement proposed by @martinetd in #149 together with a command line option to select this type of behavior explicitly. The corresponding config file option is also added and the man page and help message are updated to reflect the new option