### PR TITLE
Fix detection of HTTP chunked encoding

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -101,7 +101,7 @@ static const char *find_header(const char *res, const char *header)
 		int line_len = (char *) memmem(line, BUFSZ, "\r\n", 2) - line;
 		int head_len = strlen(header);
 
-		if (line_len > head_len && !strncasecmp(line, header, head_len))
+		if (line_len >= head_len && !strncasecmp(line, header, head_len))
 			return line + head_len;
 		line += line_len + 2;
 	}


### PR DESCRIPTION
In `src/http.c:154` the `find_header` function is called with payload `"Transfer-Encoding: chunked"` to detect whether chunked encoding is used.  If the server sends this exact string in the result header, then `find_header` fails to find the header as `line_len` equals `head_len` in that case.