### PR TITLE
FreeBSD support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,9 @@ openfortivpn_SOURCES = src/config.c src/config.h src/hdlc.c src/hdlc.h \
 		       src/tunnel.h src/main.c src/ssl.h src/xml.c \
 		       src/xml.h src/userinput.c src/userinput.h
 openfortivpn_CFLAGS = -Wall --pedantic -std=gnu99
-openfortivpn_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\"
+openfortivpn_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" \
+			-DPPP_PATH=\"@PPP_PATH@\" \
+			-DNETSTAT_PATH=\"@NETSTAT_PATH@\"
 
 openfortivpn_CPPFLAGS += $(OPENSSL_CFLAGS) $(LIBSYSTEMD_CFLAGS)
 openfortivpn_LDADD = $(OPENSSL_LIBS) $(LIBSYSTEMD_LIBS)
@@ -29,6 +31,6 @@ install-data-hook:
 dist_man_MANS = doc/openfortivpn.1
 
 doc/openfortivpn.1: $(srcdir)/doc/openfortivpn.1.in
-	mkdir -p doc; sed -e 's|[@]SYSCONFDIR[@]|$(sysconfdir)|g;s|[@]DATADIR[@]|$(datadir)|g;' $^ >$@
+	mkdir -p doc; sed -e 's|[@]SYSCONFDIR[@]|$(sysconfdir)|g;s|[@]DATADIR[@]|$(datadir)|g;' $(srcdir)/doc/openfortivpn.1.in >$@
 
 EXTRA_DIST = LICENSE README.md doc/openfortivpn.1.in $(data_DATA)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ For other distros, you'll need to build and install from source:
     * Gentoo Linux: `net-dialup/ppp` `pkg-config`
     * openSUSE: `gcc` `automake` `autoconf` `libopenssl-devel` `pkg-config`
     * macOS(Homebrew): `automake` `autoconf` `openssl@1.0` `pkg-config`
+    * FreeBSD: `automake` `autoconf` `libressl` `pkgconf`
 
     On Linux, if you manage your kernel yourself, ensure to compile those modules:
     ```

--- a/configure.ac
+++ b/configure.ac
@@ -244,18 +244,6 @@ AC_ARG_ENABLE([proc],
 			[Enable route manipulations directly via /proc/net/route \
 			when cross-compiling, use --disable-proc for the opposite]))
 
-
-# when neither ppp nor pppd are enabled, assume the previous behavior (for travis)
-AS_IF([test "x$with_ppp" = "xno" -a "x$with_pppd" = "xno"], [
-   with_pppd="yes"
-])
-
-# when both are enabled, give pppd the higher priority (we can only use one of them)
-AS_IF([test "x$with_ppp" = "xyes" -a "x$with_pppd" = "xyes"], [
-   with_ppp="no"
-])
-
-
 # Checks for existence of specific files.
 AC_CHECK_FILE([/proc/net/route],[
   AS_IF([test "x$enable_proc" = "x" ], [
@@ -291,6 +279,18 @@ AC_CHECK_FILE(/usr/sbin/pppd,[
 ],[])
 
 
+# when neither ppp nor pppd are enabled, assume the previous behavior (for travis)
+AS_IF([test "x$with_ppp" = "xno" -a "x$with_pppd" = "xno" ], [
+   with_pppd="yes"
+])
+AS_IF([test "x$with_ppp" = "x" -a "x$with_pppd" = "x" ], [
+   with_pppd="yes"
+])
+
+# when both are enabled, give pppd the higher priority (we can only use one of them)
+AS_IF([test "x$with_ppp" = "xyes" -a "x$with_pppd" = "xyes"], [
+   with_ppp="no"
+])
 
 AS_IF([test "x$with_ppp" = "xyes"], [
 	AC_DEFINE(HAVE_USR_SBIN_PPP, 1)

--- a/configure.ac
+++ b/configure.ac
@@ -21,7 +21,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 PKG_CHECK_MODULES(OPENSSL, [libcrypto >= 0.9.8 libssl >= 0.9.8], [], [AC_MSG_ERROR([Cannot find OpenSSL 0.9.8 or higher.])])
 AC_CHECK_LIB([pthread], [pthread_create], [], [AC_MSG_ERROR([Cannot find libpthread.])])
 AC_CHECK_LIB([util], [forkpty], [], [AC_MSG_ERROR([Cannot find libutil.])])
-PKG_CHECK_MODULES(LIBSYSTEMD, [libsystemd], [AC_DEFINE(HAVE_SYSTEMD)], [ ])
+PKG_CHECK_MODULES(LIBSYSTEMD, [libsystemd], [AC_DEFINE(HAVE_SYSTEMD)], [AC_MSG_RESULT([libsystemd not present])])
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h assert.h ctype.h errno.h fcntl.h getopt.h ifaddrs.h limits.h netdb.h net/if.h netinet/in.h netinet/tcp.h pthread.h signal.h stdarg.h stdint.h stdio.h stdlib.h string.h sys/ioctl.h syslog.h sys/socket.h sys/stat.h sys/types.h sys/wait.h termios.h unistd.h], [], AC_MSG_ERROR([Required header not found]))

--- a/configure.ac
+++ b/configure.ac
@@ -23,14 +23,53 @@ AC_CHECK_LIB([pthread], [pthread_create], [], [AC_MSG_ERROR([Cannot find libpthr
 AC_CHECK_LIB([util], [forkpty], [], [AC_MSG_ERROR([Cannot find libutil.])])
 PKG_CHECK_MODULES(LIBSYSTEMD, [libsystemd], [AC_DEFINE(HAVE_SYSTEMD)], [AC_MSG_RESULT([libsystemd not present])])
 
-# Checks for header files.
-AC_CHECK_HEADERS([arpa/inet.h assert.h ctype.h errno.h fcntl.h getopt.h ifaddrs.h limits.h netdb.h net/if.h netinet/in.h netinet/tcp.h pthread.h signal.h stdarg.h stdint.h stdio.h stdlib.h string.h sys/ioctl.h syslog.h sys/socket.h sys/stat.h sys/types.h sys/wait.h termios.h unistd.h], [], AC_MSG_ERROR([Required header not found]))
+# we assume presence of the follwowing C standard headers
+# and ommit them in the follwoing header checks
+#
+# assert.h
+# ctype.h
+# errno.h
+# limits.h
+# signal.h
+# stdarg.h
+# stdint.h
+# stdio.h
+# stdlib.h
+# string.h
+
+# Checks for required header files.
+AC_CHECK_HEADERS([ \
+arpa/inet.h \
+fcntl.h \
+getopt.h \
+ifaddrs.h \
+netdb.h \
+net/if.h \
+netinet/in.h \
+netinet/tcp.h \
+pthread.h \
+sys/ioctl.h \
+syslog.h \
+sys/socket.h \
+sys/stat.h \
+sys/types.h \
+sys/wait.h \
+termios.h \
+unistd.h \
+], [], AC_MSG_ERROR([Required header not found]))
 
 # Checks for header files with prerequisites of other headers.
 AC_CHECK_HEADERS([net/route.h], [], AC_MSG_ERROR([Required header not found]), [#include <net/if.h>])
 
 # Checks for optional header files.
-AC_CHECK_HEADERS([libutil.h mach/mach.h pty.h semaphore.h sys/mutex.h util.h])
+AC_CHECK_HEADERS([ \
+libutil.h \
+mach/mach.h \
+pty.h \
+semaphore.h \
+sys/mutex.h \
+util.h \
+])
 
 # Checks for optional header files with prerequisites of other headers.
 AC_CHECK_HEADERS([net/if_var.h],[],[],[#include <net/if.h>])
@@ -49,7 +88,95 @@ AC_CHECK_TYPES([struct termios], [], [], [#include <termios.h>])
 # Checks for library functions.
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
-AC_CHECK_FUNCS([atoi close connect execv exit _exit fclose fcntl fflush fopen forkpty fprintf fputs free freeaddrinfo freeifaddrs freopen fwrite getaddrinfo getchar getenv getopt_long htons index inet_addr inet_ntoa isatty isdigit isspace malloc memcpy memmem memmove memset ntohs open openlog pclose popen printf pthread_cancel pthread_cond_init pthread_cond_signal pthread_cond_wait pthread_join pthread_mutexattr_init pthread_mutex_destroy pthread_mutex_init pthread_mutex_lock pthread_mutex_unlock pthread_sigmask puts read realloc rewind select setenv sigaddset sigemptyset signal snprintf socket sprintf strcasestr strcat strchr strcmp strcpy strdup strerror strlen strncasecmp strncat strncpy strsignal strstr strtok strtok_r strtol syslog system tcsetattr usleep vprintf vsnprintf vsyslog write], [], AC_MSG_ERROR([Required function not found]))
+AC_CHECK_FUNCS([ \
+atoi \
+close \
+connect \
+execv \
+exit \
+_exit \
+fclose \
+fcntl \
+fflush \
+fopen \
+forkpty \
+fprintf \
+fputs \
+free \
+freeaddrinfo \
+freeifaddrs \
+freopen \
+fwrite \
+getaddrinfo \
+getchar \
+getenv \
+getopt_long \
+htons \
+index \
+inet_addr \
+inet_ntoa \
+isatty \
+isdigit \
+isspace \
+malloc \
+memcpy \
+memmem \
+memmove \
+memset \
+ntohs \
+open \
+openlog \
+pclose \
+popen \
+printf \
+pthread_cancel \
+pthread_cond_init \
+pthread_cond_signal \
+pthread_cond_wait \
+pthread_join \
+pthread_mutexattr_init \
+pthread_mutex_destroy \
+pthread_mutex_init \
+pthread_mutex_lock \
+pthread_mutex_unlock \
+pthread_sigmask \
+puts \
+read \
+realloc \
+rewind \
+select \
+setenv \
+sigaddset \
+sigemptyset \
+signal \
+snprintf \
+socket \
+sprintf \
+strcasestr \
+strcat \
+strchr \
+strcmp \
+strcpy \
+strdup \
+strerror \
+strlen \
+strncasecmp \
+strncat \
+strncpy \
+strsignal \
+strstr \
+strtok \
+strtok_r \
+strtol \
+syslog \
+system \
+tcsetattr \
+usleep \
+vprintf \
+vsnprintf \
+vsyslog \
+write \
+], [], AC_MSG_ERROR([Required function not found]))
 
 # Checks for optional functions.
 AC_CHECK_FUNCS([pthread_mutexattr_setrobust])

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ PKG_PROG_PKG_CONFIG
 # Helps support multiarch by setting 'host_os' and 'host_cpu'
 AC_CANONICAL_HOST
 
-AM_SILENT_RULES([yes])
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 # Checks for libraries.
 PKG_CHECK_MODULES(OPENSSL, [libcrypto >= 0.9.8 libssl >= 0.9.8], [], [AC_MSG_ERROR([Cannot find OpenSSL 0.9.8 or higher.])])
@@ -24,7 +24,16 @@ AC_CHECK_LIB([util], [forkpty], [], [AC_MSG_ERROR([Cannot find libutil.])])
 PKG_CHECK_MODULES(LIBSYSTEMD, [libsystemd], [AC_DEFINE(HAVE_SYSTEMD)], [ ])
 
 # Checks for header files.
-AC_CHECK_HEADERS([arpa/inet.h assert.h ctype.h errno.h fcntl.h getopt.h ifaddrs.h limits.h mach/mach.h netdb.h net/if.h netinet/in.h netinet/tcp.h net/route.h pty.h semaphore.h signal.h stdarg.h stddef.h stdint.h stdio.h stdlib.h string.h strings.h sys/ioctl.h syslog.h sys/socket.h sys/stat.h sys/time.h sys/types.h sys/wait.h termios.h unistd.h util.h])
+AC_CHECK_HEADERS([arpa/inet.h assert.h ctype.h errno.h fcntl.h getopt.h ifaddrs.h limits.h netdb.h net/if.h netinet/in.h netinet/tcp.h pthread.h signal.h stdarg.h stdint.h stdio.h stdlib.h string.h sys/ioctl.h syslog.h sys/socket.h sys/stat.h sys/types.h sys/wait.h termios.h unistd.h], [], AC_MSG_ERROR([Required header not found]))
+
+# Checks for header files with prerequisites of other headers.
+AC_CHECK_HEADERS([net/route.h], [], AC_MSG_ERROR([Required header not found]), [#include <net/if.h>])
+
+# Checks for optional header files.
+AC_CHECK_HEADERS([libutil.h mach/mach.h pty.h semaphore.h sys/mutex.h util.h])
+
+# Checks for optional header files with prerequisites of other headers.
+AC_CHECK_HEADERS([net/if_var.h],[],[],[#include <net/if.h>])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE
@@ -40,7 +49,9 @@ AC_CHECK_TYPES([struct termios], [], [], [#include <termios.h>])
 # Checks for library functions.
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
-AC_CHECK_FUNCS([atoi close connect execv exit _exit fclose fcntl fflush fopen forkpty fprintf fputs free freeaddrinfo freeifaddrs freopen fwrite getaddrinfo getchar getenv getopt_long htons index inet_addr inet_ntoa isatty isdigit isspace malloc memcpy memmem memmove memset ntohs open openlog pclose popen printf pthread_cancel pthread_cond_init pthread_cond_signal pthread_cond_wait pthread_join pthread_mutexattr_init pthread_mutex_destroy pthread_mutex_init pthread_mutex_lock pthread_mutex_unlock pthread_sigmask puts read realloc rewind select setenv sigaddset sigemptyset signal snprintf socket sprintf strcasestr strcat strchr strcmp strcpy strdup strerror strlen strncasecmp strncat strncpy strsignal strstr strtok strtok_r strtol syslog system tcsetattr usleep vprintf vsnprintf vsyslog write], [], AC_MSG_ERROR([Required function not present]))
+AC_CHECK_FUNCS([atoi close connect execv exit _exit fclose fcntl fflush fopen forkpty fprintf fputs free freeaddrinfo freeifaddrs freopen fwrite getaddrinfo getchar getenv getopt_long htons index inet_addr inet_ntoa isatty isdigit isspace malloc memcpy memmem memmove memset ntohs open openlog pclose popen printf pthread_cancel pthread_cond_init pthread_cond_signal pthread_cond_wait pthread_join pthread_mutexattr_init pthread_mutex_destroy pthread_mutex_init pthread_mutex_lock pthread_mutex_unlock pthread_sigmask puts read realloc rewind select setenv sigaddset sigemptyset signal snprintf socket sprintf strcasestr strcat strchr strcmp strcpy strdup strerror strlen strncasecmp strncat strncpy strsignal strstr strtok strtok_r strtol syslog system tcsetattr usleep vprintf vsnprintf vsyslog write], [], AC_MSG_ERROR([Required function not found]))
+
+# Checks for optional functions.
 AC_CHECK_FUNCS([pthread_mutexattr_setrobust])
 # Use PKG_CHECK_MODULES compiler/linker flags
 save_openssl_CPPFLAGS="${CPPFLAGS}"
@@ -51,4 +62,106 @@ AC_CHECK_FUNCS([X509_check_host])
 CPPFLAGS="${save_openssl_CPPFLAGS}"
 LIBS="${save_openssl_LIBS}"
 
+# Specialised checks for particular features.
+AC_MSG_CHECKING(whether rtentry is available and has rt_dst )
+AC_TRY_RUN([
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <net/route.h>
+static inline struct sockaddr_in *cast_addr(struct sockaddr *addr)
+{
+       return (struct sockaddr_in *) addr;
+}
+struct rtentry route;
+int main() {
+  cast_addr(&(&route)->rt_dst)->sin_family = AF_INET;
+  return (cast_addr(&(&route)->rt_dst)->sin_family == AF_INET) ? 0 : 1; }
+], [
+  AC_DEFINE(HAVE_RT_ENTRY_WITH_RT_DST)
+  AC_MSG_RESULT(yes)
+], AC_MSG_RESULT(no) )
+
+with_ppp=no
+with_pppd=no
+
+# Checks for existence of specific files.
+NETSTAT_PATH=
+AC_CHECK_FILE(/proc/net/route,[
+  enable_proc=yes
+],[
+  AC_CHECK_FILE(/usr/sbin/netstat,[
+    NETSTAT_PATH=/usr/sbin/netstat
+  ],[
+    AC_CHECK_FILE(/usr/bin/netstat,[
+      NETSTAT_PATH=/usr/bin/netstat
+    ],[])
+  ])
+])
+
+AC_CHECK_FILE(/usr/sbin/ppp,[
+  PPP_PATH=/usr/sbin/ppp
+  with_ppp=yes
+],[])
+AC_CHECK_FILE(/usr/sbin/pppd,[
+  PPP_PATH=/usr/sbin/pppd
+  with_pppd=yes
+],[])
+
+# possibility to override default locations
+AC_ARG_WITH([netstat],
+        AS_HELP_STRING([--with-netstat],
+                       [Set the path to the netstat executable on MacOSX or FreeBSD]),
+        NETSTAT_PATH="$withval"
+)
+# this is for the pppd daemon executable
+AC_ARG_WITH([pppd],
+        AS_HELP_STRING([--with-pppd],
+                       [Set the path to the pppd daemon executable]),
+        AS_IF([test ! "x$with_pppd" = "xno" -a ! "x$with_pppd" = "xyes"],[
+		PPP_PATH="$withval"
+		with_pppd=yes
+		with_ppp=no
+	])
+)
+# and this is for the ppp user space client on FreeBSD
+AC_ARG_WITH([ppp],
+        AS_HELP_STRING([--with-ppp],
+                       [Set the path to the ppp userspace client on FreeBSD]),
+        AS_IF([test ! "x$with_ppp" = "xno" -a ! "x$with_ppp" = "xyes"],[
+		PPP_PATH="$withval"
+		with_ppp=yes
+		with_pppd=no
+	])
+)
+
+# override for /proc/net/route detection
+AC_ARG_ENABLE([proc],
+	AS_HELP_STRING([--enable-proc],
+			[Enable route manipulations directly via /proc/net/route when cross-compiling]))
+
+# assume the previous behavior for travis
+AS_IF([test "x$with_ppp" = "xno" -a "x$with_pppd" = "xno"], [
+   with_pppd=yes
+])
+
+AS_IF([test "x$with_ppp" = "xyes"], [
+	AC_DEFINE(HAVE_USR_SBIN_PPP, 1)
+],[
+	AC_DEFINE(HAVE_USR_SBIN_PPP, 0)
+])
+AS_IF([test "x$with_pppd" = "xyes"], [
+	AC_DEFINE(HAVE_USR_SBIN_PPPD, 1)
+],[
+	AC_DEFINE(HAVE_USR_SBIN_PPPD, 0)
+])
+AS_IF([test "x$enable_proc" = "xyes"], [
+	AC_DEFINE(HAVE_PROC_NET_ROUTE)
+],[
+	AC_DEFINE(HAVE_PROC_NET_ROUTE, 0)
+])
+
+AC_SUBST(PPP_PATH)
+AC_SUBST(NETSTAT_PATH)
+
+AC_CONFIG_COMMANDS([timestamp], [touch src/.dirstamp])
 AC_OUTPUT(Makefile)

--- a/configure.ac
+++ b/configure.ac
@@ -208,33 +208,10 @@ int main() {
   AC_MSG_RESULT(yes)
 ], AC_MSG_RESULT(no) )
 
-with_ppp=no
-with_pppd=no
+NETSTAT_PATH=""
+PPP_PATH=""
 
-# Checks for existence of specific files.
-NETSTAT_PATH=
-AC_CHECK_FILE(/proc/net/route,[
-  enable_proc=yes
-],[
-  AC_CHECK_FILE(/usr/sbin/netstat,[
-    NETSTAT_PATH=/usr/sbin/netstat
-  ],[
-    AC_CHECK_FILE(/usr/bin/netstat,[
-      NETSTAT_PATH=/usr/bin/netstat
-    ],[])
-  ])
-])
-
-AC_CHECK_FILE(/usr/sbin/ppp,[
-  PPP_PATH=/usr/sbin/ppp
-  with_ppp=yes
-],[])
-AC_CHECK_FILE(/usr/sbin/pppd,[
-  PPP_PATH=/usr/sbin/pppd
-  with_pppd=yes
-],[])
-
-# possibility to override default locations
+# prepare possibility to override default locations
 AC_ARG_WITH([netstat],
         AS_HELP_STRING([--with-netstat],
                        [Set the path to the netstat executable on MacOSX or FreeBSD]),
@@ -246,8 +223,8 @@ AC_ARG_WITH([pppd],
                        [Set the path to the pppd daemon executable]),
         AS_IF([test ! "x$with_pppd" = "xno" -a ! "x$with_pppd" = "xyes"],[
 		PPP_PATH="$withval"
-		with_pppd=yes
-		with_ppp=no
+		with_pppd="yes"
+		with_ppp="no"
 	])
 )
 # and this is for the ppp user space client on FreeBSD
@@ -256,20 +233,64 @@ AC_ARG_WITH([ppp],
                        [Set the path to the ppp userspace client on FreeBSD]),
         AS_IF([test ! "x$with_ppp" = "xno" -a ! "x$with_ppp" = "xyes"],[
 		PPP_PATH="$withval"
-		with_ppp=yes
-		with_pppd=no
+		with_ppp="yes"
+		with_pppd="no"
 	])
 )
 
 # override for /proc/net/route detection
 AC_ARG_ENABLE([proc],
 	AS_HELP_STRING([--enable-proc],
-			[Enable route manipulations directly via /proc/net/route when cross-compiling]))
+			[Enable route manipulations directly via /proc/net/route \
+			when cross-compiling, use --disable-proc for the opposite]))
 
-# assume the previous behavior for travis
+
+# when neither ppp nor pppd are enabled, assume the previous behavior (for travis)
 AS_IF([test "x$with_ppp" = "xno" -a "x$with_pppd" = "xno"], [
-   with_pppd=yes
+   with_pppd="yes"
 ])
+
+# when both are enabled, give pppd the higher priority (we can only use one of them)
+AS_IF([test "x$with_ppp" = "xyes" -a "x$with_pppd" = "xyes"], [
+   with_ppp="no"
+])
+
+
+# Checks for existence of specific files.
+AC_CHECK_FILE([/proc/net/route],[
+  AS_IF([test "x$enable_proc" = "x" ], [
+    enable_proc="yes"
+  ])
+],[
+  AS_IF([test "x$NETSTAT_PATH" = "x" ], [
+    AC_CHECK_FILE([/usr/sbin/netstat],[
+      NETSTAT_PATH="/usr/sbin/netstat"
+    ],[
+      AC_CHECK_FILE([/usr/bin/netstat],[
+	NETSTAT_PATH="/usr/bin/netstat"
+      ],[])
+    ])
+  ])
+])
+
+AC_CHECK_FILE(/usr/sbin/ppp,[
+  AS_IF([test "x$PPP_PATH" = "x" ], [
+    PPP_PATH="/usr/sbin/ppp"
+  ])
+  AS_IF([test "x$with_ppp" = "x" ], [
+    with_ppp="yes"
+  ])
+],[])
+AC_CHECK_FILE(/usr/sbin/pppd,[
+  AS_IF([test "x$PPP_PATH" = "x" ], [
+    PPP_PATH="/usr/sbin/pppd"
+  ])
+  AS_IF([test "x$with_pppd" = "x" ], [
+    with_pppd="yes"
+  ])
+],[])
+
+
 
 AS_IF([test "x$with_ppp" = "xyes"], [
 	AC_DEFINE(HAVE_USR_SBIN_PPP, 1)
@@ -282,7 +303,7 @@ AS_IF([test "x$with_pppd" = "xyes"], [
 	AC_DEFINE(HAVE_USR_SBIN_PPPD, 0)
 ])
 AS_IF([test "x$enable_proc" = "xyes"], [
-	AC_DEFINE(HAVE_PROC_NET_ROUTE)
+	AC_DEFINE(HAVE_PROC_NET_ROUTE, 1)
 ],[
 	AC_DEFINE(HAVE_PROC_NET_ROUTE, 0)
 ])

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -8,6 +8,7 @@ openfortivpn \- Client for PPP+SSL VPN tunnel services
 [\fI<host>\fR:\fI<port>\fR]
 [\fB\-u\fR \fI<user>\fR]
 [\fB\-p\fR \fI<pass>\fR]
+[\fB\-\-otp=\fI<otp>\fR]
 [\fB\-\-realm=\fI<realm>\fR]
 [\fB\-\-set-routes=<bool>\fR]
 [\fB\-\-no-routes\fR]
@@ -58,6 +59,9 @@ VPN account username.
 .TP
 \fB\-p \fI<pass>\fR, \fB\-\-password=\fI<pass>\fR
 VPN account password.
+.TP
+\fB\-o \fI<otp>\fR, \fB\-\-otp=\fI<otp>\fR
+One-Time-Password.
 .TP
 \fB\-\-realm=\fI<realm>\fR
 Connect to the specified authentication realm. Defaults to empty, which

--- a/etc/ppp/ppp.conf.example
+++ b/etc/ppp/ppp.conf.example
@@ -1,0 +1,12 @@
+# Example configuration for a ppp client
+# for more examples see
+# https://github.com/freebsd/freebsd-base-graphics/blob/master/share/examples/ppp/ppp.conf.sample
+
+vpn-client: 
+ set dial
+ set speed 38400
+ set mru 1354
+ set login
+ set timeout 0
+ disable deflate pred1 
+ deny deflate pred1

--- a/etc/ppp/ppp.conf.example
+++ b/etc/ppp/ppp.conf.example
@@ -2,11 +2,11 @@
 # for more examples see
 # https://github.com/freebsd/freebsd-base-graphics/blob/master/share/examples/ppp/ppp.conf.sample
 
-vpn-client: 
+vpn-client:
  set dial
  set speed 38400
  set mru 1354
  set login
  set timeout 0
- disable deflate pred1 
+ disable deflate pred1
  deny deflate pred1

--- a/src/config.h
+++ b/src/config.h
@@ -42,6 +42,12 @@ static inline const char *err_cfg_str(int code)
 	return "unknown";
 }
 
+#if HAVE_USR_SBIN_PPPD
+#define PPP_DAEMON "pppd"
+#else
+#define PPP_DAEMON "ppp"
+#endif
+
 #define SHA256LEN	(256 / 8)
 #define SHA256STRLEN	(2 * SHA256LEN + 1)
 

--- a/src/config.h
+++ b/src/config.h
@@ -70,11 +70,16 @@ struct vpn_config {
 
 	unsigned int	persistent;
 
+#if HAVE_USR_SBIN_PPPD
 	char	*pppd_log;
 	char	*pppd_plugin;
 	char	*pppd_ipparam;
 	char	*pppd_ifname;
-	char	*pppd_call;
+	char    *pppd_call;
+#endif
+#if HAVE_USR_SBIN_PPP
+	char	*ppp_system;
+#endif
 
 	char			*ca_file;
 	char			*user_cert;

--- a/src/config.h
+++ b/src/config.h
@@ -75,7 +75,7 @@ struct vpn_config {
 	char	*pppd_plugin;
 	char	*pppd_ipparam;
 	char	*pppd_ifname;
-	char    *pppd_call;
+	char	*pppd_call;
 #endif
 #if HAVE_USR_SBIN_PPP
 	char	*ppp_system;

--- a/src/io.c
+++ b/src/io.c
@@ -360,7 +360,7 @@ err_free_buf:
 	 && pkt_data(packet)[2] == 0x01 \
 	 && pkt_data(packet)[4] == 0x00 \
 	 && pkt_data(packet)[5] == 0x04) || \
-	((packet)-> len == 12 \
+	((packet)-> len >= 12 \
 	 && pkt_data(packet)[0] == 0x80 \
 	 && pkt_data(packet)[1] == 0x21 \
 	 && pkt_data(packet)[2] == 0x02)

--- a/src/io.c
+++ b/src/io.c
@@ -475,7 +475,7 @@ static void *ssl_read(void *arg)
 				log_info("Got addresses: %s\n", line);
 			}
 			if (packet_is_end_negociation(packet)) {
-				log_debug("got negotation\n");
+				log_info("negotiation complete\n");
 				SEM_POST(&sem_if_config);
 			}
 		}

--- a/src/io.c
+++ b/src/io.c
@@ -253,8 +253,13 @@ static void *pppd_read(void *arg)
 			packet = repacket;
 			packet->len = pktsize;
 
-			log_debug("ppp ---> gateway (%d bytes)\n", packet->len);
+			log_debug("%s ---> gateway (%d bytes)\n", PPP_DAEMON,
+			          packet->len);
+#if HAVE_USR_SBIN_PPPD
+			log_packet("pppd:   ", packet->len, pkt_data(packet));
+#else
 			log_packet("ppp:   ", packet->len, pkt_data(packet));
+#endif
 			pool_push(&tunnel->pty_to_ssl_pool, packet);
 
 			off_r += frm_len;
@@ -457,7 +462,7 @@ static void *ssl_read(void *arg)
 			goto exit;
 		}
 
-		log_debug("gateway ---> ppp (%d bytes)\n", packet->len);
+		log_debug("gateway ---> %s (%d bytes)\n", PPP_DAEMON, packet->len);
 		log_packet("gtw:    ", packet->len, pkt_data(packet));
 		pool_push(&tunnel->ssl_to_pty_pool, packet);
 

--- a/src/io.c
+++ b/src/io.c
@@ -39,11 +39,11 @@
 #include <string.h>
 #include <errno.h>
 
-#ifdef __APPLE__
-
-/* Mac OS X defines sem_init but actually does not implement them */
+#if HAVE_MACH_MACH_H
+/* this is typical for mach kernel used on Mac OSX */
 #include <mach/mach.h>
 
+/* Mac OS X defines sem_init but actually does not implement them */
 typedef semaphore_t os_semaphore_t;
 
 #define SEM_INIT(sem, x, value)	semaphore_create(mach_task_self(), sem, \
@@ -253,8 +253,8 @@ static void *pppd_read(void *arg)
 			packet = repacket;
 			packet->len = pktsize;
 
-			log_debug("pppd ---> gateway (%d bytes)\n", packet->len);
-			log_packet("pppd:   ", packet->len, pkt_data(packet));
+			log_debug("ppp ---> gateway (%d bytes)\n", packet->len);
+			log_packet("ppp:   ", packet->len, pkt_data(packet));
 			pool_push(&tunnel->pty_to_ssl_pool, packet);
 
 			off_r += frm_len;
@@ -359,7 +359,11 @@ err_free_buf:
 	 && pkt_data(packet)[1] == 0x21 \
 	 && pkt_data(packet)[2] == 0x01 \
 	 && pkt_data(packet)[4] == 0x00 \
-	 && pkt_data(packet)[5] == 0x04)
+	 && pkt_data(packet)[5] == 0x04) || \
+	((packet)-> len == 12 \
+	 && pkt_data(packet)[0] == 0x80 \
+	 && pkt_data(packet)[1] == 0x21 \
+	 && pkt_data(packet)[2] == 0x02)
 
 static inline void set_tunnel_ips(struct tunnel *tunnel,
                                   struct ppp_packet *packet)
@@ -453,7 +457,7 @@ static void *ssl_read(void *arg)
 			goto exit;
 		}
 
-		log_debug("gateway ---> pppd (%d bytes)\n", packet->len);
+		log_debug("gateway ---> ppp (%d bytes)\n", packet->len);
 		log_packet("gtw:    ", packet->len, pkt_data(packet));
 		pool_push(&tunnel->ssl_to_pty_pool, packet);
 
@@ -469,7 +473,9 @@ static void *ssl_read(void *arg)
 				strncat(line, inet_ntoa(tunnel->ipv4.ns2_addr), 15);
 				strcat(line, "]");
 				log_info("Got addresses: %s\n", line);
-			} else if (packet_is_end_negociation(packet)) {
+			}
+			if (packet_is_end_negociation(packet)) {
+				log_debug("got negotation\n");
 				SEM_POST(&sem_if_config);
 			}
 		}
@@ -606,7 +612,7 @@ int io_loop(struct tunnel *tunnel)
 	}
 
 // on osx this prevents the program from being stopped with ctrl-c
-#ifndef __APPLE__
+#if !HAVE_MACH_MACH_H
 	// Disable SIGINT and SIGTERM for the future spawned threads
 	sigset_t sigset, oldset;
 	sigemptyset(&sigset);
@@ -635,7 +641,7 @@ int io_loop(struct tunnel *tunnel)
 	if (pthread_create(&if_config_thread, NULL, if_config, tunnel))
 		goto err_thread;
 
-#ifndef __APPLE__
+#if !HAVE_MACH_MACH_H
 	// Restore the signal for the main thread
 	pthread_sigmask(SIG_SETMASK, &oldset, NULL);
 #endif

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -177,6 +177,8 @@ static int ipv4_get_route(struct rtentry *route)
 	uint32_t total_bytes_read = 0;
 
 	char *saveptr3 = NULL;
+	int have_ref = 0;
+	int have_use = 0;
 
 	static const char netstat_path[] = NETSTAT_PATH;
 	if (access(netstat_path, F_OK) != 0) {
@@ -320,6 +322,8 @@ static int ipv4_get_route(struct rtentry *route)
 	start++;
 
 #if !HAVE_PROC_NET_ROUTE
+	if (strstr(buffer, "Ref") != NULL) have_ref = 1;
+	if (strstr(buffer, "Use") != NULL) have_use = 1;
 	// Skip 3 more lines from netstat output on Mac OSX and on FreeBSD
 	start = index(start, '\n');
 	start = index(++start, '\n');
@@ -435,10 +439,10 @@ static int ipv4_get_route(struct rtentry *route)
 		// this is the reason for the 256 entries mentioned above
 		for (pos = 0; pos < strlen(tmpstr); pos++)
 			flags |= flag_table[(unsigned char)tmpstr[pos]];
-#ifndef __FreeBSD__
-		strtok_r(NULL, " ", &saveptr2); // "Refs"
-		strtok_r(NULL, " ", &saveptr2); // "Use"
-#endif
+
+		if (have_ref) strtok_r(NULL, " ", &saveptr2); // "Ref"
+		if (have_use) strtok_r(NULL, " ", &saveptr2); // "Use"
+
 		iface = strtok_r(NULL, " ", &saveptr2); // "Netif"
 		log_debug("- Interface: %s\n", iface);
 		log_debug("\n");

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -178,6 +178,13 @@ static int ipv4_get_route(struct rtentry *route)
 
 	char *saveptr3 = NULL;
 
+	static const char netstat_path[] = NETSTAT_PATH;
+	if (access(netstat_path, F_OK) != 0) {
+		log_error("%s: %s.\n", netstat_path, strerror(errno));
+		return 1;
+	}
+	log_debug("netstat_path: %s\n", netstat_path);
+
 	// Open the command for reading
 	fp = popen(NETSTAT_PATH" -f inet -rn", "r");
 	if (fp == NULL) {
@@ -546,7 +553,12 @@ static int ipv4_set_route(struct rtentry *route)
 	/* we have to use the route command as tool for route manipulation */
 	char cmd[SHOW_ROUTE_BUFFER_SIZE];
 
-	strcpy(cmd, "route -n add -net ");
+	if (access("/sbin/route", F_OK) != 0) {
+		log_error("/sbin/route: %s.\n", strerror(errno));
+		return 1;
+	}
+
+	strcpy(cmd, "/sbin/route -n add -net ");
 	strncat(cmd, inet_ntoa(route_dest(route)), 15);
 	strcat(cmd, " -netmask ");
 	strncat(cmd, inet_ntoa(route_mask(route)), 15);
@@ -596,7 +608,12 @@ static int ipv4_del_route(struct rtentry *route)
 #else
 	char cmd[SHOW_ROUTE_BUFFER_SIZE];
 
-	strcpy(cmd, "route -n delete ");
+	if (access("/sbin/route", F_OK) != 0) {
+		log_error("/sbin/route: %s.\n", strerror(errno));
+		return 1;
+	}
+
+	strcpy(cmd, "/sbin/route -n delete ");
 	strncat(cmd, inet_ntoa(route_dest(route)), 15);
 	strcat(cmd, " -netmask ");
 	strncat(cmd, inet_ntoa(route_mask(route)), 15);

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -18,11 +18,27 @@
 #ifndef _OPENFORTIVPN_IPV4_H
 #define _OPENFORTIVPN_IPV4_H
 
+#include <sys/types.h>
+#include <sys/socket.h>
+#ifdef HAVE_SYS_MUTEX_H
+/* Mac OSX and BSD wants this explicit include */
+#include <sys/mutex.h>
+#endif
 #include <netinet/in.h>
 #include <net/route.h>
+#include <net/if.h>
+#ifdef HAVE_NET_IF_IF_VAR_H
+/* on FreeBSD we need this additional header */
+#include <net/if_var.h>
+#endif
 
-#ifdef __APPLE__
-#include <sys/socket.h>
+#if !HAVE_RT_ENTRY_WITH_RT_DST
+/* On MacOSX and FreeBSD struct rtentry is not directly available.
+ * On FreeBSD one could #define _WANT_RTENTRY but the struct does not
+ * contain rt_dst for instance. The entries for mask and destination
+ * are maintained in a separate radix_tree structure by the routing
+ * table instance. We can not simply copy rtentry structures.
+ */
 
 /* This structure gets passed by the SIOCADDRT and SIOCDELRT calls. */
 struct rtentry {

--- a/src/main.c
+++ b/src/main.c
@@ -204,7 +204,7 @@ int main(int argc, char **argv)
 		{"insecure-ssl",    no_argument, &cli_cfg.insecure_ssl, 1},
 		{"cipher-list",     required_argument, 0, 0},
 #if HAVE_USR_SBIN_PPPD
-		{"pppd-no-peerdns", no_argument, &cfg.pppd_use_peerdns, 0},
+		{"pppd-no-peerdns", no_argument, &cli_cfg.pppd_use_peerdns, 0},
 		{"pppd-log",        required_argument, 0, 0},
 		{"pppd-plugin",     required_argument, 0, 0},
 		{"pppd-ipparam",    required_argument, 0, 0},

--- a/src/main.c
+++ b/src/main.c
@@ -27,14 +27,40 @@
 #include <string.h>
 #include <limits.h>
 
+#if HAVE_USR_SBIN_PPPD
+#define PPPD_USAGE \
+"                    [--pppd-no-peerdns] [--pppd-log=<file>]\n" \
+"                    [--pppd-ifname=<string>] [--pppd-ipparam=<string>]\n" \
+"                    [--pppd-call=<name>] [--pppd-plugin=<file>]\n"
+
+#define PPPD_HELP \
+"  --pppd-no-peerdns             Deprecated; do not ask peer ppp server for DNS server\n" \
+"                                addresses and do not make pppd rewrite /etc/resolv.conf\n" \
+"  --pppd-log=<file>             Set pppd in debug mode and save its logs into\n" \
+"                                <file>.\n" \
+"  --pppd-plugin=<file>          Use specified pppd plugin instead of configuring\n" \
+"                                resolver and routes directly.\n" \
+"  --pppd-ifname=<string>        Set the pppd interface name, if supported by pppd.\n" \
+"  --pppd-ipparam=<string>       Provides  an extra parameter to the ip-up, ip-pre-up\n" \
+"                                and ip-down scripts. See man (8) pppd\n" \
+"  --pppd-call=<name>            Move most pppd options from pppd cmdline to\n" \
+"                                /etc/ppp/peers/<name> and invoke pppd with\n" \
+"                                'call <name>'\n"
+#endif
+#if HAVE_USR_SBIN_PPP
+#define PPPD_USAGE \
+"                    [--ppp-system=<system>]\n"
+#define PPPD_HELP \
+"  --ppp-system=<system>         connect to the specified system as defined in\n" \
+"                                /etc/ppp/ppp.conf\n"
+#endif
+
 #define usage \
 "Usage: openfortivpn [<host>:<port>] [-u <user>] [-p <pass>]\n" \
 "                    [--realm=<realm>] [--otp=<otp>] [--set-routes=<0|1>]\n" \
 "                    [--half-internet-routes=<0|1>] [--set-dns=<0|1>]\n" \
-"                    [--pppd-no-peerdns] [--pppd-log=<file>]\n" \
-"                    [--pppd-ifname=<string>] [--pppd-ipparam=<string>]\n" \
-"                    [--pppd-call=<name>]\n" \
-"                    [--pppd-plugin=<file>] [--ca-file=<file>]\n" \
+PPPD_USAGE \
+"                    [--ca-file=<file>]\n" \
 "                    [--user-cert=<file>] [--user-key=<file>]\n" \
 "                    [--trusted-cert=<digest>] [--use-syslog]\n" \
 "                    [--persistent=<interval>] [-c <file>] [-v|-q]\n" \
@@ -48,6 +74,7 @@
 "<host>:<port>. It spawns a pppd process and operates the communication between\n" \
 "the gateway and this process.\n" \
 "\n"
+
 
 #define help_options \
 "Options:\n" \
@@ -89,18 +116,7 @@
 "                                you can try with the cipher suggested in the output\n" \
 "                                of 'openssl s_client -connect <host:port>'\n" \
 "                                (e.g. AES256-GCM-SHA384)\n" \
-"  --pppd-no-peerdns             Deprecated; do not ask peer ppp server for DNS server\n" \
-"                                addresses and do not make pppd rewrite /etc/resolv.conf\n" \
-"  --pppd-log=<file>             Set pppd in debug mode and save its logs into\n" \
-"                                <file>.\n" \
-"  --pppd-plugin=<file>          Use specified pppd plugin instead of configuring\n" \
-"                                resolver and routes directly.\n" \
-"  --pppd-ifname=<string>        Set the pppd interface name, if supported by pppd.\n" \
-"  --pppd-ipparam=<string>       Provides  an extra parameter to the ip-up, ip-pre-up\n" \
-"                                and ip-down scripts. See man (8) pppd\n" \
-"  --pppd-call=<name>            Move most pppd options from pppd cmdline to\n" \
-"                                /etc/ppp/peers/<name> and invoke pppd with\n" \
-"                                'call <name>'\n" \
+PPPD_HELP \
 "  --persistent=<interval>       Run the vpn persistently in a loop and try to re-\n" \
 "                                connect every <interval> seconds when dropping out\n" \
 "  -v                            Increase verbosity. Can be used multiple times\n" \
@@ -143,15 +159,20 @@ int main(int argc, char **argv)
 		.realm = {'\0'},
 		.set_routes = 1,
 		.set_dns = 1,
-		.pppd_use_peerdns = 1,
 		.use_syslog = 0,
 		.half_internet_routes = 0,
 		.persistent = 0,
+#if HAVE_USR_SBIN_PPPD
+		.pppd_use_peerdns = 1,
 		.pppd_log = NULL,
 		.pppd_plugin = NULL,
 		.pppd_ipparam = NULL,
 		.pppd_ifname = NULL,
 		.pppd_call = NULL,
+#endif
+#if HAVE_USR_SBIN_PPP
+		.ppp_system = NULL,
+#endif
 		.ca_file = NULL,
 		.user_cert = NULL,
 		.user_key = NULL,
@@ -174,7 +195,6 @@ int main(int argc, char **argv)
 		{"half-internet-routes", required_argument, 0, 0},
 		{"set-dns",         required_argument, 0, 0},
 		{"no-dns",          no_argument, &cli_cfg.set_dns, 0},
-		{"pppd-no-peerdns", no_argument, &cli_cfg.pppd_use_peerdns, 0},
 		{"use-syslog",      no_argument, &cli_cfg.use_syslog, 1},
 		{"persistent",      required_argument, 0, 0},
 		{"ca-file",         required_argument, 0, 0},
@@ -183,12 +203,18 @@ int main(int argc, char **argv)
 		{"trusted-cert",    required_argument, 0, 0},
 		{"insecure-ssl",    no_argument, &cli_cfg.insecure_ssl, 1},
 		{"cipher-list",     required_argument, 0, 0},
+#if HAVE_USR_SBIN_PPPD
+		{"pppd-no-peerdns", no_argument, &cfg.pppd_use_peerdns, 0},
 		{"pppd-log",        required_argument, 0, 0},
 		{"pppd-plugin",     required_argument, 0, 0},
 		{"pppd-ipparam",    required_argument, 0, 0},
 		{"pppd-ifname",     required_argument, 0, 0},
 		{"pppd-call",       required_argument, 0, 0},
 		{"plugin",          required_argument, 0, 0}, // deprecated
+#endif
+#if HAVE_USR_SBIN_PPP
+		{"ppp-system",      required_argument, 0, 0},
+#endif
 		{0, 0, 0, 0}
 	};
 
@@ -216,6 +242,7 @@ int main(int argc, char **argv)
 				ret = EXIT_SUCCESS;
 				goto exit;
 			}
+#if HAVE_USR_SBIN_PPPD
 			if (strcmp(long_options[option_index].name,
 			           "pppd-log") == 0) {
 				cli_cfg.pppd_log = strdup(optarg);
@@ -248,6 +275,14 @@ int main(int argc, char **argv)
 				cli_cfg.pppd_plugin = strdup(optarg);
 				break;
 			}
+#endif
+#if HAVE_USR_SBIN_PPP
+			if (strcmp(long_options[option_index].name,
+			           "ppp-system") == 0) {
+				cfg.ppp_system = strdup(optarg);
+				break;
+			}
+#endif
 			if (strcmp(long_options[option_index].name,
 			           "ca-file") == 0) {
 				cli_cfg.ca_file = strdup(optarg);

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -34,17 +34,20 @@
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 
-#ifdef __APPLE__
+#ifdef __clang__
 /*
  * Get rid of OSX 10.7 and greater deprecation warnings
  * see for instance https://wiki.openssl.org/index.php/Hostname_validation
  * this pragma selectively suppresses this type of warnings in clang
  */
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+#ifndef ERESTART
 /*
  * ERESTART is one of the recoverable errors which might be returned.
- * However, in OSX this constant is not defined in errno.h so we define
- * a dummy value here.
+ * However, in OSX and BSD this constant is not defined in errno.h
+ * so we define a dummy value here.
  */
 #define ERESTART -1
 #endif

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -55,7 +55,6 @@
 #include <systemd/sd-daemon.h>
 #endif
 
-
 struct ofv_varr {
 	unsigned cap;		// current capacity
 	unsigned off;		// next slot to write, always < max(cap - 1, 1)

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -39,6 +39,7 @@
 #include <net/if.h>
 #include <arpa/inet.h>
 #include <sys/socket.h>
+#include <sys/ioctl.h>
 #include <openssl/err.h>
 #include <openssl/x509v3.h>
 #if HAVE_PTY_H
@@ -53,6 +54,7 @@
 #if HAVE_SYSTEMD
 #include <systemd/sd-daemon.h>
 #endif
+
 
 struct ofv_varr {
 	unsigned cap;		// current capacity
@@ -140,12 +142,12 @@ static int pppd_run(struct tunnel *tunnel)
 	};
 #endif
 
-	static const char pppd_path[] = "/usr/sbin/pppd";
-
-	if (access(pppd_path, F_OK) != 0) {
-		log_error("%s: %s.\n", pppd_path, strerror(errno));
+	static const char ppp_path[] = PPP_PATH;
+	if (access(ppp_path, F_OK) != 0) {
+		log_error("%s: %s.\n", ppp_path, strerror(errno));
 		return 1;
 	}
+	log_debug("ppp_path: %s\n", ppp_path);
 
 #ifdef HAVE_STRUCT_TERMIOS
 	pid = forkpty(&amaster, NULL, &termp, NULL);
@@ -157,15 +159,31 @@ static int pppd_run(struct tunnel *tunnel)
 		log_error("forkpty: %s\n", strerror(errno));
 		return 1;
 	} else if (pid == 0) { // child process
+
 		struct ofv_varr pppd_args = { 0, 0, NULL };
 
+#if HAVE_USR_SBIN_PPP
+		/*
+		* assume there is a default configuration to start.
+		* Support for taking options from the command line
+		* e.g. the name of the configuration or options
+		* to send interactively to ppp will be added later
+		*/
+		const char *v[] = {
+			ppp_path,
+			"-direct"
+		};
+		for (unsigned i = 0; i < sizeof v/sizeof v[0]; i++)
+			ofv_append_varr(&pppd_args, v[i]);
+#endif
+#if HAVE_USR_SBIN_PPPD
 		if (tunnel->config->pppd_call) {
-			ofv_append_varr(&pppd_args, pppd_path);
+			ofv_append_varr(&pppd_args, ppp_path);
 			ofv_append_varr(&pppd_args, "call");
 			ofv_append_varr(&pppd_args, tunnel->config->pppd_call);
 		} else {
 			const char *v[] = {
-				pppd_path,
+				ppp_path,
 				"38400", // speed
 				":192.0.2.1", // <local_IP_address>:<remote_IP_address>
 				"noipdefault",
@@ -182,7 +200,6 @@ static int pppd_run(struct tunnel *tunnel)
 			for (unsigned i = 0; i < ARRAY_SIZE(v); i++)
 				ofv_append_varr(&pppd_args, v[i]);
 		}
-
 		if (tunnel->config->set_dns && tunnel->config->pppd_use_peerdns)
 			ofv_append_varr(&pppd_args, "usepeerdns");
 		if (tunnel->config->pppd_log) {
@@ -202,10 +219,17 @@ static int pppd_run(struct tunnel *tunnel)
 			ofv_append_varr(&pppd_args, "ifname");
 			ofv_append_varr(&pppd_args, tunnel->config->pppd_ifname);
 		}
+#endif
+#if HAVE_USR_SBIN_PPP
+		if (tunnel->config->ppp_system) {
+			ofv_append_varr(&pppd_args, tunnel->config->ppp_system);
+		}
+#endif
 
 		close(tunnel->ssl_socket);
 		execv(pppd_args.data[0], (char *const *)pppd_args.data);
 		free(pppd_args.data);
+
 		/*
 		 * The following call to fprintf() doesn't work, probably
 		 * because of the prior call to forkpty().
@@ -255,9 +279,15 @@ static const char * const pppd_message[] = {
 
 static int pppd_terminate(struct tunnel *tunnel)
 {
+#if HAVE_USR_SBIN_PPPD
+	char pppd_name[] = "pppd";
+#else
+	char pppd_name[] = "ppp";
+#endif
 	close(tunnel->pppd_pty);
 
-	log_debug("Waiting for pppd to exit...\n");
+	log_debug("Waiting for %s to exit...\n", pppd_name);
+
 	int status;
 	if (waitpid(tunnel->pppd_pid, &status, 0) == -1) {
 		log_error("waitpid: %s\n", strerror(errno));
@@ -265,28 +295,51 @@ static int pppd_terminate(struct tunnel *tunnel)
 	}
 	if (WIFEXITED(status)) {
 		int exit_status = WEXITSTATUS(status);
-		log_debug("waitpid: pppd exit status code %d\n", exit_status);
-		if (exit_status >= ARRAY_SIZE(pppd_message) || exit_status < 0)
+		log_debug("waitpid: %s exit status code %d\n",
+		          pppd_name, exit_status);
+#if HAVE_USR_SBIN_PPPD
+		if (exit_status >= ARRAY_SIZE(pppd_message) || exit_status < 0) {
 			log_error("pppd: Returned an unknown exit status: %d\n",
 			          exit_status);
-		else
+		} else {
 			switch (exit_status) {
 			case 0: // success
-				log_debug("pppd: %s\n", pppd_message[exit_status]);
+				log_debug("pppd: %s\n",
+				          pppd_message[exit_status]);
 				break;
 			case 16: // emitted when exiting normally
-				log_info("pppd: %s\n", pppd_message[exit_status]);
+				log_info("pppd: %s\n",
+				         pppd_message[exit_status]);
 				break;
 			default:
-				log_error("pppd: %s\n", pppd_message[exit_status]);
+				log_error("pppd: %s\n",
+				          pppd_message[exit_status]);
 				break;
 			}
+		}
+#else
+		// ppp exit codes in the FreeBSD case
+		switch (exit_status) {
+		case 0: // success and EX_NORMAL as defined in ppp source directly
+			log_debug("ppp: %s\n", pppd_message[exit_status]);
+			break;
+		case 1:
+		case 127:
+		case 255: // abnormal exit with hard-coded error codes in ppp
+			log_error("ppp: exited with return value of %d\n",
+			          exit_status);
+			break;
+		default:
+			log_error("ppp: %s (%d)\n", strerror(exit_status), exit_status);
+			break;
+		}
+#endif
 	} else if (WIFSIGNALED(status)) {
 		int signal_number = WTERMSIG(status);
-		log_debug("waitpid: pppd terminated by signal %d\n",
-		          signal_number);
-		log_error("pppd: terminated by signal: %s\n",
-		          strsignal(signal_number));
+		log_debug("waitpid: %s terminated by signal %d\n",
+		          pppd_name, signal_number);
+		log_error("%s: terminated by signal: %s\n",
+		          pppd_name, strsignal(signal_number));
 	}
 
 	return 0;
@@ -304,10 +357,17 @@ int ppp_interface_is_up(struct tunnel *tunnel)
 	}
 
 	for (ifa = ifap; ifa != NULL; ifa = ifa->ifa_next) {
-		if (((tunnel->config->pppd_ifname
-		      && strstr(ifa->ifa_name, tunnel->config->pppd_ifname) != NULL)
-		     || strstr(ifa->ifa_name, "ppp") != NULL)
-		    && ifa->ifa_flags & IFF_UP) {
+		if ((
+#if HAVE_USR_SBIN_PPPD
+		            (tunnel->config->pppd_ifname
+		             && strstr(ifa->ifa_name, tunnel->config->pppd_ifname)
+		             != NULL)
+		            || strstr(ifa->ifa_name, "ppp") != NULL)
+#endif
+#if HAVE_USR_SBIN_PPP
+		    strstr(ifa->ifa_name, "tun") != NULL)
+#endif
+			&& ifa->ifa_flags& IFF_UP) {
 			if (&(ifa->ifa_addr->sa_family) != NULL
 			    && ifa->ifa_addr->sa_family == AF_INET) {
 				struct in_addr if_ip_addr =
@@ -770,6 +830,11 @@ int ssl_connect(struct tunnel *tunnel)
 
 int run_tunnel(struct vpn_config *config)
 {
+#if HAVE_USR_SBIN_PPPD
+	char pppd_name[] = "pppd";
+#else
+	char pppd_name[] = "ppp";
+#endif
 	int ret;
 	struct tunnel tunnel = {
 		.config = config,
@@ -783,11 +848,13 @@ int run_tunnel(struct vpn_config *config)
 	};
 
 	// Step 0: get gateway host IP
+	log_debug("Resolving gateway host ip\n");
 	ret = get_gateway_host_ip(&tunnel);
 	if (ret)
 		goto err_tunnel;
 
 	// Step 1: open a SSL connection to the gateway
+	log_debug("Establishing ssl connection\n");
 	ret = ssl_connect(&tunnel);
 	if (ret)
 		goto err_tunnel;
@@ -819,6 +886,7 @@ int run_tunnel(struct vpn_config *config)
 		goto err_tunnel;
 
 	// Step 3: get configuration
+	log_debug("Retrieving configuration\n");
 	ret = auth_get_config(&tunnel);
 	if (ret != 1) {
 		log_error("Could not get VPN configuration (%s).\n",
@@ -828,11 +896,13 @@ int run_tunnel(struct vpn_config *config)
 	}
 
 	// Step 4: run a pppd process
+	log_debug("Establishing the tunnel\n");
 	ret = pppd_run(&tunnel);
 	if (ret)
 		goto err_tunnel;
 
 	// Step 5: ask gateway to start tunneling
+	log_debug("Switch to tunneling mode\n");
 	ret = http_send(&tunnel,
 	                "GET /remote/sslvpn-tunnel HTTP/1.1\r\n"
 	                "Host: sslvpn\r\n"
@@ -848,8 +918,10 @@ int run_tunnel(struct vpn_config *config)
 	ret = 0;
 
 	// Step 6: perform io between pppd and the gateway, while tunnel is up
+	log_debug("Starting IO through the tunnel\n");
 	io_loop(&tunnel);
 
+	log_debug("disconnecting\n");
 	if (tunnel.state == STATE_UP)
 		if (tunnel.on_ppp_if_down != NULL)
 			tunnel.on_ppp_if_down(&tunnel);
@@ -858,7 +930,7 @@ int run_tunnel(struct vpn_config *config)
 
 err_start_tunnel:
 	pppd_terminate(&tunnel);
-	log_info("Terminated pppd.\n");
+	log_info("Terminated %s.\n", pppd_name);
 err_tunnel:
 	log_info("Closed connection to gateway.\n");
 	tunnel.state = STATE_DOWN;

--- a/src/tunnel.h
+++ b/src/tunnel.h
@@ -32,11 +32,14 @@
 #include "config.h"
 #include "io.h"
 #include "ipv4.h"
+#if HAVE_LIBUTIL_H
+#include "libutil.h"
+#endif
 
 #include <openssl/ssl.h>
 #include <sys/types.h>
 
-#ifdef __APPLE__
+#ifdef __clang__
 /*
  * Get rid of OSX 10.7 and greater deprecation warnings
  * see for instance https://wiki.openssl.org/index.php/Hostname_validation


### PR DESCRIPTION
I have started this work some time ago. At the current stage I have managed to configure, compile and run _openfortivpn_ on FreeBSD 11.
The last remaining issue is that FreeBSD doesn't have `pppd` anymore and uses a user-space tool called `ppp`. It doesn't take many options from the command line but rather from STDIN or from a config file. To my understanding of the [man page](https://www.freebsd.org/cgi/man.cgi?query=ppp&sektion=8) it should be possible to put all necessary parameters into `/etc/ppp/ppp.conf` and _openfortivpn_ should work with this. If this works, the only missing bit is to provide a working sample configuration and perhaps an update of the man page.
Many command line options of _openfortivpn_ concerning how `pppd` is called are currently not supported on BSD. At a later stage one can modify the way `ppp` is called and pipe setup commands into the client before sending it to the background. I just haven't figured out to do this correctly in combination with `forkpty`, but we can keep this as a separate task, once `ppp` has successfully opened a connection by feeding it with appropriate parameters from a config file.