### PR TITLE
gethostbyname -> getaddrinfo

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -29,6 +29,7 @@
 #include <fcntl.h>
 #include <ifaddrs.h>
 #include <netdb.h>
+#include <errno.h>
 #include <net/if.h>
 #include <arpa/inet.h>
 #include <openssl/err.h>
@@ -268,14 +269,23 @@ int ppp_interface_is_up(struct tunnel *tunnel)
 
 static int get_gateway_host_ip(struct tunnel *tunnel)
 {
-	struct hostent *host = gethostbyname(tunnel->config->gateway_host);
-	if (host == NULL) {
-		log_error("gethostbyname: %s\n", hstrerror(h_errno));
+	const struct addrinfo hints = { .ai_family = AF_INET };
+	struct addrinfo *result = NULL;
+
+	int ret = getaddrinfo(tunnel->config->gateway_host, NULL, &hints, &result);
+
+	if (ret) {
+		if (ret == EAI_SYSTEM)
+			log_error("getaddrinfo: %s\n", strerror(errno));
+		else
+			log_error("getaddrinfo: %s\n", gai_strerror(ret));
 		return 1;
 	}
 
-	tunnel->config->gateway_ip = *((struct in_addr *)
-	                               host->h_addr_list[0]);
+	tunnel->config->gateway_ip = ((struct sockaddr_in *)
+	                              result->ai_addr)->sin_addr;
+	freeaddrinfo(result);
+
 	setenv("VPN_GATEWAY", inet_ntoa(tunnel->config->gateway_ip), 0);
 
 	return 0;


### PR DESCRIPTION
The obsolescent gethostbyaddr() is not part of POSIX any more.

The last POSIX version to support gethostbyaddr() is
The Open Group Base Specifications Issue 6, IEEE Std 1003.1, 2004 Edition:
	The gethostbyname() function shall return an entry containing
	addresses of address family AF_INET for the host with name name.

The current POSIX version, The Open Group Base Specifications Issue 7,
IEEE Std 1003.1-2008, 2016 Edition, reads:
	The obsolescent h_errno external integer, and the obsolescent
	gethostbyaddr() and gethostbyname() functions are removed,
	along with the HOST_NOT_FOUND, NO_DATA, NO_RECOVERY, and TRY_AGAIN
	macros.