### PR TITLE
Avoid Valgrind warning

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -98,7 +98,11 @@ static int pppd_run(struct tunnel *tunnel)
 	pid_t pid;
 	int amaster;
 #ifndef __APPLE__
-	struct termios termp;
+	struct termios termp = {
+		.c_cflag = B9600,
+		.c_cc[VTIME] = 0,
+		.c_cc[VMIN] = 1
+	};
 #endif
 
 	static const char pppd_path[] = "/usr/sbin/pppd";
@@ -109,10 +113,6 @@ static int pppd_run(struct tunnel *tunnel)
 	}
 
 #ifndef __APPLE__
-	termp.c_cflag = B9600;
-	termp.c_cc[VTIME] = 0;
-	termp.c_cc[VMIN] = 1;
-
 	pid = forkpty(&amaster, NULL, &termp, NULL);
 #else
 	pid = forkpty(&amaster, NULL, NULL, NULL);


### PR DESCRIPTION
Use C99 struct initialization to ensure other struct members are properly
initialized to 0 and avoid this Valgrind message:

Syscall param ioctl(TCSET{S,SW,SF}) points to uninitialised byte(s)
   at 0x5A03510: tcsetattr (tcsetattr.c:83)
   by 0x54E85F0: openpty (openpty.c:121)
   by 0x54E8683: forkpty (forkpty.c:31)
   by 0x40BBE9: pppd_run (tunnel.c:116)
   by 0x40BBE9: run_tunnel (tunnel.c:761)
   by 0x403F7A: main (main.c:428)