### PR TITLE
use ppp interface name instead of ip for routing

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -81,6 +81,8 @@ int http_send(struct tunnel *tunnel, const char *request, ...)
 	else if (length >= BUFSZ)
 		return ERR_HTTP_TOO_LONG;
 
+	log_debug_details("http_send : \n%s\n", buffer);
+
 	while (n == 0)
 		n = safe_ssl_write(tunnel->ssl_handle, (uint8_t *) buffer,
 		                   length);
@@ -147,6 +149,7 @@ int http_receive(
 		                  (uint8_t *) buffer + bytes_read,
 		                  BUFSZ - 1 - bytes_read);
 		if (n > 0) {
+			log_debug_details("http_receive : \n%s\n", buffer);
 			const char *eoh;
 
 			bytes_read += n;

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -364,7 +364,7 @@ static int ipv4_get_route(struct rtentry *route)
 		int pos;
 		char *tmpstr;
 
-		log_debug("line: %s\n", line);
+		log_debug_details("line: %s\n", line);
 
 		saveptr3 = NULL;
 		dest = UINT32_MAX;
@@ -375,7 +375,7 @@ static int ipv4_get_route(struct rtentry *route)
 			// we have arrived at the end of ipv4 output
 			goto end;
 		}
-		log_debug("- Destination: %s\n", tmpstr);
+		log_debug_details("- Destination: %s\n", tmpstr);
 		// replace literal "default" route by IPV4 numbers-and-dots notation
 		if (strncmp(tmpstr, "default", 7) == 0) {
 			dest = 0;
@@ -425,13 +425,13 @@ static int ipv4_get_route(struct rtentry *route)
 			}
 
 		}
-		log_debug("- Destination IP Hex: %x\n", dest);
-		log_debug("- Destination Mask Hex: %x\n", mask);
+		log_debug_details("- Destination IP Hex: %x\n", dest);
+		log_debug_details("- Destination Mask Hex: %x\n", mask);
 		// "Gateway"
 		gtw = 0;
 		if (inet_aton(strtok_r(NULL, " ", &saveptr2), &dstaddr)) {
 			gtw = dstaddr.s_addr;
-			log_debug("- Gateway Mask Hex: %x\n", gtw);
+			log_debug_details("- Gateway Mask Hex: %x\n", gtw);
 		}
 		// "Flags"
 		tmpstr = strtok_r(NULL, " ", &saveptr2);
@@ -444,8 +444,8 @@ static int ipv4_get_route(struct rtentry *route)
 		if (have_use) strtok_r(NULL, " ", &saveptr2); // "Use"
 
 		iface = strtok_r(NULL, " ", &saveptr2); // "Netif"
-		log_debug("- Interface: %s\n", iface);
-		log_debug("\n");
+		log_debug_details("- Interface: %s\n", iface);
+		log_debug_details("\n");
 #endif
 		/*
 		 * Now that we have parsed a routing entry, check if it

--- a/src/log.c
+++ b/src/log.c
@@ -88,7 +88,7 @@ void do_log(int verbosity, const char *format, ...)
 	pthread_mutex_lock(&mutex);
 
 	// Use sane default if wrong verbosity specified
-	if (verbosity > OFV_LOG_DEBUG || verbosity < 0)
+	if (verbosity > OFV_LOG_DEBUG_DETAILS || verbosity < 0)
 		verbosity = OFV_LOG_MUTE;
 	lp = &log_params[verbosity];
 

--- a/src/log.c
+++ b/src/log.c
@@ -39,7 +39,7 @@ struct log_param_s {
 	int syslog_prio;
 };
 
-static const struct log_param_s log_params[OFV_LOG_DEBUG_PACKETS + 1] = {
+static const struct log_param_s log_params[OFV_LOG_DEBUG_DETAILS + 1] = {
 	{ "        ", "",           LOG_ERR},
 	{ "ERROR:  ", "\033[0;31m", LOG_ERR},
 	{ "WARN:   ", "\033[0;33m", LOG_WARNING},
@@ -71,7 +71,7 @@ void set_syslog(int use_syslog)
 
 void increase_verbosity(void)
 {
-	if (loglevel < OFV_LOG_DEBUG_PACKETS)
+	if (loglevel < OFV_LOG_DEBUG_DETAILS)
 		loglevel++;
 }
 void decrease_verbosity(void)

--- a/src/log.h
+++ b/src/log.h
@@ -28,7 +28,7 @@ enum log_verbosity {
 	OFV_LOG_WARN  = 2,
 	OFV_LOG_INFO  = 3,
 	OFV_LOG_DEBUG = 4,
-	OFV_LOG_DEBUG_PACKETS = 5
+	OFV_LOG_DEBUG_DETAILS = 5
 };
 
 extern enum log_verbosity loglevel;
@@ -56,11 +56,11 @@ void do_log(int verbosity, const char *format, ...);
 #define log_debug(...) \
 	log_level(OFV_LOG_DEBUG, __VA_ARGS__)
 #define log_debug_details(...) \
-	log_level(OFV_LOG_DEBUG_PACKETS, __VA_ARGS__)
+	log_level(OFV_LOG_DEBUG_DETAILS, __VA_ARGS__)
 
 #define log_packet(...) \
 	do { \
-		if (loglevel >= OFV_LOG_DEBUG_PACKETS) \
+		if (loglevel >= OFV_LOG_DEBUG_DETAILS) \
 			do_log_packet(__VA_ARGS__); \
 	} while (0)
 

--- a/src/log.h
+++ b/src/log.h
@@ -55,6 +55,8 @@ void do_log(int verbosity, const char *format, ...);
 	log_level(OFV_LOG_INFO, __VA_ARGS__)
 #define log_debug(...) \
 	log_level(OFV_LOG_DEBUG, __VA_ARGS__)
+#define log_debug_details(...) \
+	log_level(OFV_LOG_DEBUG_PACKETS, __VA_ARGS__)
 
 #define log_packet(...) \
 	do { \


### PR DESCRIPTION
on FreeBSD (and OSX), namely when adding routes via route command