### PR TITLE
add ppp to build requirements on fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For other distros, you'll need to build and install from source:
 
 1.  Install build dependencies.
 
-    * RHEL/CentOS/Fedora: `gcc` `automake` `autoconf` `openssl-devel` `pkg-config`
+    * RHEL/CentOS/Fedora: `gcc` `automake` `autoconf` `openssl-devel` `pkg-config` `ppp`
     * Debian/Ubuntu: `gcc` `automake` `autoconf` `libssl-dev` `make` `pkg-config`
     * Arch Linux: `gcc` `automake` `autoconf` `openssl` `pkg-config`
     * Gentoo Linux: `net-dialup/ppp` `pkg-config`


### PR DESCRIPTION
one needs to install ppp before building on fedora
https://github.com/adrienverge/openfortivpn/issues/396