### PR TITLE
Linux kernel coding style

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -551,7 +551,7 @@ static void *if_config(void *arg)
 			          "be UP.\n");
 			break;
 		}
-		log_debug("if_config: not ready yet...\n");
+		log_debug("%s: not ready yet...\n", __func__);
 		timeout -= 200000;
 		usleep(200000);
 	}


### PR DESCRIPTION
* Prefer using '"%s...", __func__' to using the function's name