### PR TITLE
Standard error message for malloc()/realloc()

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -36,6 +36,8 @@
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
 #include <unistd.h>
+#include <string.h>
+#include <errno.h>
 
 #ifdef __APPLE__
 
@@ -218,7 +220,7 @@ static void *pppd_read(void *arg)
 			pktsize = estimated_decoded_size(frm_len);
 			packet = malloc(sizeof(*packet) + 6 + pktsize);
 			if (packet == NULL) {
-				log_warn("malloc failed.\n");
+				log_error("malloc: %s\n", strerror(errno));
 				break;
 			}
 
@@ -291,7 +293,7 @@ static void *pppd_write(void *arg)
 		hdlc_bufsize = estimated_encoded_size(packet->len);
 		hdlc_buffer = malloc(hdlc_bufsize);
 		if (hdlc_buffer == NULL) {
-			log_warn("malloc failed.\n");
+			log_error("malloc: %s\n", strerror(errno));
 			break;
 		}
 		len = hdlc_encode(hdlc_buffer, hdlc_bufsize,
@@ -430,7 +432,7 @@ static void *ssl_read(void *arg)
 
 		packet = malloc(sizeof(struct ppp_packet) + 6 + size);
 		if (packet == NULL) {
-			log_error("malloc failed\n");
+			log_error("malloc: %s\n", strerror(errno));
 			break;
 		}
 		memcpy(pkt_header(packet), header, 6);

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -737,7 +737,7 @@ int ipv4_add_nameservers_to_resolv_conf(struct tunnel *tunnel)
 	buffer = malloc(stat.st_size + 1);
 	if (buffer == NULL) {
 		log_warn("Could not read /etc/resolv.conf (%s).\n",
-		         "Not enough memory");
+		         strerror(errno));
 		goto err_close;
 	}
 
@@ -830,7 +830,7 @@ int ipv4_del_nameservers_from_resolv_conf(struct tunnel *tunnel)
 	buffer = malloc(stat.st_size + 1);
 	if (buffer == NULL) {
 		log_warn("Could not read /etc/resolv.conf (%s).\n",
-		         "Not enough memory");
+		         strerror(errno));
 		goto err_close;
 	}
 

--- a/src/log.c
+++ b/src/log.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 
 static pthread_mutex_t mutex;
 static int do_syslog = 0;
@@ -118,7 +119,7 @@ void do_log_packet(const char *prefix, size_t len, const uint8_t *packet)
 
 	str = malloc(strlen(prefix) + 3 * len + 1 + 1);
 	if (str == NULL) {
-		log_error("malloc failed\n");
+		log_error("malloc: %s\n", strerror(errno));
 		return;
 	}
 


### PR DESCRIPTION
* Use strerror(errno) whenever possible.
  Both malloc() and realloc() set errno when they fail under POSIX.

* Use either of "Not enough memory" or "malloc failed" but not both.