### PR TITLE
Helpful error messages

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -552,7 +552,8 @@ int auth_log_in(struct tunnel *tunnel)
 
 	if (strncmp(res, "HTTP/1.1 200 OK\r\n", 17)) {
 		char word[17];
-		if (sscanf(res, "%s %d", word, &ret) < 2)
+
+		if (sscanf(res, "%16s %d", word, &ret) < 2)
 			ret = ERR_HTTP_BAD_RES_CODE;
 		goto end;
 	}
@@ -606,7 +607,8 @@ int auth_log_in(struct tunnel *tunnel)
 
 		if (strncmp(res, "HTTP/1.1 200 OK\r\n", 17)) {
 			char word[17];
-			if (sscanf(res, "%s %d", word, &ret) < 2)
+
+			if (sscanf(res, "%16s %d", word, &ret) < 2)
 				ret = ERR_HTTP_BAD_RES_CODE;
 			goto end;
 		}
@@ -641,7 +643,8 @@ static int parse_xml_config(struct tunnel *tunnel, const char *buffer)
 
 	if (strncmp(buffer, "HTTP/1.1 200 OK\r\n", 17)) {
 		char word[17];
-		if (sscanf(buffer, "%s %d", word, &ret) < 2)
+
+		if (sscanf(buffer, "%16s %d", word, &ret) < 2)
 			ret = ERR_HTTP_BAD_RES_CODE;
 		return ret;
 	}

--- a/src/http.c
+++ b/src/http.c
@@ -551,7 +551,9 @@ int auth_log_in(struct tunnel *tunnel)
 	}
 
 	if (strncmp(res, "HTTP/1.1 200 OK\r\n", 17)) {
-		ret = ERR_HTTP_BAD_RES_CODE;
+		char word[17];
+		if (sscanf(res, "%s %d", word, &ret) < 2)
+			ret = ERR_HTTP_BAD_RES_CODE;
 		goto end;
 	}
 	ret = get_auth_cookie(tunnel, res, response_size);
@@ -603,7 +605,9 @@ int auth_log_in(struct tunnel *tunnel)
 			goto end;
 
 		if (strncmp(res, "HTTP/1.1 200 OK\r\n", 17)) {
-			ret = ERR_HTTP_BAD_RES_CODE;
+			char word[17];
+			if (sscanf(res, "%s %d", word, &ret) < 2)
+				ret = ERR_HTTP_BAD_RES_CODE;
 			goto end;
 		}
 
@@ -633,9 +637,14 @@ static int parse_xml_config(struct tunnel *tunnel, const char *buffer)
 {
 	const char *val;
 	char *gateway;
+	int ret = 0;
 
-	if (strncmp(buffer, "HTTP/1.1 200 OK\r\n", 17))
-		return ERR_HTTP_BAD_RES_CODE;
+	if (strncmp(buffer, "HTTP/1.1 200 OK\r\n", 17)) {
+		char word[17];
+		if (sscanf(buffer, "%s %d", word, &ret) < 2)
+			ret = ERR_HTTP_BAD_RES_CODE;
+		return ret;
+	}
 
 	// Skip the HTTP header
 	buffer = strstr(buffer, "\r\n\r\n");

--- a/src/http.h
+++ b/src/http.h
@@ -30,7 +30,9 @@
 
 static inline const char *err_http_str(int code)
 {
-	if (code == ERR_HTTP_INVALID)
+	if (code > 0)
+		return "HTTP status code";
+	else if (code == ERR_HTTP_INVALID)
 		return "Invalid input";
 	else if (code == ERR_HTTP_TOO_LONG)
 		return "Request too long";

--- a/src/main.c
+++ b/src/main.c
@@ -458,8 +458,11 @@ int main(int argc, char **argv)
 	if (cfg.otp[0] != '\0')
 		log_debug("One-time password = \"%s\"\n", cfg.otp);
 
-	if (geteuid() != 0)
-		log_warn("This process was not spawned with root privileges, this will probably not work.\n");
+	if (geteuid() != 0) {
+		log_error("This process was not spawned with root privileges, which are required.\n");
+		ret = EXIT_FAILURE;
+		goto exit;
+	}
 
 	do {
 		if (run_tunnel(&cfg) != 0)

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -854,8 +854,7 @@ int run_tunnel(struct vpn_config *config)
 	// cookie
 	ret = auth_log_in(&tunnel);
 	if (ret != 1) {
-		log_error("Could not authenticate to gateway (%s).\n",
-		          err_http_str(ret));
+		log_error("Could not authenticate to gateway. Please check the password, client certificate, etc.\n");
 		ret = 1;
 		goto err_tunnel;
 	}

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -855,6 +855,7 @@ int run_tunnel(struct vpn_config *config)
 	ret = auth_log_in(&tunnel);
 	if (ret != 1) {
 		log_error("Could not authenticate to gateway. Please check the password, client certificate, etc.\n");
+		log_debug("%s %d\n", err_http_str(ret), ret);
 		ret = 1;
 		goto err_tunnel;
 	}


### PR DESCRIPTION
Printing "Bad HTTP response" for any HTTP response different from 200 is imprecise and eventually not helpful.

Better error messages might be a compelling reason to use a lightweight 3rd party HTTP library.