### PR TITLE
If the OTP is specified in the configuration, use it for 2FA

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -481,7 +481,7 @@ int auth_log_in(struct tunnel *tunnel)
 	char reqid[32] = { '\0' };
 	char polid[32] = { '\0' };
 	char group[128] = { '\0' };
-	char data[256], token[128];
+	char data[256], token[128], tokenresponse[256];
 	char *res = NULL;
 
 	url_encode(username, tunnel->config->username);
@@ -545,9 +545,10 @@ int auth_log_in(struct tunnel *tunnel)
 			}
 		}
 
+		url_encode(tokenresponse, cfg->otp);
 		snprintf(data, 256, "username=%s&realm=%s&reqid=%s&polid=%s&grp=%s"
 		         "&code=%s&code2=&redir=%%2Fremote%%2Findex&just_logged_in=1",
-		         username, realm, reqid, polid, group, cfg->otp);
+		         username, realm, reqid, polid, group, tokenresponse);
 
 		ret = http_request(tunnel, "POST", "/remote/logincheck", data, &res);
 		if (ret != 1)


### PR DESCRIPTION
Assume the second factor is the one-time password. The distinction
between a mechanism OTP is requested from how 2FA token is requested
doesn't provide much clue into what's the distinction. Assume they're
the same thing, not used together.

This allows the NetworkManager (that sets the otp key in config) to work
with 2FA setups.