### PR TITLE
replace hard-coded virtual ip address in pppd call parameters...

### DIFF
--- a/etc/ppp/peers/openfortivpn
+++ b/etc/ppp/peers/openfortivpn
@@ -1,5 +1,5 @@
 38400
-:1.1.1.1
+:192.0.2.1
 noipdefault
 noaccomp
 noauth

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -125,7 +125,7 @@ static int pppd_run(struct tunnel *tunnel)
 		static const char *args[] = {
 			pppd_path,
 			"38400", // speed
-			":1.1.1.1", // <local_IP_address>:<remote_IP_address>
+			":192.0.2.1", // <local_IP_address>:<remote_IP_address>
 			"noipdefault",
 			"noaccomp",
 			"noauth",


### PR DESCRIPTION
...by a rfc3330 test-net address

1.1.1.1 was widely used for ppp connections in the past but it has been assigned by IANA and is used by a public DNS server operated by Cloudflare now. Recommendation is to use a test-net address instead. This commit therefore changes it to 192.0.2.1 and solves #280 (this is a second attempt after #281 was closed by accident)