### PR TITLE
clean up config initialization and error messages during parsing options

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -85,19 +85,26 @@ struct vpn_config {
 	do { \
 		(cfg)->gateway_host[0] = '\0'; \
 		(cfg)->gateway_port = 0; \
-		(cfg)->realm[0] = '\0'; \
 		(cfg)->username[0] = '\0'; \
 		(cfg)->password[0] = '\0'; \
 		(cfg)->otp[0] = '\0'; \
+		(cfg)->cookie[0] = '\0'; \
+		(cfg)->realm[0] = '\0'; \
+		(cfg)->set_routes = 1; \
+		(cfg)->set_dns = 1; \
+		(cfg)->pppd_use_peerdns = 1; \
+		(cfg)->half_internet_routes = 0; \
+		(cfg)->use_syslog = 0; \
 		(cfg)->pppd_log = NULL; \
 		(cfg)->pppd_plugin = NULL; \
 		(cfg)->pppd_ipparam = NULL; \
 		(cfg)->ca_file = NULL; \
 		(cfg)->user_cert = NULL; \
 		(cfg)->user_key = NULL; \
+		(cfg)->verify_cert = 1; \
+		(cfg)->insecure_ssl = 0; \
 		(cfg)->cipher_list = NULL; \
 		(cfg)->cert_whitelist = NULL; \
-		(cfg)->use_syslog = 0; \
 	} while (0)
 
 #define destroy_vpn_config(cfg) \

--- a/src/main.c
+++ b/src/main.c
@@ -126,11 +126,6 @@ int main(int argc, char **argv)
 
 	// Set defaults
 	init_vpn_config(&cfg);
-	cfg.set_routes = 1;
-	cfg.set_dns = 1;
-	cfg.verify_cert = 1;
-	cfg.insecure_ssl = 0;
-	cfg.pppd_use_peerdns = 1;
 
 	struct option long_options[] = {
 		{"help",            no_argument,       0, 'h'},
@@ -241,7 +236,7 @@ int main(int argc, char **argv)
 			           "set-routes") == 0) {
 				int set_routes = strtob(optarg);
 				if (set_routes < 0) {
-					log_warn("Bad set-routes options: \"%s\"\n",
+					log_warn("Bad set-routes option: \"%s\"\n",
 					         optarg);
 					break;
 				}
@@ -252,7 +247,7 @@ int main(int argc, char **argv)
 			           "half-internet-routes") == 0) {
 				int half_internet_routes = strtob(optarg);
 				if (half_internet_routes < 0) {
-					log_warn("Bad half-internet-routes options: " \
+					log_warn("Bad half-internet-routes option: " \
 					         "\"%s\"\n", optarg);
 					break;
 				}
@@ -263,7 +258,7 @@ int main(int argc, char **argv)
 			           "set-dns") == 0) {
 				int set_dns = strtob(optarg);
 				if (set_dns < 0) {
-					log_warn("Bad set-dns options: \"%s\"\n",
+					log_warn("Bad set-dns option: \"%s\"\n",
 					         optarg);
 					break;
 				}


### PR DESCRIPTION
initialization took place in a macro, except for a few variables of the config. This patch cleans that up and moves all initialization into the macro. There were also a few grammar mistakes in the error messages that may printed out when wrong values were supplied for the command line options