### PR TITLE
Let pppd handle DNS servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Examples
 
 * Don't set IP routes and don't add VPN nameservers to `/etc/resolv.conf`:
   ```
-  openfortivpn vpn-gateway:8443 -u foo -p bar --no-routes --no-dns --pppd-no-peerdns
+  openfortivpn vpn-gateway:8443 -u foo -p bar --no-routes --pppd-no-peerdns
   ```
 * Using a config file:
   ```
@@ -38,8 +38,8 @@ Examples
   port = 8443
   username = foo
   password = bar
-  set-dns = 0
   set-routes = 0
+  pppd-use-peerdns = 0
   # X509 certificate sha256 sum, trust only this one!
   trusted-cert = e46d4aff08ba6914e64daa85bc6112a422fa7ce16631bff0b592a28556f993db
   ```

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -13,7 +13,6 @@ openfortivpn \- Client for PPP+SSL VPN tunnel services
 [\fB\-\-no-routes\fR]
 [\fB\-\-set-dns=<bool>\fR]
 [\fB\-\-half-internet-routes=<bool>\fR]
-[\fB\-\-no-dns\fR]
 [\fB\-\-ca-file=\fI<file>\fR]
 [\fB\-\-user-cert=\fI<file>\fR]
 [\fB\-\-user-key=\fI<file>\fR]
@@ -73,11 +72,9 @@ tunnel is up. If used multiple times, the last one takes priority.
 Set if openfortivpn should add two 0.0.0.0/1 and 128.0.0.0/1 routes with
 higher priority instead of replacing the default route.
 .TP
-\fB\-\-set-dns=\fI<bool>\fR, \fB\-\-no-dns\fR
+\fB\-\-set-dns=\fI<bool>\fR
 Set if openfortivpn should add VPN nameservers in /etc/resolv.conf when
 tunnel is up. If used multiple times, the last one takes priority.
-
-\fB\-\-no-dns\fR is the same as \fB\-\-set-dns=\fI0\fR.
 .TP
 \fB\-\-ca-file=\fI<file>\fR
 Use specified PEM-encoded certificate bundle instead of system-wide store to

--- a/src/main.c
+++ b/src/main.c
@@ -67,7 +67,6 @@
 "                                priority instead of replacing the default route.\n" \
 "  --set-dns=[01]                Set if openfortivpn should add VPN name servers in\n" \
 "                                /etc/resolv.conf\n" \
-"  --no-dns                      Do not reconfigure DNS, same as --set-dns=0\n" \
 "  --ca-file=<file>              Use specified PEM-encoded certificate bundle\n" \
 "                                instead of system-wide store to verify the gateway\n" \
 "                                certificate.\n" \
@@ -160,7 +159,7 @@ int main(int argc, char **argv)
 		.cookie = {'\0'},
 		.realm = {'\0'},
 		.set_routes = 1,
-		.set_dns = 1,
+		.set_dns = 0,
 		.pppd_use_peerdns = 1,
 		.use_syslog = 0,
 		.half_internet_routes = 0,
@@ -188,8 +187,7 @@ int main(int argc, char **argv)
 		{"set-routes",	    required_argument, 0, 0},
 		{"no-routes",       no_argument, &cfg.set_routes, 0},
 		{"half-internet-routes", required_argument, 0, 0},
-		{"set-dns",	    required_argument, 0, 0},
-		{"no-dns",          no_argument, &cfg.set_dns, 0},
+		{"set-dns",         required_argument, 0, 0},
 		{"pppd-no-peerdns", no_argument, &cfg.pppd_use_peerdns, 0},
 		{"use-syslog",      no_argument, &cfg.use_syslog, 1},
 		{"persistent",      required_argument, 0, 0},


### PR DESCRIPTION
From now on _openfortivpn_ will not attempt to modify DNS settings and `/etc/resov.conf` by default. Instead leave it to _pppd_ to handle DNS (or not if `--pppd-no-peerdns`).

* Option `set-dns` is now disabled by default.
* Remove `--no-dns` which is now useless.

This is a first step towards entirely getting rid of `--set-dns` as suggested in #230 and #101.