### PR TITLE
config.h: set FIELD_SIZE to 128

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -30,7 +30,7 @@ const struct vpn_config invalid_cfg = {
 	.gateway_host = {'\0'},
 	.gateway_port = 0,
 	.username = {'\0'},
-	.password = {'\0'},
+	.password = NULL,
 	.otp = {'\0'},
 	.realm = {'\0'},
 	.set_routes = -1,
@@ -201,8 +201,7 @@ int load_config(struct vpn_config *cfg, const char *filename)
 			strncpy(cfg->username, val, FIELD_SIZE - 1);
 			cfg->username[FIELD_SIZE] = '\0';
 		} else if (strcmp(key, "password") == 0) {
-			strncpy(cfg->password, val, FIELD_SIZE - 1);
-			cfg->password[FIELD_SIZE] = '\0';
+			cfg->password = strdup(val);
 		} else if (strcmp(key, "otp") == 0) {
 			strncpy(cfg->otp, val, FIELD_SIZE - 1);
 			cfg->otp[FIELD_SIZE] = '\0';
@@ -330,6 +329,7 @@ err_close:
 
 void destroy_vpn_config(struct vpn_config *cfg)
 {
+	free(cfg->password);
 #if HAVE_USR_SBIN_PPPD
 	free(cfg->pppd_log);
 	free(cfg->pppd_plugin);
@@ -359,8 +359,8 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 		dst->gateway_port = src->gateway_port;
 	if (src->username[0])
 		strcpy(dst->username, src->username);
-	if (src->password[0])
-		strcpy(dst->password, src->password);
+	if (src->password != NULL && src->password[0])
+		dst->password = strdup(src->password);
 	if (src->otp[0])
 		strcpy(dst->otp, src->otp);
 	if (src->realm[0])

--- a/src/config.h
+++ b/src/config.h
@@ -64,7 +64,7 @@ struct vpn_config {
 	struct in_addr	gateway_ip;
 	uint16_t	gateway_port;
 	char		username[FIELD_SIZE + 1];
-	char		password[FIELD_SIZE + 1];
+	char		*password;
 	char		otp[FIELD_SIZE + 1];
 	char		realm[FIELD_SIZE + 1];
 

--- a/src/main.c
+++ b/src/main.c
@@ -440,9 +440,7 @@ int main(int argc, char **argv)
 	}
 	// If no password given, interactively ask user
 	if (cfg.password == NULL || cfg.password[0] == '\0') {
-		if (cfg.password != NULL) {
-			free(cfg.password);
-		}
+		free(cfg.password);
 		char *tmp_password = malloc(PWD_BUFSIZ); // allocate large buffer
 		read_password("VPN account password: ", tmp_password, PWD_BUFSIZ);
 		cfg.password = strdup(tmp_password); // copy string of correct size

--- a/src/main.c
+++ b/src/main.c
@@ -27,6 +27,9 @@
 #include <string.h>
 #include <limits.h>
 
+#define PWD_BUFSIZ	4096
+
+
 #if HAVE_USR_SBIN_PPPD
 #define PPPD_USAGE \
 "                    [--pppd-no-peerdns] [--pppd-log=<file>]\n" \
@@ -440,8 +443,8 @@ int main(int argc, char **argv)
 		if (cfg.password != NULL) {
 			free(cfg.password);
 		}
-		char *tmp_password = malloc(BUFSIZ); // allocate large buffer
-		read_password("VPN account password: ", tmp_password, BUFSIZ);
+		char *tmp_password = malloc(PWD_BUFSIZ); // allocate large buffer
+		read_password("VPN account password: ", tmp_password, PWD_BUFSIZ);
 		cfg.password = strdup(tmp_password); // copy string of correct size
 		free(tmp_password);
 	}


### PR DESCRIPTION
I was recently hit by #358. I have a password that is length 64. 

Despite [config.h](https://github.com/adrienverge/openfortivpn/compare/master...nknotts:longer-passwords#diff-ebab3775208ceccb934d0d29f384a367R61) defining `struct vpn_config` with `password[FIELD_SIZE + 1];`, [config.c](https://github.com/adrienverge/openfortivpn/blob/3b5a28ca21ed0ee3f56b58828eee78f26402f7af/src/config.c#L170) reads password via

```
strncpy(cfg->password, val, FIELD_SIZE - 1);
cfg->password[FIELD_SIZE] = '\0';
```

Thus, despite password having a length of 65, only 63 bytes would be used. I considered fixing all uses of `FIELD_SIZE` but wanted to start a discussion about it first. 

Increasing `FIELD_SIZE` allows the use of my password and should help alleviate #358. I did not do a deep inspection to determine the negatives of increasing `FIELD_SIZE` other than slightly increased memory usage.
