### PR TITLE
socket() requires <sys/socket.h>

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -38,6 +38,7 @@
 #include <string.h>
 #include <net/if.h>
 #include <arpa/inet.h>
+#include <sys/socket.h>
 #include <openssl/err.h>
 #include <openssl/x509v3.h>
 #ifdef __APPLE__

--- a/src/userinput.c
+++ b/src/userinput.c
@@ -15,7 +15,8 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <stddef.h>
+#include "userinput.h"
+
 #include <stdio.h>
 #include <termios.h>
 #include <unistd.h>

--- a/src/userinput.h
+++ b/src/userinput.h
@@ -18,6 +18,8 @@
 #ifndef _OPENFORTIVPN_USERINPUT_H
 #define _OPENFORTIVPN_USERINPUT_H
 
+#include <sys/types.h>
+
 void read_password(const char *prompt, char *pass, size_t len);
 
 #endif


### PR DESCRIPTION
Also size_t is defined in both <stddef.h> (C) and <sys/types.h> (POSIX).
Use the second for consistency, and include before using size_t.