### PR TITLE
gcc 8: fix -Wstring-truncation warnings

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -485,7 +485,7 @@ int auth_log_in(struct tunnel *tunnel)
 	char reqid[32] = { '\0' };
 	char polid[32] = { '\0' };
 	char group[128] = { '\0' };
-	char data[256], token[128], tokenresponse[256];
+	char data[1024], token[128], tokenresponse[256];
 	char *res = NULL;
 
 	url_encode(username, tunnel->config->username);
@@ -494,7 +494,7 @@ int auth_log_in(struct tunnel *tunnel)
 
 	tunnel->config->cookie[0] = '\0';
 
-	snprintf(data, 256, "username=%s&credential=%s&realm=%s&ajax=1"
+	snprintf(data, sizeof(data), "username=%s&credential=%s&realm=%s&ajax=1"
 	         "&redir=%%2Fremote%%2Findex&just_logged_in=1",
 	         username, password, realm);
 
@@ -550,8 +550,9 @@ int auth_log_in(struct tunnel *tunnel)
 		}
 
 		url_encode(tokenresponse, cfg->otp);
-		snprintf(data, 256, "username=%s&realm=%s&reqid=%s&polid=%s&grp=%s"
-		         "&code=%s&code2=&redir=%%2Fremote%%2Findex&just_logged_in=1",
+		snprintf(data, sizeof(data), "username=%s&realm=%s&reqid=%s"
+		         "&polid=%s&grp=%s&code=%s&code2="
+		         "&redir=%%2Fremote%%2Findex&just_logged_in=1",
 		         username, realm, reqid, polid, group, tokenresponse);
 
 		ret = http_request(tunnel, "POST", "/remote/logincheck", data, &res);

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -72,9 +72,10 @@ static char *ipv4_show_route(struct rtentry *route)
 		strcat(show_route_buffer, " via ");
 		strncat(show_route_buffer, inet_ntoa(route_gtw(route)), 15);
 	}
-	if (route_iface(route)[0] != '\0') {
+	if (route_iface(route) != NULL) {
 		strcat(show_route_buffer, " dev ");
-		strncat(show_route_buffer, route_iface(route), ROUTE_IFACE_LEN - 1);
+		strncat(show_route_buffer, route_iface(route),
+		        SHOW_ROUTE_BUFFER_SIZE - strlen(show_route_buffer) - 1);
 	}
 
 	return show_route_buffer;
@@ -83,11 +84,6 @@ static char *ipv4_show_route(struct rtentry *route)
 static inline int route_init(struct rtentry *route)
 {
 	memset(route, 0, sizeof(*route));
-
-	route_iface(route) = malloc(ROUTE_IFACE_LEN);
-	if (route_iface(route) == NULL)
-		return ERR_IPV4_NO_MEM;
-	route_iface(route)[0] = '\0';
 
 	cast_addr(&(route)->rt_dst)->sin_family = AF_INET;
 	cast_addr(&(route)->rt_genmask)->sin_family = AF_INET;
@@ -98,10 +94,8 @@ static inline int route_init(struct rtentry *route)
 
 static inline void route_destroy(struct rtentry *route)
 {
-	if (route_iface(route) != NULL) {
-		free(route_iface(route));
-		route_iface(route) = NULL;
-	}
+	free(route_iface(route));
+	route_iface(route) = NULL;
 }
 
 /*
@@ -446,8 +440,10 @@ static int ipv4_get_route(struct rtentry *route)
 				route_gtw(route).s_addr = gtw;
 				route->rt_flags = flags;
 
-				strncpy(route_iface(route), iface,
-				        ROUTE_IFACE_LEN - 1);
+				free(route_iface(route));
+				route_iface(route) = strdup(iface);
+				if (!route_iface(route))
+					return ERR_IPV4_NO_MEM;
 
 #ifndef __APPLE__
 				// we do not have these values from Mac OS X netstat,
@@ -491,7 +487,8 @@ static int ipv4_set_route(struct rtentry *route)
 		strncat(cmd, inet_ntoa(route_gtw(route)), 15);
 	} else {
 		strcat(cmd, " -interface ");
-		strcat(cmd, route_iface(route));
+		strncat(cmd, route_iface(route),
+		        SHOW_ROUTE_BUFFER_SIZE - strlen(cmd) - 1);
 	}
 
 	log_debug("%s\n", cmd);
@@ -678,7 +675,10 @@ int ipv4_add_split_vpn_route(struct tunnel *tunnel, char *dest, char *mask,
 		route_gtw(route).s_addr = inet_addr(gateway);
 		route->rt_flags |= RTF_GATEWAY;
 	} else {
-		strncpy(route_iface(route), tunnel->ppp_iface, ROUTE_IFACE_LEN - 1);
+		free(route_iface(route));
+		route_iface(route) = strdup(tunnel->ppp_iface);
+		if (!route_iface(route))
+			return ERR_IPV4_NO_MEM;
 	}
 
 	return 0;
@@ -692,8 +692,10 @@ static int ipv4_set_split_routes(struct tunnel *tunnel)
 		struct rtentry *route;
 		int ret;
 		route = &tunnel->ipv4.split_rt[i];
-		strncpy(route_iface(route), tunnel->ppp_iface,
-		        ROUTE_IFACE_LEN - 1);
+		free(route_iface(route));
+		route_iface(route) = strdup(tunnel->ppp_iface);
+		if (!route_iface(route))
+			return ERR_IPV4_NO_MEM;
 		if (route_gtw(route).s_addr == 0)
 			route_gtw(route).s_addr = tunnel->ipv4.ip_addr.s_addr;
 		route->rt_flags |= RTF_GATEWAY;
@@ -731,7 +733,10 @@ static int ipv4_set_default_routes(struct tunnel *tunnel)
 		route_gtw(ppp_rt).s_addr = inet_addr("0.0.0.0");
 		log_debug("Setting new default route...\n");
 
-		strncpy(route_iface(ppp_rt), tunnel->ppp_iface, ROUTE_IFACE_LEN - 1);
+		free(route_iface(ppp_rt));
+		route_iface(ppp_rt) = strdup(tunnel->ppp_iface);
+		if (!route_iface(ppp_rt))
+			return ERR_IPV4_NO_MEM;
 
 		ret = ipv4_set_route(ppp_rt);
 		if (ret == ERR_IPV4_SEE_ERRNO && errno == EEXIST) {
@@ -749,7 +754,10 @@ static int ipv4_set_default_routes(struct tunnel *tunnel)
 		route_dest(ppp_rt).s_addr = inet_addr("0.0.0.0");
 		route_mask(ppp_rt).s_addr = inet_addr("128.0.0.0");
 
-		strncpy(route_iface(ppp_rt), tunnel->ppp_iface, ROUTE_IFACE_LEN - 1);
+		free(route_iface(ppp_rt));
+		route_iface(ppp_rt) = strdup(tunnel->ppp_iface);
+		if (!route_iface(ppp_rt))
+			return ERR_IPV4_NO_MEM;
 
 		ret = ipv4_set_route(ppp_rt);
 		if (ret == ERR_IPV4_SEE_ERRNO && errno == EEXIST) {


### PR DESCRIPTION
New warnings introduced with recent of version of GCC need ignoring
or fixing.
This is an attempt to fix them.