### PR TITLE
Add --otp-delay option

### DIFF
--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -9,6 +9,7 @@ openfortivpn \- Client for PPP+SSL VPN tunnel services
 [\fB\-u\fR \fI<user>\fR]
 [\fB\-p\fR \fI<pass>\fR]
 [\fB\-\-otp=\fI<otp>\fR]
+[\fB\-\-otp-delay=\fI<delay>\fR]
 [\fB\-\-realm=\fI<realm>\fR]
 [\fB\-\-set-routes=<bool>\fR]
 [\fB\-\-no-routes\fR]
@@ -62,6 +63,11 @@ VPN account password.
 .TP
 \fB\-o \fI<otp>\fR, \fB\-\-otp=\fI<otp>\fR
 One-Time-Password.
+.TP
+\fB\-\-otp\-delay\=\fI<delay>\fR
+Set the amount of time to wait before sending the One-Time-Password.
+The delay time must be specified in seconds, where 0 means
+no wait (this is the default).
 .TP
 \fB\-\-realm=\fI<realm>\fR
 Connect to the specified authentication realm. Defaults to empty, which

--- a/src/config.c
+++ b/src/config.c
@@ -32,6 +32,7 @@ const struct vpn_config invalid_cfg = {
 	.username = {'\0'},
 	.password = NULL,
 	.otp = {'\0'},
+	.otp_delay = -1,
 	.realm = {'\0'},
 	.set_routes = -1,
 	.set_dns = -1,
@@ -205,6 +206,14 @@ int load_config(struct vpn_config *cfg, const char *filename)
 		} else if (strcmp(key, "otp") == 0) {
 			strncpy(cfg->otp, val, FIELD_SIZE - 1);
 			cfg->otp[FIELD_SIZE] = '\0';
+		} else if (strcmp(key, "otp-delay") == 0) {
+			long int otp_delay = strtol(val, NULL, 0);
+			if (otp_delay < 0 || otp_delay > UINT_MAX) {
+				log_warn("Bad value for otp-delay in config file: \"%s\".\n",
+				         val);
+				continue;
+			}
+			cfg->otp_delay = otp_delay;
 		} else if (strcmp(key, "realm") == 0) {
 			strncpy(cfg->realm, val, FIELD_SIZE - 1);
 			cfg->realm[FIELD_SIZE] = '\0';
@@ -363,6 +372,8 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 		dst->password = strdup(src->password);
 	if (src->otp[0])
 		strcpy(dst->otp, src->otp);
+	if (src->otp_delay != invalid_cfg.otp_delay)
+		dst->otp_delay = src->otp_delay;
 	if (src->realm[0])
 		strcpy(dst->realm, src->realm);
 	if (src->set_routes != invalid_cfg.set_routes)

--- a/src/config.h
+++ b/src/config.h
@@ -66,6 +66,7 @@ struct vpn_config {
 	char		username[FIELD_SIZE + 1];
 	char		*password;
 	char		otp[FIELD_SIZE + 1];
+	unsigned int  otp_delay;
 	char		realm[FIELD_SIZE + 1];
 
 	int	set_routes;

--- a/src/main.c
+++ b/src/main.c
@@ -60,7 +60,7 @@
 
 #define usage \
 "Usage: openfortivpn [<host>[:<port>]] [-u <user>] [-p <pass>]\n" \
-"                    [--realm=<realm>] [--otp=<otp>] [--set-routes=<0|1>]\n" \
+"                    [--realm=<realm>] [--otp=<otp>] [--otp-delay=<delay>] [--set-routes=<0|1>]\n" \
 "                    [--half-internet-routes=<0|1>] [--set-dns=<0|1>]\n" \
 PPPD_USAGE \
 "                    [--ca-file=<file>]\n" \
@@ -87,6 +87,7 @@ PPPD_USAGE \
 "  -u <user>, --username=<user>  VPN account username.\n" \
 "  -p <pass>, --password=<pass>  VPN account password.\n" \
 "  -o <otp>, --otp=<otp>         One-Time-Password.\n" \
+"  --otp-delay=<delay>	         Wait <delay> seconds before sending the OTP.\n" \
 "  --realm=<realm>               Use specified authentication realm on VPN gateway\n" \
 "                                when tunnel is up.\n" \
 "  --set-routes=[01]             Set if openfortivpn should configure output routes through\n" \
@@ -156,6 +157,7 @@ int main(int argc, char **argv)
 		.username = {'\0'},
 		.password = NULL,
 		.otp = {'\0'},
+		.otp_delay = 0,
 		.realm = {'\0'},
 		.set_routes = 1,
 		.set_dns = 1,
@@ -190,6 +192,7 @@ int main(int argc, char **argv)
 		{"username",        required_argument, 0, 'u'},
 		{"password",        required_argument, 0, 'p'},
 		{"otp",             required_argument, 0, 'o'},
+		{"otp-delay",       required_argument, 0, 0},
 		{"set-routes",	    required_argument, 0, 0},
 		{"no-routes",       no_argument, &cli_cfg.set_routes, 0},
 		{"half-internet-routes", required_argument, 0, 0},
@@ -335,6 +338,17 @@ int main(int argc, char **argv)
 					break;
 				}
 				cli_cfg.half_internet_routes = half_internet_routes;
+				break;
+			}
+			if (strcmp(long_options[option_index].name,
+			           "otp-delay") == 0) {
+				long int otp_delay = strtol(optarg, NULL, 0);
+				if (otp_delay < 0 || otp_delay > UINT_MAX) {
+					log_warn("Bad otp-delay option: \"%s\"\n",
+					         optarg);
+					break;
+				}
+				cli_cfg.otp_delay = otp_delay;
 				break;
 			}
 			if (strcmp(long_options[option_index].name,


### PR DESCRIPTION
This fixes #348.

I added a --otp-delay option, which takes a integer representing the number of seconds to wait before sending the OTP to the server.