### PR TITLE
Fix missing or misnamed header guards

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -15,8 +15,8 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _CONFIG_H
-#define _CONFIG_H
+#ifndef _OPENFORTIVPN_CONFIG_H
+#define _OPENFORTIVPN_CONFIG_H
 
 #include <errno.h>
 #include <netinet/in.h>

--- a/src/hdlc.h
+++ b/src/hdlc.h
@@ -15,8 +15,8 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _HDLC_H
-#define _HDLC_H
+#ifndef _OPENFORTIVPN_HDLC_H
+#define _OPENFORTIVPN_HDLC_H
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/http.h
+++ b/src/http.h
@@ -15,8 +15,8 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _AUTH_H
-#define _AUTH_H
+#ifndef _OPENFORTIVPN_HTTP_H
+#define _OPENFORTIVPN_HTTP_H
 
 #include "tunnel.h"
 

--- a/src/io.h
+++ b/src/io.h
@@ -15,8 +15,8 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _IO_H
-#define _IO_H
+#ifndef _OPENFORTIVPN_IO_H
+#define _OPENFORTIVPN_IO_H
 
 /*
  * For performance reasons, we store the 6-byte header used by the SSL

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -15,8 +15,8 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _IPV4_H
-#define _IPV4_H
+#ifndef _OPENFORTIVPN_IPV4_H
+#define _OPENFORTIVPN_IPV4_H
 
 #ifdef __APPLE__
 

--- a/src/log.h
+++ b/src/log.h
@@ -15,8 +15,8 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _LOG_H
-#define _LOG_H
+#ifndef _OPENFORTIVPN_LOG_H
+#define _OPENFORTIVPN_LOG_H
 
 #include <stdint.h>
 

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -26,6 +26,9 @@
  *  all source files in the program, then also delete it here.
  */
 
+#ifndef _OPENFORTIVPN_SSL_H
+#define _OPENFORTIVPN_SSL_H
+
 #include <errno.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
@@ -165,3 +168,5 @@ static inline int safe_ssl_write(SSL *ssl, const uint8_t *buf, int n)
 
 	return handle_ssl_error(ssl, ret);
 }
+
+#endif

--- a/src/tunnel.h
+++ b/src/tunnel.h
@@ -26,8 +26,8 @@
  *  all source files in the program, then also delete it here.
  */
 
-#ifndef _TUNNEL_H
-#define _TUNNEL_H
+#ifndef _OPENFORTIVPN_TUNNEL_H
+#define _OPENFORTIVPN_TUNNEL_H
 
 #include <openssl/ssl.h>
 #ifndef __APPLE__

--- a/src/userinput.h
+++ b/src/userinput.h
@@ -15,8 +15,8 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _USERINPUT_H
-#define _USERINPUT_H
+#ifndef _OPENFORTIVPN_USERINPUT_H
+#define _OPENFORTIVPN_USERINPUT_H
 
 void read_password(const char *prompt, char *pass, size_t len);
 

--- a/src/xml.h
+++ b/src/xml.h
@@ -15,8 +15,8 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _XML_H
-#define _XML_H
+#ifndef _OPENFORTIVPN_XML_H
+#define _OPENFORTIVPN_XML_H
 
 #include "tunnel.h"
 


### PR DESCRIPTION
Also add an _OPENFORTIVPN prefix to avoid collisions with external headers.