### PR TITLE
show version number in debug output

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -374,6 +374,8 @@ int main(int argc, char **argv)
 	if (password != NULL)
 		log_warn("You should not pass the password on the command line. Type it interactively or use a config file instead.\n");
 
+	log_debug("openfortivpn " VERSION "\n", config_file);
+
 	// Load config file
 	if (config_file[0] != '\0') {
 		ret = load_config(&cfg, config_file);


### PR DESCRIPTION
one of the most frequently asked questions that we ask the users who open issues is "can you try to run with -v for verbose output?" and in most cases the next question is "which version of openfortivpn is this?", so it would make sense to include this information in the debug output already. 