### PR TITLE
Handle backspace/^U for password prompt

### DIFF
--- a/src/userinput.c
+++ b/src/userinput.c
@@ -32,7 +32,7 @@ void read_password(const char *prompt, char *pass, size_t len)
 	// Try to hide user input
 	if (tcgetattr(STDIN_FILENO, &oldt) == 0) {
 		newt = oldt;
-		newt.c_lflag &= ~(ICANON | ECHO);
+		newt.c_lflag &= ~ECHO;
 		tcsetattr(STDIN_FILENO, TCSANOW, &newt);
 		masked = 1;
 	}


### PR DESCRIPTION
The way we're setting terminal options when reading password right now means that we're filling the password buffer with non-printable bytes when someone hits backspace or ^U instead of clearing it appropriately.

I've done two versions of this patch, that I left in the commit history:
 - the first version naively catches such backspace/^H/^U bytes and tries to handle it; this "works" mostly but won't handle utf-8 characters in the input or weird terminals (although the two bytes I'm comparing should work for most)
 - the second version simply does not unset ICANON, I'm not sure why it was unset in the first place (been since the first version of this function) -- not unsetting it means the terminal will handle these as usual (like in a bash 'read' prompt) and will just work™

Please see the individual commits for details.