### PR TITLE
support realm together with 2FA

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -500,6 +500,16 @@ int try_otp_auth(
 				return -1;
 			url_encode(d, cfg->otp);
 			d += strlen(d);
+			/*  realm workaround */
+			if (cfg->realm[0] != '\0') {
+				l = strlen(cfg->realm);
+				if (!SPACE_AVAILABLE(3 * l + 8))
+					return -1;
+				strcat(d, "&realm=");
+				d += strlen(d);
+				url_encode(d, cfg->realm);
+				d += strlen(d);
+			}
 		} else if (strncmp(t, "submit", 6) == 0) {
 			/* avoid adding another '&' */
 			n = v = e = NULL;


### PR DESCRIPTION
Citing from issue #411:
I have implemented 2FA using Radius+PrivacyIdea and is working quite well.
For openfortivpn, I have found that "try_otp_auth()" does not send 'realm'
information, so connection is dropped even if authentication was successful.

Additional correction of the check for LENGTH_AVAILABLE: Take into account
the length of the additional "&realm="