### PR TITLE
Fix warning from static analysis tool scan-build

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -138,10 +138,10 @@ static void pool_push(struct ppp_packet_pool *pool, struct ppp_packet *new)
  */
 static struct ppp_packet *pool_pop(struct ppp_packet_pool *pool)
 {
-	struct ppp_packet *first = pool->list_head;
+	struct ppp_packet *first;
 
-	//SEM_WAIT(&pool->sem);
 	pthread_mutex_lock(&pool->mutex);
+
 	while (pool->list_head == NULL)
 		pthread_cond_wait(&pool->new_data, &pool->mutex);
 


### PR DESCRIPTION
This static analysis tool emits this single warning.

Once fixed, I could have Travis run _scan-build_ automatically.

Also the code was "prettyfied" for consistency between `pool_pop()` and `pool_push()`.