### PR TITLE
treat carriage returns as white space (might solve #129)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -135,19 +135,21 @@ int load_config(struct vpn_config *cfg, const char *filename)
 		val = equals + 1;
 
 		// Remove heading spaces
-		while (key[0] != '\0' && (key[0] == ' ' || key[0] == '\t'))
+		while (key[0] != '\0'
+		       && (key[0] == ' ' || key[0] == '\t' || key[0] == '\r'))
 			key++;
-		while (val[0] != '\0' && (val[0] == ' ' || val[0] == '\t'))
+		while (val[0] != '\0'
+		       && (val[0] == ' ' || val[0] == '\t' || val[0] == '\r'))
 			val++;
 		// Remove trailing spaces
 		for (i = strlen(key) - 1; i > 0; i--) {
-			if (key[i] == ' ' || key[i] == '\t')
+			if (key[i] == ' ' || key[i] == '\t' || key[i] == '\r')
 				key[i] = '\0';
 			else
 				break;
 		}
 		for (i = strlen(val) - 1; i > 0; i--) {
-			if (val[i] == ' ' || val[i] == '\t')
+			if (val[i] == ' ' || val[i] == '\t' || val[i] == '\r')
 				val[i] = '\0';
 			else
 				break;

--- a/src/config.c
+++ b/src/config.c
@@ -135,21 +135,19 @@ int load_config(struct vpn_config *cfg, const char *filename)
 		val = equals + 1;
 
 		// Remove heading spaces
-		while (key[0] != '\0'
-		       && (key[0] == ' ' || key[0] == '\t' || key[0] == '\r'))
+		while (iswhitespace_like(key[0]))
 			key++;
-		while (val[0] != '\0'
-		       && (val[0] == ' ' || val[0] == '\t' || val[0] == '\r'))
+		while (iswhitespace_like(val[0]))
 			val++;
 		// Remove trailing spaces
 		for (i = strlen(key) - 1; i > 0; i--) {
-			if (key[i] == ' ' || key[i] == '\t' || key[i] == '\r')
+			if (iswhitespace_like(key[i]))
 				key[i] = '\0';
 			else
 				break;
 		}
 		for (i = strlen(val) - 1; i > 0; i--) {
-			if (val[i] == ' ' || val[i] == '\t' || val[i] == '\r')
+			if (iswhitespace_like(val[i]))
 				val[i] = '\0';
 			else
 				break;

--- a/src/config.h
+++ b/src/config.h
@@ -91,8 +91,10 @@ int strtob(const char *str);
 
 int load_config(struct vpn_config *cfg, const char *filename);
 
-#define iswhitespace_like(character) \
-	(character != '\0' \
-	&& (character == ' ' || character == '\t' || character == '\r'))
+inline int iswhitespace_like(character)
+{
+	return (character != '\0' \
+	        && (character == ' ' || character == '\t' || character == '\r'));
+}
 
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -91,4 +91,8 @@ int strtob(const char *str);
 
 int load_config(struct vpn_config *cfg, const char *filename);
 
+#define iswhitespace_like(character) \
+	(character != '\0' \
+	&& (character == ' ' || character == '\t' || character == '\r'))
+
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -91,7 +91,7 @@ int strtob(const char *str);
 
 int load_config(struct vpn_config *cfg, const char *filename);
 
-inline int iswhitespace_like(character)
+inline int iswhitespace_like(const char character)
 {
 	return (character != '\0' \
 	        && (character == ' ' || character == '\t' || character == '\r'));


### PR DESCRIPTION
carriage returns (that might have come in from copy&paste out of dos/win files) can lead to a damaged config file