### PR TITLE
Revert "Rationalize DNS options"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Examples
 
 * Don't set IP routes and don't add VPN nameservers to `/etc/resolv.conf`:
   ```
-  openfortivpn vpn-gateway:8443 -u foo -p bar --no-routes --no-dns
+  openfortivpn vpn-gateway:8443 -u foo -p bar --no-routes --no-dns --pppd-no-peerdns
   ```
 * Using a config file:
   ```
@@ -39,6 +39,7 @@ Examples
   password = bar
   set-routes = 0
   set-dns = 0
+  pppd-use-peerdns = 0
   # X509 certificate sha256 sum, trust only this one!
   trusted-cert = e46d4aff08ba6914e64daa85bc6112a422fa7ce16631bff0b592a28556f993db
   ```

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -119,8 +119,8 @@ $ openssl s_client -connect \fI<host:port>\fR
 (default: HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4)
 .TP
 \fB\-\-pppd-no-peerdns\fR
-Deprecated; do not ask peer ppp server for DNS server addresses and do not make
-pppd rewrite /etc/resolv.conf.
+Do not ask peer ppp server for DNS server addresses and do not make pppd
+rewrite /etc/resolv.conf.
 .TP
 \fB\-\-pppd-log=\fI<file>\fR
 Set pppd in debug mode and save its logs into \fI<file>\fR.
@@ -235,6 +235,8 @@ set-dns = 0
 set-routes = 1
 .br
 half-internet-routes = 0
+.br
+pppd-use-peerdns = 1
 .br
 # alternatively, use a specific pppd plugin instead
 .br

--- a/src/main.c
+++ b/src/main.c
@@ -34,8 +34,8 @@
 "                    [--pppd-call=<name>] [--pppd-plugin=<file>]\n"
 
 #define PPPD_HELP \
-"  --pppd-no-peerdns             Deprecated; do not ask peer ppp server for DNS server\n" \
-"                                addresses and do not make pppd rewrite /etc/resolv.conf\n" \
+"  --pppd-no-peerdns             Do not ask peer ppp server for DNS server addresses\n" \
+"                                and do not make pppd rewrite /etc/resolv.conf\n" \
 "  --pppd-log=<file>             Set pppd in debug mode and save its logs into\n" \
 "                                <file>.\n" \
 "  --pppd-plugin=<file>          Use specified pppd plugin instead of configuring\n" \

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -98,7 +98,7 @@ static int on_ppp_if_up(struct tunnel *tunnel)
 		}
 	}
 
-	if (tunnel->config->set_dns && !tunnel->config->pppd_use_peerdns) {
+	if (tunnel->config->set_dns) {
 		log_info("Adding VPN nameservers...\n");
 		ipv4_add_nameservers_to_resolv_conf(tunnel);
 	}
@@ -121,7 +121,7 @@ static int on_ppp_if_down(struct tunnel *tunnel)
 		ipv4_restore_routes(tunnel);
 	}
 
-	if (tunnel->config->set_dns && !tunnel->config->pppd_use_peerdns) {
+	if (tunnel->config->set_dns) {
 		log_info("Removing VPN nameservers...\n");
 		ipv4_del_nameservers_from_resolv_conf(tunnel);
 	}
@@ -199,7 +199,7 @@ static int pppd_run(struct tunnel *tunnel)
 			for (unsigned i = 0; i < ARRAY_SIZE(v); i++)
 				ofv_append_varr(&pppd_args, v[i]);
 		}
-		if (tunnel->config->set_dns && tunnel->config->pppd_use_peerdns)
+		if (tunnel->config->pppd_use_peerdns)
 			ofv_append_varr(&pppd_args, "usepeerdns");
 		if (tunnel->config->pppd_log) {
 			ofv_append_varr(&pppd_args, "debug");


### PR DESCRIPTION
This reverts commit f3830844090d9107112fb83dd93089da4961add1.

See #349 and #406.

With f383084 it is not possible anymore to use _openfortivpn_'s internal mechanism to update  `/etc/resolv.conf`, because it ***also*** needs to pass the `usepeerdns` option to `pppd` in order to receive this information from the vpn server. Here a symmary of the combinations of the options and the result:

New behavior without specific ip-up scripts for the ppp interface or _openresolv_ service:

| set-dns | pppd-use-peerdns | `/var/run/ppp/resolv.conf` | `/etc/resolv.conf` |
| --- | --- | --- | --- | 
| true | true |  created/updated | **not** updated (default case) |
| true | false |  not created/updated | not updated (**broken**) |
| false | true |  **not** created/updated | not updated |
| false | false |  not created/updated | not updated |

old behavior (without specific ip-up scripts for the ppp interface or _openresolv_):

| set-dns | pppd-use-peerdns | `/var/run/ppp/resolv.conf` | `/etc/resolv.conf` |
| --- | --- | --- | --- | 
| true | true |  created/updated | **updated** (default case) |
| true | false |  not created/updated | not updated (**expected but not very intuitive**) |
| false | true |  **created/updated** | not updated (intended for _openresolv_ or `ip-up` script) |
| false | false |  not created/updated | not updated |


With `ip-up` script or _openresolv_, the new default behavior is the required one, with the old behavior `set-dns=0` would be needed. 
Without `ip-up` script or _openresolv_, the old default behavior is the required one, whereas there is **no** combination that can update `/etc/resolv.conf` out of the box.

Edit: restore formatting which was lost during copy&paste