### PR TITLE
Increase buffer size  in ipv4_get_route to 64k, add sanity check for overflows in MacOS

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -93,12 +93,18 @@ int http_send(struct tunnel *tunnel, const char *request, ...)
 	return 1;
 }
 
-static const char *find_header(const char *res, const char *header, uint32_t response_size)
+static const char *find_header(
+        const char *res,
+        const char *header,
+        uint32_t response_size
+)
 {
 	const char *line = res;
 
 	while (memcmp(line, "\r\n", 2)) {
-		int line_len = (char *) memmem(line, response_size - (line - res), "\r\n", 2) - line;
+		int line_len = (char *) memmem(
+		                       line, response_size - (line - res), "\r\n", 2
+		               ) - line;
 		int head_len = strlen(header);
 
 		if (line_len >= head_len && !strncasecmp(line, header, head_len))
@@ -118,7 +124,11 @@ static const char *find_header(const char *res, const char *header, uint32_t res
  * @return     1         in case of success
  *             < 0       in case of error
  */
-int http_receive(struct tunnel *tunnel, char **response, uint32_t *response_size)
+int http_receive(
+        struct tunnel *tunnel,
+        char **response,
+        uint32_t *response_size
+)
 {
 	uint32_t res_size = BUFSZ;
 	char *buffer, *res;
@@ -147,13 +157,16 @@ int http_receive(struct tunnel *tunnel, char **response, uint32_t *response_size
 				if (eoh) {
 					const char *header;
 
-					header = find_header(buffer, "Content-Length: ", BUFSZ);
+					header = find_header(
+					                 buffer,
+					                 "Content-Length: ", BUFSZ);
 					header_size = eoh - buffer + 4;
 					if (header)
 						content_size = atoi(header);
 
 					if (find_header(buffer,
-					                "Transfer-Encoding: chunked", BUFSZ))
+					                "Transfer-Encoding: chunked",
+					                BUFSZ))
 						chunked = 1;
 				}
 			}
@@ -214,8 +227,13 @@ int http_receive(struct tunnel *tunnel, char **response, uint32_t *response_size
 	return 1;
 }
 
-static int do_http_request(struct tunnel *tunnel, const char *method,
-                           const char *uri, const char *data, char **response, uint32_t *response_size)
+static int do_http_request(struct tunnel *tunnel,
+                           const char *method,
+                           const char *uri,
+                           const char *data,
+                           char **response,
+                           uint32_t *response_size
+                          )
 {
 	int ret;
 	const char *template = ("%s %s HTTP/1.1\r\n"
@@ -247,13 +265,21 @@ static int do_http_request(struct tunnel *tunnel, const char *method,
  *             < 0       in case of error
  */
 static int http_request(struct tunnel *tunnel, const char *method,
-                        const char *uri, const char *data, char **response, uint32_t *response_size)
+                        const char *uri,
+                        const char *data,
+                        char **response,
+                        uint32_t *response_size
+                       )
 {
-	int ret = do_http_request(tunnel, method, uri, data, response, response_size);
+	int ret = do_http_request(
+	                  tunnel, method, uri, data, response, response_size);
 
 	if (ret == ERR_HTTP_SSL) {
 		ssl_connect(tunnel);
-		ret = do_http_request(tunnel, method, uri, data, response, response_size);
+		ret = do_http_request(
+		              tunnel, method, uri, data, response,
+		              response_size
+		      );
 	}
 
 	if (ret != 1)
@@ -305,7 +331,11 @@ end:
 	return ret;
 }
 
-static int get_auth_cookie(struct tunnel *tunnel, char *buf, uint32_t buffer_size)
+static int get_auth_cookie(
+        struct tunnel *tunnel,
+        char *buf,
+        uint32_t buffer_size
+)
 {
 	int ret = 0;
 	const char *line;
@@ -340,7 +370,12 @@ static int get_auth_cookie(struct tunnel *tunnel, char *buf, uint32_t buffer_siz
 }
 
 static
-int try_otp_auth(struct tunnel *tunnel, const char *buffer, char **res, uint32_t *response_size)
+int try_otp_auth(
+        struct tunnel *tunnel,
+        const char *buffer,
+        char **res,
+        uint32_t *response_size
+)
 {
 	char data[256];
 	char path[40];
@@ -502,7 +537,8 @@ int auth_log_in(struct tunnel *tunnel)
 	         "&redir=%%2Fremote%%2Findex&just_logged_in=1",
 	         username, password, realm);
 
-	ret = http_request(tunnel, "POST", "/remote/logincheck", data, &res, &response_size);
+	ret = http_request(
+	              tunnel, "POST", "/remote/logincheck", data, &res, &response_size);
 	if (ret != 1)
 		goto end;
 
@@ -558,7 +594,9 @@ int auth_log_in(struct tunnel *tunnel)
 		         "&code=%s&code2=&redir=%%2Fremote%%2Findex&just_logged_in=1",
 		         username, realm, reqid, polid, group, tokenresponse);
 
-		ret = http_request(tunnel, "POST", "/remote/logincheck", data, &res, &response_size);
+		ret = http_request(
+		              tunnel, "POST", "/remote/logincheck",
+		              data, &res, &response_size);
 		if (ret != 1)
 			goto end;
 

--- a/src/http.c
+++ b/src/http.c
@@ -223,7 +223,8 @@ int http_receive(
 	res[bytes_read] = '\0';
 
 	*response = res;
-	if (response_size != NULL) *response_size = res_size;
+	if (response_size != NULL)
+		*response_size = res_size;
 	return 1;
 }
 

--- a/src/http.h
+++ b/src/http.h
@@ -48,7 +48,7 @@ static inline const char *err_http_str(int code)
 }
 
 int http_send(struct tunnel *tunnel, const char *request, ...);
-int http_receive(struct tunnel *tunnel, char **response);
+int http_receive(struct tunnel *tunnel, char **response, uint32_t *response_size);
 
 int auth_log_in(struct tunnel *tunnel);
 int auth_log_out(struct tunnel *tunnel);

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -158,7 +158,7 @@ static int ipv4_get_route(struct rtentry *route)
 			realloc_buffer = realloc(buffer, buffer_size);
 			if (realloc_buffer) {
 				buffer = realloc_buffer;
-      } else {
+			} else {
 				err = ERR_IPV4_SEE_ERRNO;
 				goto end;
 			}
@@ -278,7 +278,7 @@ static int ipv4_get_route(struct rtentry *route)
 			realloc_buffer = realloc(buffer, buffer_size);
 			if (realloc_buffer) {
 				buffer = realloc_buffer;
-      } else {
+			} else {
 				err = ERR_IPV4_SEE_ERRNO;
 				goto end;
 			}

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -508,7 +508,8 @@ end:
 
 	free(buffer);
 
-	if (err) return err;
+	if (err)
+		return err;
 
 	if (rtfound==0) {
 		// should not occur anymore unless there is no default route

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -31,7 +31,7 @@
 #include <stdint.h>
 #include <errno.h>
 
-#define GET_ROUTE_BUFFER_SIZE 0x10000
+#define GET_ROUTE_BUFFER_CHUNK_SIZE 0x1000
 #define SHOW_ROUTE_BUFFER_SIZE 128
 
 static char show_route_buffer[SHOW_ROUTE_BUFFER_SIZE];
@@ -117,8 +117,10 @@ static inline void route_destroy(struct rtentry *route)
  */
 static int ipv4_get_route(struct rtentry *route)
 {
-	size_t size;
-	char buffer[GET_ROUTE_BUFFER_SIZE];
+	size_t buffer_size = GET_ROUTE_BUFFER_CHUNK_SIZE;
+	char *buffer = malloc(buffer_size);
+	int err = 0;
+
 	char *start, *line;
 	char *saveptr1 = NULL, *saveptr2 = NULL;
 	uint32_t rtdest, rtmask, rtgtw;
@@ -139,27 +141,30 @@ static int ipv4_get_route(struct rtentry *route)
 
 #ifdef __APPLE__
 	FILE *fp;
-	int len = sizeof(buffer) - 1;
+	uint32_t total_bytes_read = 0;
+
 	char *saveptr3 = NULL;
 
 	// Open the command for reading
 	fp = popen("/usr/sbin/netstat -f inet -rn", "r");
-	if (fp == NULL)
-		return ERR_IPV4_SEE_ERRNO;
+	if (fp == NULL) {
+		err = ERR_IPV4_SEE_ERRNO;
+		goto end;
+	}
 
 	line = buffer;
 	// Read the output a line at a time
-	while (fgets(line, len, fp) != NULL) {
+	while (fgets(line, buffer_size - total_bytes_read - 1, fp) != NULL) {
 		uint32_t bytes_read = strlen(line);
-		if (bytes_read > 0 && line[bytes_read - 1] != 0xa) {
-			log_error("routing table too large; please consider increasing the buffer size\n");
-			return ERR_IPV4_PROC_NET_ROUTE;
+		total_bytes_read += bytes_read;
+
+		if (bytes_read > 0 && line[bytes_read - 1] != '\n') {
+			buffer_size += GET_ROUTE_BUFFER_CHUNK_SIZE;
+			buffer = realloc(buffer, buffer_size);
 		}
 
-		len -= bytes_read;
-		line += bytes_read;
+		line = buffer + total_bytes_read;
 	}
-	size = sizeof(buffer)-1 - len;
 	pclose(fp);
 
 	// reserve enough memory (256 shorts)
@@ -251,30 +256,47 @@ static int ipv4_get_route(struct rtentry *route)
 
 #else
 	int fd;
+	uint32_t total_bytes_read = 0;
+
 	// Cannot stat, mmap not lseek this special /proc file
 	fd = open("/proc/net/route", O_RDONLY);
-	if (fd == -1)
-		return ERR_IPV4_SEE_ERRNO;
-
-	size = read(fd, buffer, sizeof(buffer) - 1);
-	if (size == -1) {
-		close(fd);
-		return ERR_IPV4_SEE_ERRNO;
+	if (fd == -1) {
+		err = return ERR_IPV4_SEE_ERRNO;
+		goto end;
 	}
+
+	int bytes_read;
+	while (bytes_read(fd, buffer + total_bytes_read, buffer_size - total_bytes_read - 1) > 0) {
+		total_bytes_read += bytes_read;
+
+		if ((buffer_size - total_bytes_read) < 1) {
+			buffer_size += GET_ROUTE_BUFFER_CHUNK_SIZE;
+			buffer = realloc(buffer, buffer_size)
+		}
+	}
+
 	close(fd);
+
+	if (bytes_read < 0) {
+		err = ERR_IPV4_SEE_ERRNO;
+		goto end;
+	}
+
 #endif
 
-	if (size == 0) {
+	if (total_bytes_read == 0) {
 		log_debug("routing table is empty.\n");
-		return ERR_IPV4_PROC_NET_ROUTE;
+		err = ERR_IPV4_PROC_NET_ROUTE;
+		goto end;
 	}
-	buffer[size] = '\0';
+	buffer[total_bytes_read] = '\0';
 
 	// Skip first line
 	start = index(buffer, '\n');
 	if (start == NULL) {
 		log_debug("routing table is malformed.\n");
-		return ERR_IPV4_PROC_NET_ROUTE;
+		err = ERR_IPV4_PROC_NET_ROUTE;
+		goto end;
 	}
 	start++;
 
@@ -285,7 +307,8 @@ static int ipv4_get_route(struct rtentry *route)
 	start = index(++start, '\n');
 	if (start == NULL) {
 		log_debug("routing table is malformed.\n");
-		return ERR_IPV4_PROC_NET_ROUTE;
+		err = ERR_IPV4_PROC_NET_ROUTE;
+		goto end;
 	}
 
 #endif
@@ -471,6 +494,10 @@ static int ipv4_get_route(struct rtentry *route)
 #ifdef __APPLE__
 end:
 #endif
+	free(buffer);
+
+	if (err) return err;
+
 	if (rtfound==0) {
 		// should not occur anymore unless there is no default route
 		log_debug("Route not found.\n");
@@ -478,6 +505,7 @@ end:
 		route_dest(route).s_addr = rtdest;
 		route_mask(route).s_addr = rtmask;
 		route_gtw(route).s_addr = rtgtw;
+
 		return ERR_IPV4_NO_SUCH_ROUTE;
 	}
 


### PR DESCRIPTION
On MacOS, `ipv4_get_route` gets stuck in an infinite loop if the buffer is too small. This patch increases buffer size to 64k and adds a sanity check that raises an error instead of locking up.