### PR TITLE
Ooops... Fix --help output.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -63,7 +63,7 @@
 "  --set-routes=[01]             Set if openfortivpn should configure output roues through\n" \
 "                                the VPN when tunnel is up.\n" \
 "  --no-routes                   Do not configure routes, same as --set-routes=0.\n" \
-"  --half-internet-routes=[01]   Add two 0.0.0.0/1 and 128.0.0.0/1 routes with higher" \
+"  --half-internet-routes=[01]   Add two 0.0.0.0/1 and 128.0.0.0/1 routes with higher\n" \
 "                                priority instead of replacing the default route.\n" \
 "  --set-dns=[01]                Set if openfortivpn should add VPN name servers in\n" \
 "                                /etc/resolv.conf\n" \


### PR DESCRIPTION
Typo introduced by bec10e5 has been breaking `--help` output.