### PR TITLE
replace hard-coded virtual ip address in pppd call parameters…

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -125,7 +125,7 @@ static int pppd_run(struct tunnel *tunnel)
 		static const char *args[] = {
 			pppd_path,
 			"38400", // speed
-			":1.1.1.1", // <local_IP_address>:<remote_IP_address>
+			":192.0.2.1", // <local_IP_address>:<remote_IP_address>
 			"noipdefault",
 			"noaccomp",
 			"noauth",


### PR DESCRIPTION
…by a rc3330 test-net address

1.1.1.1 was widely used for ppp connections in the past but it has been assigned by  IANA and is used by a public DNS server operated by Cloudflare now. Recommendation is to use a test-net address instead. This commit therefore changes it to 192.0.2.1 and solves #280 