### PR TITLE
execvp() -> execv()

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -177,7 +177,7 @@ static int pppd_run(struct tunnel *tunnel)
 		assert(i < ARRAY_SIZE(args));
 
 		close(tunnel->ssl_socket);
-		execvp(args[0], (char *const *)args);
+		execv(args[0], (char *const *)args);
 		/*
 		 * The following call to fprintf() doesn't work, probably
 		 * because of the prior call to forkpty().


### PR DESCRIPTION
We provide the full path to /usr/sbin/pppd. No need to search the PATH
with execvp(), execv() is enough.