### PR TITLE
Rework OpenSSL library detection

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,9 +9,6 @@ openfortivpn_SOURCES = src/config.c src/config.h src/hdlc.c src/hdlc.h \
 openfortivpn_CFLAGS = -Wall --pedantic -std=gnu99
 openfortivpn_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\"
 
-openfortivpn_CFLAGS += $(OPENSSL_CFLAGS)
-openfortivpn_LDADD = $(OPENSSL_LIBS)
-
 DISTCHECK_CONFIGURE_FLAGS = CFLAGS=-Werror
 
 confdir=$(sysconfdir)/openfortivpn

--- a/configure.ac
+++ b/configure.ac
@@ -18,9 +18,10 @@ AC_CANONICAL_HOST
 AM_SILENT_RULES([yes])
 
 # Checks for libraries.
-PKG_CHECK_MODULES(OPENSSL, [libcrypto libssl])
 AC_CHECK_LIB([pthread], [pthread_create], [], [AC_MSG_ERROR([Cannot find libpthread.])])
 AC_CHECK_LIB([util], [forkpty], [], [AC_MSG_ERROR([Cannot find libutil.])])
+AC_CHECK_LIB([crypto], [EVP_sha256])
+AC_CHECK_LIB([ssl], [SSL_set_verify])
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h assert.h ctype.h errno.h fcntl.h getopt.h ifaddrs.h limits.h mach/mach.h netdb.h net/if.h netinet/in.h netinet/tcp.h net/route.h pty.h semaphore.h signal.h stdarg.h stddef.h stdint.h stdio.h stdlib.h string.h strings.h sys/ioctl.h syslog.h sys/socket.h sys/stat.h sys/time.h sys/types.h sys/wait.h termios.h unistd.h util.h])


### PR DESCRIPTION
Currently, X509_check_host function is always marked as missing, since
AC_CHECK_FUNCS is missing linker flags for libssl and libcrypto.

Culprit for this is the PKG_CHECK_MODULES call that does not add
libraries to the link arguments that configure uses to create function
tests, which in turn makes function check fail.

To remedy the situation, this commit replaces PKG_CHECK_MODULES with
two AC_CHECK_LIB calls (one for libcrypto and one for libssl) that
properly populate configure linker flags.