### PR TITLE
Restore configure options removed in ac5c083

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 
 install:
   - ./autogen.sh
-  - PKG_CONFIG_PATH=$HOME/.openfortivpn-deps/lib/pkgconfig ./configure
+  - PKG_CONFIG_PATH=$HOME/.openfortivpn-deps/lib/pkgconfig ./configure --prefix=/usr --sysconfdir=/etc
   - make
 
 script:


### PR DESCRIPTION
This way these configure options do get tested at build time by Travis CI.