### PR TITLE
HTML URL Encoding Reference uses upper case

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -47,7 +47,7 @@ static void url_encode(char *dest, const char *str)
 		else if (*str == ' ')
 			*dest++ = '+';
 		else {
-			static const char hex[] = "0123456789abcdef";
+			static const char hex[] = "0123456789ABCDEF";
 
 			*dest++ = '%';
 			*dest++ = hex[*str >> 4];


### PR DESCRIPTION
All examples in this reference use upper case for hexadecimals:
	https://www.w3schools.com/tags/ref_urlencode.asp

While URL decoding is (hopefully!) case insensitive, let's follow the reference blindly.