### PR TITLE
improve routing code for Mac OSX and FreeBSD

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -622,6 +622,12 @@ static int ipv4_del_route(struct rtentry *route)
 	strcat(cmd, " -netmask ");
 	strncat(cmd, inet_ntoa(route_mask(route)), 15);
 
+	if (!(route->rt_flags & RTF_GATEWAY)) {
+		strcat(cmd, " -interface ");
+		strncat(cmd, route_iface(route),
+		        SHOW_ROUTE_BUFFER_SIZE - strlen(cmd) - 1);
+	}
+
 	log_debug("%s\n", cmd);
 
 	int res = system(cmd);

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -667,15 +667,6 @@ int ipv4_protect_tunnel_route(struct tunnel *tunnel)
 			goto err_destroy;
 	}
 
-	ret = ipv4_get_route(def_rt);
-	if (ret != 0) {
-		log_warn("Could not get current default route (%s).\n",
-		         err_ipv4_str(ret));
-		log_warn("Protecting tunnel route has failed. But this can be working except for some cases.\n");
-		goto err_destroy;
-	}
-
-
 	// Back up default route
 	route_dest(def_rt).s_addr = inet_addr("0.0.0.0");
 	route_mask(def_rt).s_addr = inet_addr("0.0.0.0");

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -490,9 +490,9 @@ static int ipv4_get_route(struct rtentry *route)
 		    && (mask <= rtmask)
 		    && ((route_iface(route) == NULL)
 		        || (strcmp(iface, route_iface(route)) == 0)
-		        || ((strlen(route_iface(route))>0)
-		            && (route_iface(route)[0] == '!')
-		            && (strcmp(iface, &route_iface(route)[1]) != 0))
+		        || (strlen(route_iface(route)) > 0
+		            && route_iface(route)[0] == '!'
+		            && strcmp(iface, &route_iface(route)[1]) != 0)
 		       )) {
 #if HAVE_PROC_NET_ROUTE
 			if (((mask == route_mask(route).s_addr)


### PR DESCRIPTION
this solves #378:

On OSX and FreeBSD there is no /proc file system where we could look up the routes currently configured.  We have to parse the output of the netstat tool. In this output there are also routes which are directly connected to specific interface, e.g. the tunnel interface automatically has a default route attached. When determining the route to the vpn gateway for instance, we need a route which does not go through the tunnel. Therefore we need a way to specify that routes over a particular interface are taken (or explicitly not taken, in this particular case). 