### PR TITLE
config: prioritize cli options to config file

### DIFF
--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -8,6 +8,7 @@ openfortivpn \- Client for PPP+SSL VPN tunnel services
 [\fI<host>\fR:\fI<port>\fR]
 [\fB\-u\fR \fI<user>\fR]
 [\fB\-p\fR \fI<pass>\fR]
+[\fB\-\-otp=\fI<otp>\fR]
 [\fB\-\-realm=\fI<realm>\fR]
 [\fB\-\-set-routes=<bool>\fR]
 [\fB\-\-no-routes\fR]
@@ -58,6 +59,9 @@ VPN account username.
 .TP
 \fB\-p \fI<pass>\fR, \fB\-\-password=\fI<pass>\fR
 VPN account password.
+.TP
+\fB\-o \fI<otp>\fR, \fB\-\-otp=\fI<otp>\fR
+One-Time-Password.
 .TP
 \fB\-\-realm=\fI<realm>\fR
 Connect to the specified authentication realm. Defaults to empty, which

--- a/src/config.c
+++ b/src/config.c
@@ -24,6 +24,35 @@
 #include <ctype.h>
 #include <sys/stat.h>
 
+
+const struct vpn_config invalid_cfg = {
+	.gateway_host = {'\0'},
+	.gateway_port = 0,
+	.username = {'\0'},
+	.password = {'\0'},
+	.otp = {'\0'},
+	.cookie = {'\0'},
+	.realm = {'\0'},
+	.set_routes = -1,
+	.set_dns = -1,
+	.pppd_use_peerdns = -1,
+	.use_syslog = -1,
+	.half_internet_routes = -1,
+	.persistent = -1,
+	.pppd_log = NULL,
+	.pppd_plugin = NULL,
+	.pppd_ipparam = NULL,
+	.pppd_ifname = NULL,
+	.pppd_call = NULL,
+	.ca_file = NULL,
+	.user_cert = NULL,
+	.user_key = NULL,
+	.verify_cert = -1,
+	.insecure_ssl = -1,
+	.cipher_list = NULL,
+	.cert_whitelist = NULL
+};
+
 /*
  * Adds a sha256 digest to the list of trusted certificates.
  */
@@ -217,14 +246,19 @@ int load_config(struct vpn_config *cfg, const char *filename)
 			}
 			cfg->pppd_use_peerdns = pppd_use_peerdns;
 		} else if (strcmp(key, "pppd-log") == 0) {
+			free(cfg->pppd_log);
 			cfg->pppd_log = strdup(val);
 		} else if (strcmp(key, "pppd-plugin") == 0) {
+			free(cfg->pppd_plugin);
 			cfg->pppd_plugin = strdup(val);
 		} else if (strcmp(key, "pppd-ipparam") == 0) {
+			free(cfg->pppd_ipparam);
 			cfg->pppd_ipparam = strdup(val);
 		} else if (strcmp(key, "pppd-ifname") == 0) {
+			free(cfg->pppd_ifname);
 			cfg->pppd_ifname = strdup(val);
 		} else if (strcmp(key, "pppd-call") == 0) {
+			free(cfg->pppd_call);
 			cfg->pppd_call = strdup(val);
 		} else if (strcmp(key, "use-syslog") == 0) {
 			int use_syslog = strtob(val);
@@ -244,10 +278,13 @@ int load_config(struct vpn_config *cfg, const char *filename)
 				log_warn("Could not add certificate digest to whitelist.\n");
 
 		} else if (strcmp(key, "ca-file") == 0) {
+			free(cfg->ca_file);
 			cfg->ca_file = strdup(val);
 		} else if (strcmp(key, "user-cert") == 0) {
+			free(cfg->user_cert);
 			cfg->user_cert = strdup(val);
 		} else if (strcmp(key, "user-key") == 0) {
+			free(cfg->user_key);
 			cfg->user_key = strdup(val);
 		} else if (strcmp(key, "insecure-ssl") == 0) {
 			int insecure_ssl = strtob(val);
@@ -258,6 +295,7 @@ int load_config(struct vpn_config *cfg, const char *filename)
 			}
 			cfg->insecure_ssl = insecure_ssl;
 		} else if (strcmp(key, "cipher-list") == 0) {
+			free(cfg->cipher_list);
 			cfg->cipher_list = strdup(val);
 		} else {
 			log_warn("Bad key in config file: \"%s\".\n", key);
@@ -273,4 +311,98 @@ err_close:
 	fclose(file);
 
 	return ret;
+}
+
+void destroy_vpn_config(struct vpn_config *cfg)
+{
+	free(cfg->pppd_log);
+	free(cfg->pppd_plugin);
+	free(cfg->pppd_ipparam);
+	free(cfg->pppd_ifname);
+	free(cfg->pppd_call);
+	free(cfg->ca_file);
+	free(cfg->user_cert);
+	free(cfg->user_key);
+	free(cfg->cipher_list);
+	while (cfg->cert_whitelist != NULL) {
+		struct x509_digest *tmp = cfg->cert_whitelist->next;
+		free(cfg->cert_whitelist);
+		cfg->cert_whitelist = tmp;
+	}
+}
+
+void merge_config(struct vpn_config *dst, struct vpn_config *src)
+{
+	if (src->gateway_host[0])
+		strcpy(dst->gateway_host, src->gateway_host);
+	if (src->gateway_port != invalid_cfg.gateway_port)
+		dst->gateway_port = src->gateway_port;
+	if (src->username[0])
+		strcpy(dst->username, src->username);
+	if (src->password[0])
+		strcpy(dst->password, src->password);
+	if (src->otp[0])
+		strcpy(dst->otp, src->otp);
+	if (src->realm[0])
+		strcpy(dst->realm, src->realm);
+	if (src->set_routes != invalid_cfg.set_routes)
+		dst->set_routes = src->set_routes;
+	if (src->set_dns != invalid_cfg.set_dns)
+		dst->set_dns = src->set_dns;
+	if (src->pppd_use_peerdns != invalid_cfg.pppd_use_peerdns)
+		dst->pppd_use_peerdns = src->pppd_use_peerdns;
+	if (src->use_syslog != invalid_cfg.use_syslog)
+		dst->use_syslog = src->use_syslog;
+	if (src->half_internet_routes != invalid_cfg.half_internet_routes)
+		dst->half_internet_routes = src->half_internet_routes;
+	if (src->persistent != invalid_cfg.persistent)
+		dst->persistent = src->persistent;
+	if (src->pppd_log) {
+		free(dst->pppd_log);
+		dst->pppd_log = src->pppd_log;
+	}
+	if (src->pppd_plugin) {
+		free(dst->pppd_plugin);
+		dst->pppd_plugin = src->pppd_plugin;
+	}
+	if (src->pppd_ipparam) {
+		free(dst->pppd_ipparam);
+		dst->pppd_ipparam = src->pppd_ipparam;
+	}
+	if (src->pppd_ifname) {
+		free(dst->pppd_ifname);
+		dst->pppd_ifname = src->pppd_ifname;
+	}
+	if (src->pppd_call) {
+		free(dst->pppd_call);
+		dst->pppd_call = src->pppd_call;
+	}
+	if (src->ca_file) {
+		free(dst->ca_file);
+		dst->ca_file = src->ca_file;
+	}
+	if (src->user_cert) {
+		free(dst->user_cert);
+		dst->user_cert = src->user_cert;
+	}
+	if (src->user_key) {
+		free(dst->user_key);
+		dst->user_key = src->user_key;
+	}
+	if (src->verify_cert != invalid_cfg.verify_cert)
+		dst->verify_cert = src->verify_cert;
+	if (src->insecure_ssl != invalid_cfg.insecure_ssl)
+		dst->insecure_ssl = src->insecure_ssl;
+	if (src->cipher_list) {
+		free(dst->cipher_list);
+		dst->cipher_list = src->cipher_list;
+	}
+	if (src->cert_whitelist) {
+		while (dst->cert_whitelist != NULL) {
+			struct x509_digest *tmp = dst->cert_whitelist->next;
+			free(dst->cert_whitelist);
+			dst->cert_whitelist = tmp;
+		}
+		dst->cert_whitelist = src->cert_whitelist;
+	}
 }

--- a/src/config.c
+++ b/src/config.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <sys/stat.h>
+#include <limits.h>
 
 
 const struct vpn_config invalid_cfg = {
@@ -231,7 +232,7 @@ int load_config(struct vpn_config *cfg, const char *filename)
 			cfg->half_internet_routes = half_internet_routes;
 		} else if (strcmp(key, "persistent") == 0) {
 			long int persistent = strtol(val, NULL, 0);
-			if (persistent < 0) {
+			if (persistent < 0 || persistent > UINT_MAX) {
 				log_warn("Bad value for persistent in config file: \"%s\".\n",
 				         val);
 				continue;

--- a/src/config.c
+++ b/src/config.c
@@ -48,7 +48,6 @@ const struct vpn_config invalid_cfg = {
 	.ca_file = NULL,
 	.user_cert = NULL,
 	.user_key = NULL,
-	.verify_cert = -1,
 	.insecure_ssl = -1,
 	.cipher_list = NULL,
 	.cert_whitelist = NULL
@@ -390,8 +389,6 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 		free(dst->user_key);
 		dst->user_key = src->user_key;
 	}
-	if (src->verify_cert != invalid_cfg.verify_cert)
-		dst->verify_cert = src->verify_cert;
 	if (src->insecure_ssl != invalid_cfg.insecure_ssl)
 		dst->insecure_ssl = src->insecure_ssl;
 	if (src->cipher_list) {

--- a/src/config.c
+++ b/src/config.c
@@ -32,7 +32,6 @@ const struct vpn_config invalid_cfg = {
 	.username = {'\0'},
 	.password = {'\0'},
 	.otp = {'\0'},
-	.cookie = {'\0'},
 	.realm = {'\0'},
 	.set_routes = -1,
 	.set_dns = -1,

--- a/src/config.h
+++ b/src/config.h
@@ -60,13 +60,12 @@ struct vpn_config {
 	char		username[FIELD_SIZE + 1];
 	char		password[FIELD_SIZE + 1];
 	char		otp[FIELD_SIZE + 1];
-	char		cookie[COOKIE_SIZE + 1];
 	char		realm[FIELD_SIZE + 1];
 
 	int	set_routes;
 	int	set_dns;
-	int     pppd_use_peerdns;
-	int     use_syslog;
+	int	pppd_use_peerdns;
+	int	use_syslog;
 	int	half_internet_routes;
 
 	unsigned int	persistent;
@@ -75,11 +74,11 @@ struct vpn_config {
 	char	*pppd_plugin;
 	char	*pppd_ipparam;
 	char	*pppd_ifname;
-	char    *pppd_call;
+	char	*pppd_call;
 
-	char	                *ca_file;
-	char	                *user_cert;
-	char	                *user_key;
+	char			*ca_file;
+	char			*user_cert;
+	char			*user_key;
 	int			insecure_ssl;
 	char			*cipher_list;
 	struct x509_digest	*cert_whitelist;

--- a/src/config.h
+++ b/src/config.h
@@ -80,7 +80,6 @@ struct vpn_config {
 	char	                *ca_file;
 	char	                *user_cert;
 	char	                *user_key;
-	int			verify_cert;
 	int			insecure_ssl;
 	char			*cipher_list;
 	struct x509_digest	*cert_whitelist;

--- a/src/config.h
+++ b/src/config.h
@@ -90,5 +90,15 @@ int add_trusted_cert(struct vpn_config *cfg, const char *digest);
 int strtob(const char *str);
 
 int load_config(struct vpn_config *cfg, const char *filename);
+void destroy_vpn_config(struct vpn_config *cfg);
+
+/** merge source config into dest
+ *
+ * memory allocated dynamically is transferred with this function
+ * e.g. ownership goes to dest config
+ */
+void merge_config(struct vpn_config *dest, struct vpn_config *source);
+
+extern const struct vpn_config invalid_cfg;
 
 #endif

--- a/src/http.c
+++ b/src/http.c
@@ -227,7 +227,7 @@ static int do_http_request(struct tunnel *tunnel, const char *method,
 
 	ret = http_send(tunnel, template, method, uri,
 	                tunnel->config->gateway_host,
-	                tunnel->config->gateway_port, tunnel->config->cookie,
+	                tunnel->config->gateway_port, tunnel->cookie,
 	                strlen(data), data);
 	if (ret != 1)
 		return ret;
@@ -322,8 +322,8 @@ static int get_auth_cookie(struct tunnel *tunnel, char *buf)
 				if (end != NULL)
 					end[0] = '\0';
 				log_debug("Cookie: %s\n", line);
-				strncpy(tunnel->config->cookie, line, COOKIE_SIZE);
-				tunnel->config->cookie[COOKIE_SIZE] = '\0';
+				strncpy(tunnel->cookie, line, COOKIE_SIZE);
+				tunnel->cookie[COOKIE_SIZE] = '\0';
 				if (strlen(line) > COOKIE_SIZE) {
 					log_error("Cookie larger than expected: %zu > %d\n",
 					          strlen(line), COOKIE_SIZE);
@@ -492,7 +492,7 @@ int auth_log_in(struct tunnel *tunnel)
 	url_encode(password, tunnel->config->password);
 	url_encode(realm, tunnel->config->realm);
 
-	tunnel->config->cookie[0] = '\0';
+	tunnel->cookie[0] = '\0';
 
 	snprintf(data, 256, "username=%s&credential=%s&realm=%s&ajax=1"
 	         "&redir=%%2Fremote%%2Findex&just_logged_in=1",

--- a/src/main.c
+++ b/src/main.c
@@ -156,7 +156,6 @@ int main(int argc, char **argv)
 		.ca_file = NULL,
 		.user_cert = NULL,
 		.user_key = NULL,
-		.verify_cert = 1,
 		.insecure_ssl = 0,
 		.cipher_list = NULL,
 		.cert_whitelist = NULL

--- a/src/main.c
+++ b/src/main.c
@@ -140,7 +140,6 @@ int main(int argc, char **argv)
 		.username = {'\0'},
 		.password = {'\0'},
 		.otp = {'\0'},
-		.cookie = {'\0'},
 		.realm = {'\0'},
 		.set_routes = 1,
 		.set_dns = 1,

--- a/src/main.c
+++ b/src/main.c
@@ -307,7 +307,7 @@ int main(int argc, char **argv)
 			if (strcmp(long_options[option_index].name,
 			           "persistent") == 0) {
 				long int persistent = strtol(optarg, NULL, 0);
-				if ((persistent < 0) || (persistent >= UINT_MAX)) {
+				if (persistent < 0 || persistent > UINT_MAX) {
 					log_warn("Bad persistent option: \"%s\"\n",
 					         optarg);
 					break;

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -796,7 +796,7 @@ int run_tunnel(struct vpn_config *config)
 		goto err_tunnel;
 	}
 	log_info("Authenticated.\n");
-	log_debug("Cookie: %s\n", config->cookie);
+	log_debug("Cookie: %s\n", tunnel.cookie);
 
 	ret = auth_request_vpn_allocation(&tunnel);
 	if (ret != 1) {
@@ -830,7 +830,7 @@ int run_tunnel(struct vpn_config *config)
 	                "GET /remote/sslvpn-tunnel HTTP/1.1\r\n"
 	                "Host: sslvpn\r\n"
 	                "Cookie: %s\r\n\r\n",
-	                tunnel.config->cookie);
+	                tunnel.cookie);
 	if (ret != 1) {
 		log_error("Could not start tunnel (%s).\n", err_http_str(ret));
 		ret = 1;

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -751,9 +751,8 @@ int ssl_connect(struct tunnel *tunnel)
 	}
 	SSL_set_mode(tunnel->ssl_handle, SSL_MODE_AUTO_RETRY);
 
-	if (tunnel->config->verify_cert)
-		if (ssl_verify_cert(tunnel))
-			return 1;
+	if (ssl_verify_cert(tunnel))
+		return 1;
 
 	// Disable SIGPIPE (occurs when trying to write to an already-closed
 	// socket).

--- a/src/tunnel.h
+++ b/src/tunnel.h
@@ -56,6 +56,7 @@ struct tunnel {
 	struct vpn_config *config;
 
 	enum tunnel_state state;
+	char cookie[COOKIE_SIZE + 1];
 
 	struct ppp_packet_pool ssl_to_pty_pool;
 	struct ppp_packet_pool pty_to_ssl_pool;


### PR DESCRIPTION
Parse config file and command line arguments in two different variables
and merge them appropriately.

Future work could make the merge function behave differently depending
on environmental circumstances (e.g. openfortivpn run as a setuid
program probably would want to refuse some cli options)

Fixes #258.