### PR TITLE
Revert 79f52ef

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,9 @@ openfortivpn_SOURCES = src/config.c src/config.h src/hdlc.c src/hdlc.h \
 openfortivpn_CFLAGS = -Wall --pedantic -std=gnu99
 openfortivpn_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\"
 
+openfortivpn_CPPFLAGS += $(OPENSSL_CFLAGS)
+openfortivpn_LDADD = $(OPENSSL_LIBS)
+
 DISTCHECK_CONFIGURE_FLAGS = CFLAGS=-Werror
 
 confdir=$(sysconfdir)/openfortivpn

--- a/configure.ac
+++ b/configure.ac
@@ -18,10 +18,9 @@ AC_CANONICAL_HOST
 AM_SILENT_RULES([yes])
 
 # Checks for libraries.
+PKG_CHECK_MODULES(OPENSSL, [libcrypto libssl])
 AC_CHECK_LIB([pthread], [pthread_create], [], [AC_MSG_ERROR([Cannot find libpthread.])])
 AC_CHECK_LIB([util], [forkpty], [], [AC_MSG_ERROR([Cannot find libutil.])])
-AC_CHECK_LIB([crypto], [EVP_sha256])
-AC_CHECK_LIB([ssl], [SSL_set_verify])
 
 # Checks for header files.
 AC_CHECK_HEADERS([arpa/inet.h assert.h ctype.h errno.h fcntl.h getopt.h ifaddrs.h limits.h mach/mach.h netdb.h net/if.h netinet/in.h netinet/tcp.h net/route.h pty.h semaphore.h signal.h stdarg.h stddef.h stdint.h stdio.h stdlib.h string.h strings.h sys/ioctl.h syslog.h sys/socket.h sys/stat.h sys/time.h sys/types.h sys/wait.h termios.h unistd.h util.h])


### PR DESCRIPTION
It breaks builds on macOS and other systems where OpenSSL headers and
libraries are not available in system directories.

We still need a proper solution for AC_CHECK_FUNCS to work properly.