### PR TITLE
Temporarily change recipient of Coverity reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ addons:
     project:
       name: adrienverge/openfortivpn
       description: Client for PPP+SSL VPN tunnel services 
-    notification_email: adrienverge@users.noreply.github.com
+    notification_email: DimitriPapadopoulos@users.noreply.github.com
     build_command_prepend: ./configure --prefix=/usr --sysconfdir=/etc; make clean
     build_command: make
     branch_pattern: coverity_scan


### PR DESCRIPTION
Not sure we can define multiple recipients.
Defining myself as the recipient for now as I'm currently working on Coverity warnings.