### PR TITLE
Consistently use Linux kernel coding style

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -56,7 +56,7 @@ int add_trusted_cert(struct vpn_config *cfg, const char *digest)
  * @params[in] str  the string to read from
  * @return          0 or 1 if successful, < 0 if unrecognized value
  */
-int strtob(const char* str)
+int strtob(const char *str)
 {
 	if (str[0] == '\0') {
 		return 0;

--- a/src/config.h
+++ b/src/config.h
@@ -122,7 +122,7 @@ struct vpn_config {
 	free((cfg)->cipher_list);
 
 int add_trusted_cert(struct vpn_config *cfg, const char *digest);
-int strtob(const char* str);
+int strtob(const char *str);
 
 int load_config(struct vpn_config *cfg, const char *filename);
 

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -284,7 +284,7 @@ static int ipv4_get_route(struct rtentry *route)
 			mask = 0;
 		} else {
 			int is_mask_set = 0;
-			char* tmp_position;
+			char *tmp_position;
 			int dot_count = -1;
 
 			if (index(tmpstr, '/') != NULL) {
@@ -478,7 +478,7 @@ int ipv4_protect_tunnel_route(struct tunnel *tunnel)
 
 
 	// Set the default route as the route to the tunnel gateway
-	char* iface = route_iface(gtw_rt);
+	char *iface = route_iface(gtw_rt);
 	memcpy(gtw_rt, def_rt, sizeof(*gtw_rt));
 	route_iface(gtw_rt) = iface;
 	strncpy(route_iface(gtw_rt), route_iface(def_rt), ROUTE_IFACE_LEN - 1);


### PR DESCRIPTION
From [Linux kernel coding style](https://www.kernel.org/doc/html/latest/process/coding-style.html):

When declaring pointer data or a function that returns a pointer type, the preferred use of `*` is adjacent to the data name or function name and not adjacent to the type name. Examples:
```
char *linux_banner;
unsigned long long memparse(char *ptr, char **retptr);
char *match_strdup(substring_t *s);
```