### PR TITLE
Linux kernel coding style

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -110,7 +110,7 @@ static void destroy_ssl_locks(void)
 #endif
 
 // global variable to pass signal out of its handler
-volatile sig_atomic_t sig_received = 0;
+sig_atomic_t sig_received = 0;
 
 int get_sig_received(void)
 {


### PR DESCRIPTION
https://github.com/torvalds/linux/blob/master/Documentation/process/volatile-considered-harmful.rst

C programmers have often taken volatile to mean that the variable could
be changed outside of the current thread of execution; as a result, they
are sometimes tempted to use it in kernel code when shared data
structures are being used. In other words, they have been known to treat
volatile types as a sort of easy atomic variable, which they are not. The
use of volatile in kernel code is almost never correct; this document
describes why.

The key point to understand with regard to volatile is that its purpose
is to suppress optimization, which is almost never what one really wants
to do. In the kernel, one must protect shared data structures against
unwanted concurrent access, which is very much a different task. The
process of protecting against unwanted concurrency will also avoid almost
all optimization-related problems in a more efficient way.

Like volatile, the kernel primitives which make concurrent access to data
safe (spinlocks, mutexes, memory barriers, etc.) are designed to prevent
unwanted optimization. If they are being used properly, there will be no
need to use volatile as well. If volatile is still necessary, there is
almost certainly a bug in the code somewhere. In properly-written kernel
code, volatile can only serve to slow things down.