### PR TITLE
Providing an option for setting the authentication realm in the configfile

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -174,6 +174,9 @@ int load_config(struct vpn_config *cfg, const char *filename)
 		} else if (strcmp(key, "otp") == 0) {
 			strncpy(cfg->otp, val, FIELD_SIZE - 1);
 			cfg->otp[FIELD_SIZE] = '\0';
+		} else if (strcmp(key, "realm") == 0) {
+			strncpy(cfg->realm, val, FIELD_SIZE - 1);
+			cfg->realm[FIELD_SIZE] = '\0';
 		} else if (strcmp(key, "set-dns") == 0) {
 			int set_dns = strtob(val);
 			if (set_dns < 0) {


### PR DESCRIPTION
I'm a big fan of this handy tool, but after our VPNs got upgraded and auth realms were introduced I discovered that the 'realm' option can only be passed through the command line, not through the configfile.   

The proposed change enables that behavior by adding 'realm' to the list of keywords checked for in the configfile on launch.