### PR TITLE
Print proper pppd status messages

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -220,7 +220,6 @@ static int pppd_run(struct tunnel *tunnel)
 }
 
 static const char * const pppd_message[] = {
-	"Returned an unknown exit status", // fall back
 	"Has detached, or otherwise the connection was successfully"
 	" established and terminated at the peer's request.",
 	"An immediately fatal error of some kind occurred, such as an"
@@ -245,7 +244,7 @@ static const char * const pppd_message[] = {
 	" connect time limit was reached.",
 	"Callback was negotiated and an incoming call should arrive shortly.",
 	"The link was terminated because the peer is not responding to echo"
-	" requests.", // emitted when exiting normally
+	" requests.",
 	"The link was terminated by the modem hanging up.",
 	"The PPP negotiation failed because serial loopback was detected.",
 	"The init script failed (returned a non-zero exit status).",
@@ -265,13 +264,21 @@ static int pppd_terminate(struct tunnel *tunnel)
 	if (WIFEXITED(status)) {
 		int exit_status = WEXITSTATUS(status);
 		log_debug("waitpid: pppd exit status code %d\n", exit_status);
-		if (exit_status) {
-			size_t len_pppd_message = ARRAY_SIZE(pppd_message);
-			if (exit_status >= len_pppd_message)
-				exit_status = 0;
-			if (exit_status != 16) // emitted when exiting normally
+		if (exit_status >= ARRAY_SIZE(pppd_message) || exit_status < 0)
+			log_error("pppd: Returned an unknown exit status: %d\n",
+			          exit_status);
+		else
+			switch (exit_status) {
+			case 0: // success
+				log_debug("pppd: %s\n", pppd_message[exit_status]);
+				break;
+			case 16: // emitted when exiting normally
+				log_info("pppd: %s\n", pppd_message[exit_status]);
+				break;
+			default:
 				log_error("pppd: %s\n", pppd_message[exit_status]);
-		}
+				break;
+			}
 	} else if (WIFSIGNALED(status)) {
 		int signal_number = WTERMSIG(status);
 		log_debug("waitpid: pppd terminated by signal %d\n",


### PR DESCRIPTION
Fixes #273.

The enumeration of pppd exit status codes was off by one
in the HTML man page this code was based on.