### PR TITLE
Rationalize DNS options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Examples
 
 * Don't set IP routes and don't add VPN nameservers to `/etc/resolv.conf`:
   ```
-  openfortivpn vpn-gateway:8443 -u foo -p bar --no-routes --no-dns --pppd-no-peerdns
+  openfortivpn vpn-gateway:8443 -u foo -p bar --no-routes --no-dns
   ```
 * Using a config file:
   ```
@@ -39,7 +39,6 @@ Examples
   password = bar
   set-routes = 0
   set-dns = 0
-  pppd-use-peerdns = 0
   # X509 certificate sha256 sum, trust only this one!
   trusted-cert = e46d4aff08ba6914e64daa85bc6112a422fa7ce16631bff0b592a28556f993db
   ```

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -115,8 +115,8 @@ $ openssl s_client -connect \fI<host:port>\fR
 (default: HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4)
 .TP
 \fB\-\-pppd-no-peerdns\fR
-Do not ask peer ppp server for DNS server addresses and do not make pppd
-rewrite /etc/resolv.conf.
+Deprecated; do not ask peer ppp server for DNS server addresses and do not make
+pppd rewrite /etc/resolv.conf.
 .TP
 \fB\-\-pppd-log=\fI<file>\fR
 Set pppd in debug mode and save its logs into \fI<file>\fR.
@@ -231,8 +231,6 @@ set-dns = 0
 set-routes = 1
 .br
 half-internet-routes = 0
-.br
-pppd-use-peerdns = 1
 .br
 # aternatively, use a specific pppd plugin instead
 .br

--- a/src/main.c
+++ b/src/main.c
@@ -89,8 +89,8 @@
 "                                you can try with the cipher suggested in the output\n" \
 "                                of 'openssl s_client -connect <host:port>'\n" \
 "                                (e.g. AES256-GCM-SHA384)\n" \
-"  --pppd-no-peerdns             Do not ask peer ppp server for DNS server addresses\n" \
-"                                and do not make pppd rewrite /etc/resolv.conf\n" \
+"  --pppd-no-peerdns             Deprecated; do not ask peer ppp server for DNS server\n" \
+"                                addresses and do not make pppd rewrite /etc/resolv.conf\n" \
 "  --pppd-log=<file>             Set pppd in debug mode and save its logs into\n" \
 "                                <file>.\n" \
 "  --pppd-plugin=<file>          Use specified pppd plugin instead of configuring\n" \

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -94,7 +94,7 @@ static int on_ppp_if_up(struct tunnel *tunnel)
 		}
 	}
 
-	if (tunnel->config->set_dns) {
+	if (tunnel->config->set_dns && !tunnel->config->pppd_use_peerdns) {
 		log_info("Adding VPN nameservers...\n");
 		ipv4_add_nameservers_to_resolv_conf(tunnel);
 	}
@@ -113,7 +113,7 @@ static int on_ppp_if_down(struct tunnel *tunnel)
 		ipv4_restore_routes(tunnel);
 	}
 
-	if (tunnel->config->set_dns) {
+	if (tunnel->config->set_dns && !tunnel->config->pppd_use_peerdns) {
 		log_info("Removing VPN nameservers...\n");
 		ipv4_del_nameservers_from_resolv_conf(tunnel);
 	}
@@ -176,7 +176,7 @@ static int pppd_run(struct tunnel *tunnel)
 				ofv_append_varr(&pppd_args, v[i]);
 		}
 
-		if (tunnel->config->pppd_use_peerdns)
+		if (tunnel->config->set_dns && tunnel->config->pppd_use_peerdns)
 			ofv_append_varr(&pppd_args, "usepeerdns");
 		if (tunnel->config->pppd_log) {
 			ofv_append_varr(&pppd_args, "debug");


### PR DESCRIPTION
* The `--set-dns`/`set-dns` option enables either of _pppd_/_openfortivpn_ to get DNS settings from peer _ppp_/FortiGate server and rewrite `/etc/resolv.conf`.
* The `--pppd-no-peerdns`/`pppd-use-peerdns` option switches the above functionality from _pppd_ to _openfortivpn_. This option is not documented any more.

The difference with the previous behaviour is that:
* `--set-dns=0`/`set-dns=0` disables DNS handling in both _pppd_ and _openfortivpn_ instead of _openfortivpn_ only. A single option is now sufficient to avoid messing with `/etc/resolv.conf`.
* `--pppd-no-peerdns`/`pppd-use-peerdns=0` switches DNS handling from _pppd_ to _openfortivpn_. It didn't make sense to have both programs compete to modify `/etc/resolv.conf`, did it? Feels much better this way.

Fixes #328.

This is also a first step towards entirely getting rid of one of the DNS options as suggested in #230, #101 and #326. Future steps might include:
* Remove code that handles DNS changes and modifies `/etc/resolv.conf` directly in _openfortivpn_.
* Instead always delegate DNS handling to _pppd_.
* Remove `--pppd-no-peerdns`/`pppd-use-peerdns` options.