### PR TITLE
Bail out if not run as root

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -458,8 +458,11 @@ int main(int argc, char **argv)
 	if (cfg.otp[0] != '\0')
 		log_debug("One-time password = \"%s\"\n", cfg.otp);
 
-	if (geteuid() != 0)
-		log_warn("This process was not spawned with root privileges, this will probably not work.\n");
+	if (geteuid() != 0) {
+		log_error("This process was not spawned with root privileges, which are required.\n");
+		ret = EXIT_FAILURE;
+		goto exit;
+	}
 
 	do {
 		if (run_tunnel(&cfg) != 0)


### PR DESCRIPTION
Actual root privileges are required in many places, depending on the OS:
* On Linux, the 'noauth' option of pppd seems to require actual root privileges. Being a meber of the 'dip' group on Ubuntu is not sufficient.
* On Linux, setting routes requires root privileges unless user has CAP_NET_ADMIN capability.
* On FreeBSD, setting routes using 'route' requires root privileges.

Fixes #373.