### PR TITLE
Explain why Coverity defect is a false positive

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -154,6 +154,7 @@ static int pppd_run(struct tunnel *tunnel)
 
 		/*
 		 * Coverity detected a defect:
+		 * 	CID 196857: Out-of-bounds write (OVERRUN)
 		 *
 		 * It is actually a false positive:
 		 * Although 'args' is  constant, Coverity is unable


### PR DESCRIPTION
Previous rebase of 25643d6 did not work as expected. Sorry about that.