### PR TITLE
Documentation: we -> openfortivpn

### DIFF
--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -64,7 +64,7 @@ Connect to the specified authentication realm. Defaults to empty, which
 is usually what you want.
 .TP
 \fB\-\-set-routes=\fI<bool>\fR, \fB\-\-no-routes\fR
-Set if we should try to configure IP routes through the VPN when tunnel is up. If used multiple times, the last one takes priority.
+Set if openfortivpn should try to configure IP routes through the VPN when tunnel is up. If used multiple times, the last one takes priority.
 
 \fB\-\-no-routes\fR is the same as \fB\-\-set-routes=\fI0\fR.
 .TP
@@ -73,7 +73,7 @@ to replace the default route by a different one, but to set up two 0.0.0.0/1
 and 128.0.0.0/1 routes with higher priority instead.
 .TP
 \fB\-\-set-dns=\fI<bool>\fR, \fB\-\-no-dns\fR
-Set if we should add VPN nameservers in /etc/resolv.conf when tunnel is up. If used multiple times, the last one takes priority.
+Set if openfortivpn should add VPN nameservers in /etc/resolv.conf when tunnel is up. If used multiple times, the last one takes priority.
 
 \fB\-\-no-dns\fR is the same as \fB\-\-set-dns=\fI0\fR.
 .TP
@@ -224,7 +224,7 @@ trusted-cert = othercertificatedigest6631bf...
 .br
 # ca-file = @SYSCONFDIR@/openfortivpn/ca-bundle.pem
 .br
-set-dns = 1
+set-dns = 0
 .br
 set-routes = 1
 .br

--- a/src/main.c
+++ b/src/main.c
@@ -60,12 +60,12 @@
 "  -o <otp>, --otp=<otp>         One-Time-Password.\n" \
 "  --realm=<realm>               Use specified authentication realm on VPN gateway\n" \
 "                                when tunnel is up.\n" \
-"  --set-routes=[01]             Set if we should configure output roues through\n" \
+"  --set-routes=[01]             Set if openfortivpn should configure output roues through\n" \
 "                                the VPN when tunnel is up.\n" \
 "  --no-routes                   Do not configure routes, same as --set-routes=0.\n" \
 "  --half-internet-routes=[01]   Add two 0.0.0.0/1 and 128.0.0.0/1 routes with higher" \
 "                                priority instead of replacing the default route.\n" \
-"  --set-dns=[01]                Set if we should add VPN name servers in\n" \
+"  --set-dns=[01]                Set if openfortivpn should add VPN name servers in\n" \
 "                                /etc/resolv.conf\n" \
 "  --no-dns                      Do not reconfigure DNS, same as --set-dns=0\n" \
 "  --ca-file=<file>              Use specified PEM-encoded certificate bundle\n" \


### PR DESCRIPTION
Also in the example config file suggest this setting
which will hopefully be the default setting soon:
set-dns = 0