### PR TITLE
Cookie size

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -50,7 +50,7 @@ struct x509_digest {
 };
 
 #define FIELD_SIZE	64
-#define COOKIE_SIZE	300
+#define COOKIE_SIZE	4096
 
 struct vpn_config {
 	char 		gateway_host[FIELD_SIZE + 1];

--- a/src/http.c
+++ b/src/http.c
@@ -316,9 +316,16 @@ static int get_auth_cookie(struct tunnel *tunnel, char *buf)
 				end = strstr(line, ";");
 				if (end != NULL)
 					end[0] = '\0';
+				log_debug("Cookie: %s\n", line);
 				strncpy(tunnel->config->cookie, line, COOKIE_SIZE);
 				tunnel->config->cookie[COOKIE_SIZE] = '\0';
-				ret = 1; // success
+				if (strlen(line) > COOKIE_SIZE) {
+					log_error("Cookie larger than expected:"
+					          " %zu > %d\n",
+					          strlen(line), COOKIE_SIZE);
+				} else {
+					ret = 1; // success
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #171.

* Increase cookie size to 4096, the maximum cookie size as per [RFC 2109](https://www.ietf.org/rfc/rfc2109.txt).
* Add some code to bail out should ever the cookie size be larger than that limit.