### PR TITLE
supply the SVPNCOOKIE via environment

### DIFF
--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -191,6 +191,14 @@ VPN_ROUTE_MASK_... the network mask for this route
 .br
 VPN_ROUTE_GATEWAY_... the gateway for the current route entry
 
+If an environment variable
+.B SVPNCOOKIE
+is present 
+.B openfortivpn
+will skip the authentication step and use that value as cookie. It assumes
+that some other mechanism (a surrounding GUI or scripting framework) has 
+already performed the login and recieved this cookie from the remote side.
+
 .SH CONFIG FILE
 Options can be taken from a configuration file. Options passed in the command
 line will override those from the config file, though. The default config file


### PR DESCRIPTION
if the SVPNCOOKIE is set in the enviroment authentication is skipped and
the cookie is taken from the environment instead. (addresses #46)