### PR TITLE
Consistently use Linux kernel coding style

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -96,7 +96,7 @@ static const char *find_header(const char *res, const char *header)
 
 	while (memcmp(line, "\r\n", 2)) {
 		int line_len = (char *) memmem(line, BUFSZ, "\r\n", 2) - line;
-		int head_len = strlen (header);
+		int head_len = strlen(header);
 
 		if (line_len > head_len && !strncasecmp(line, header, head_len))
 			return line + head_len;
@@ -243,11 +243,11 @@ static int do_http_request(struct tunnel *tunnel, const char *method,
 static int http_request(struct tunnel *tunnel, const char *method,
                         const char *uri, const char *data, char **response)
 {
-	int ret = do_http_request (tunnel, method, uri, data, response);
+	int ret = do_http_request(tunnel, method, uri, data, response);
 
 	if (ret == ERR_HTTP_SSL) {
-		ssl_connect (tunnel);
-		ret = do_http_request (tunnel, method, uri, data, response);
+		ssl_connect(tunnel);
+		ret = do_http_request(tunnel, method, uri, data, response);
 	}
 
 	if (ret != 1)
@@ -337,32 +337,32 @@ int try_otp_auth(struct tunnel *tunnel, const char *buffer, char **res)
 	char *d = data;
 	const char *p = NULL;
 	/* Length-check for destination buffer */
-#define SPACE_AVAILABLE(sz) (sizeof (data) - (d - data) >= (sz))
+#define SPACE_AVAILABLE(sz) (sizeof(data) - (d - data) >= (sz))
 	/* Get the form action */
-	s = strcasestr (s, "<FORM");
+	s = strcasestr(s, "<FORM");
 	if (s == NULL)
 		return -1;
-	s = strcasestr (s + 5, "ACTION=\"");
+	s = strcasestr(s + 5, "ACTION=\"");
 	if (s == NULL)
 		return -1;
 	s += 8;
 	e = strchr(s, '"');
 	if (e == NULL)
 		return -1;
-	if (e - s + 1 > sizeof (path))
+	if (e - s + 1 > sizeof(path))
 		return -1;
-	strncpy (path, s, e - s);
+	strncpy(path, s, e - s);
 	path [e - s] = '\0';
 	/* Try to get password prompt, asume it starts with 'Please'
 	 * Fall back to default prompt if not found/parseable
 	 */
-	p = strstr (s, "Please");
+	p = strstr(s, "Please");
 	if (p) {
-		e = strchr (p, '<');
+		e = strchr(p, '<');
 		if (e != NULL) {
-			if (e - p + 1 < sizeof (prompt)) {
-				strncpy (prompt, p, e - p);
-				prompt [e - p] = '\0';
+			if (e - p + 1 < sizeof(prompt)) {
+				strncpy(prompt, p, e - p);
+				prompt[e - p] = '\0';
 				p = prompt;
 			} else {
 				p = NULL;
@@ -374,80 +374,80 @@ int try_otp_auth(struct tunnel *tunnel, const char *buffer, char **res)
 	if (p == NULL)
 		p = "Please enter one-time password:";
 	/* Search for all inputs */
-	while ((s = strcasestr (s, "<INPUT"))) {
+	while ((s = strcasestr(s, "<INPUT"))) {
 		s += 6;
 		/* check if we found parameters for a later INPUT
 		 * during last round
 		 */
 		if (s < t || s < n || (v && s < v))
 			return -1;
-		t = strcasestr (s, "TYPE=\"");
-		n = strcasestr (s, "NAME=\"");
-		v = strcasestr (s, "VALUE=\"");
+		t = strcasestr(s, "TYPE=\"");
+		n = strcasestr(s, "NAME=\"");
+		v = strcasestr(s, "VALUE=\"");
 		if (t == NULL)
 			return -1;
 		if (n == NULL)
 			continue;
 		n += 6;
 		t += 6;
-		if  (  0 == strncmp (t, "hidden", 6) || 0 == strncmp (t, "password", 8)) {
+		if (0 == strncmp(t, "hidden", 6) || 0 == strncmp(t, "password", 8)) {
 			/* We try to be on the safe side
 			 * and url-encode the variable name
 			 */
 			/* Append '&' if we found something in last round */
 			if (d > data) {
-				if (!SPACE_AVAILABLE (1))
+				if (!SPACE_AVAILABLE(1))
 					return -1;
 				*d++ = '&';
 			}
-			e = strchr (n, '"');
+			e = strchr(n, '"');
 			if (e == NULL)
 				return -1;
-			if (e - n + 1 > sizeof (tmp))
+			if (e - n + 1 > sizeof(tmp))
 				return -1;
-			strncpy (tmp, n, e - n);
+			strncpy(tmp, n, e - n);
 			tmp [e - n] = '\0';
-			if (!SPACE_AVAILABLE (3 * (e - n) + 1))
+			if (!SPACE_AVAILABLE(3 * (e - n) + 1))
 				return -1;
-			url_encode (d, tmp);
-			d += strlen (d);
+			url_encode(d, tmp);
+			d += strlen(d);
 			if (!SPACE_AVAILABLE(1))
 				return -1;
 			*d++ = '=';
 		}
-		if (0 == strncmp (t, "hidden", 6)) {
+		if (0 == strncmp(t, "hidden", 6)) {
 			/* Require value for hidden fields */
 			if (v == NULL)
 				return -1;
 			v += 7;
-			e = strchr (v, '"');
+			e = strchr(v, '"');
 			if (e == NULL)
 				return -1;
-			if (e - v + 1 > sizeof (tmp))
+			if (e - v + 1 > sizeof(tmp))
 				return -1;
-			strncpy (tmp, v, e - v);
+			strncpy(tmp, v, e - v);
 			tmp [e - v] = '\0';
-			if (!SPACE_AVAILABLE (3 * (e - v) + 1))
+			if (!SPACE_AVAILABLE(3 * (e - v) + 1))
 				return -1;
-			url_encode (d, tmp);
-			d += strlen (d);
-		} else if (0 == strncmp (t, "password", 8)) {
+			url_encode(d, tmp);
+			d += strlen(d);
+		} else if (0 == strncmp(t, "password", 8)) {
 			struct vpn_config *cfg = tunnel->config;
 			size_t l;
 			v = NULL;
 			if (cfg->otp [0] == '\0') {
-				read_password (p, cfg->otp, FIELD_SIZE);
+				read_password(p, cfg->otp, FIELD_SIZE);
 				if (cfg->otp [0] == '\0') {
-					log_error ("No OTP specified\n");
+					log_error("No OTP specified\n");
 					return 0;
 				}
 			}
-			l = strlen (cfg->otp);
-			if (!SPACE_AVAILABLE (3 * l + 1))
+			l = strlen(cfg->otp);
+			if (!SPACE_AVAILABLE(3 * l + 1))
 				return -1;
-			url_encode (d, cfg->otp);
-			d += strlen (d);
-		} else if (0 == strncmp (t, "submit", 6)) {
+			url_encode(d, cfg->otp);
+			d += strlen(d);
+		} else if (0 == strncmp(t, "submit", 6)) {
 			/* avoid adding another '&' */
 			n = v = e = NULL;
 		}

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -646,9 +646,9 @@ int ipv4_set_tunnel_routes(struct tunnel *tunnel)
 
 	if (tunnel->ipv4.split_routes)
 		// try even if ipv4_protect_tunnel_route has failed
-		return ipv4_set_split_routes (tunnel);
+		return ipv4_set_split_routes(tunnel);
 	else if (ret == 0) {
-		return ipv4_set_default_routes (tunnel);
+		return ipv4_set_default_routes(tunnel);
 	} else {
 		return ret;
 	}

--- a/src/log.c
+++ b/src/log.c
@@ -60,12 +60,12 @@ void init_logging()
 	pthread_mutex_init(&mutex, &mutexattr);
 }
 
-void set_syslog (int use_syslog)
+void set_syslog(int use_syslog)
 {
 	if (!use_syslog)
 		return;
 	do_syslog = use_syslog;
-	openlog ("openfortivpn", LOG_PID, LOG_DAEMON);
+	openlog("openfortivpn", LOG_PID, LOG_DAEMON);
 }
 
 void increase_verbosity()
@@ -92,11 +92,11 @@ void do_log(int verbosity, const char *format, ...)
 	lp = &log_params [verbosity];
 
 	if (!do_syslog)
-		printf ("%s%s", is_a_tty ? lp->color_string : "", lp->prefix);
+		printf("%s%s", is_a_tty ? lp->color_string : "", lp->prefix);
 
 	va_start(args, format);
 	if (do_syslog)
-		vsyslog (lp->syslog_prio, format, args);
+		vsyslog(lp->syslog_prio, format, args);
 	else
 		vprintf(format, args);
 	va_end(args);
@@ -130,7 +130,7 @@ void do_log_packet(const char *prefix, size_t len, const uint8_t *packet)
 	strcpy(pos - 1, "\n");
 
 	if (do_syslog)
-		syslog (LOG_DEBUG, "%s", str);
+		syslog(LOG_DEBUG, "%s", str);
 	else
 		puts(str);
 

--- a/src/main.c
+++ b/src/main.c
@@ -120,7 +120,7 @@ int main(int argc, char **argv)
 	long int port;
 
 	/* Init cfg */
-	memset (&cfg, 0, sizeof (cfg));
+	memset(&cfg, 0, sizeof(cfg));
 
 	init_logging();
 
@@ -295,7 +295,7 @@ int main(int argc, char **argv)
 
 	if (optind < argc - 1 || optind > argc)
 		goto user_error;
-	set_syslog (cfg.use_syslog);
+	set_syslog(cfg.use_syslog);
 
 	if (password != NULL)
 		log_warn("You should not pass the password on the command "
@@ -305,7 +305,7 @@ int main(int argc, char **argv)
 	// Load config file
 	if (config_file[0] != '\0') {
 		ret = load_config(&cfg, config_file);
-		set_syslog (cfg.use_syslog);
+		set_syslog(cfg.use_syslog);
 		if (ret == 0)
 			log_debug("Loaded config file \"%s\".\n", config_file);
 		else

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -118,7 +118,7 @@ static int pppd_run(struct tunnel *tunnel)
 		};
 		// Dynamically get first NULL pointer so that changes of
 		// args above don't need code changes here
-		int i = sizeof (args) / sizeof (*args) - 1;
+		int i = sizeof(args) / sizeof(*args) - 1;
 		for (; args [i] == NULL; i--)
 			;
 		i++;
@@ -140,7 +140,7 @@ static int pppd_run(struct tunnel *tunnel)
 			args[i++] = tunnel->config->pppd_ipparam;
 		}
 		// Assert that we didn't use up all NULL pointers above
-		assert (i < sizeof (args) / sizeof (*args));
+		assert(i < sizeof(args) / sizeof(*args));
 
 		close(tunnel->ssl_socket);
 		execvp(args[0], args);
@@ -363,7 +363,7 @@ static void ssl_disconnect(struct tunnel *tunnel)
  */
 int ssl_connect(struct tunnel *tunnel)
 {
-	ssl_disconnect (tunnel);
+	ssl_disconnect(tunnel);
 
 	tunnel->ssl_socket = tcp_connect(tunnel);
 	if (tunnel->ssl_socket == -1)


### PR DESCRIPTION
From [Linux kernel coding style](https://www.kernel.org/doc/html/latest/process/coding-style.html):

### 3.1) Spaces

Linux kernel style for use of spaces depends (mostly) on function-versus-keyword usage. Use a space after (most) keywords. The notable exceptions are sizeof, typeof, alignof, and \_\_attribute\_\_, which look somewhat like functions (and are usually used with parentheses in Linux, although they are not required in the language, as in: `sizeof info` after `struct fileinfo info;` is declared).

So use a space after these keywords:

`if, switch, case, for, do, while`

but not with sizeof, typeof, alignof, or \_\_attribute\_\_. E.g.,

`s = sizeof(struct file);`