### PR TITLE
Fix value of Accept-Encoding request header

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -244,7 +244,7 @@ static int do_http_request(struct tunnel *tunnel,
 	                        "Host: %s:%d\r\n"
 	                        "User-Agent: Mozilla/5.0 SV1\r\n"
 	                        "Accept: text/plain\r\n"
-	                        "Accept-Encoding: identify\r\n"
+	                        "Accept-Encoding: identity\r\n"
 	                        "Content-Type: application/x-www-form-urlencoded\r\n"
 	                        "Cookie: %s\r\n"
 	                        "Content-Length: %d\r\n"


### PR DESCRIPTION
While debugging some case of #366 I noticed that the value of the `Accept-Encoding` header had a typo.

Fixing the value doesn't make the issue go away but is one less thing which might go wrong.

I also added the fall-back value `*/*` to the `Accept` request header, just in case this might cause some trouble somewhere.