### PR TITLE
openfortivpn version 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,18 @@ Legend
 Releases
 --------
 
-### Upcoming release (current master)
+This high level changelog is usually updated when a release is tagged.
+On the master branch there may be changes that are not (yet) described here.
 
-Note: This list is going to change and perhaps needs some review before the next release is tagged.
+### 1.8.1
 
+* [~] Support longer passowrds by allocation of a larger buffer
+* [-] With version 1.8.0 /etc/resolv.conf was not updated anymore in some situations.
+  To avoid this regression the change "Rationalize DNS options" has been reverted again
+  to restore the behavior of versions up to 1.7.1.
+* [-] Correctly use realm together with two factor authentication
+* [~] If no port is specified use standard https port similar as vendor client
+* [-] Fix value of Accept-Encoding request header
 * [-] Bugfix in url_encode for non alphanumerical characters
 * [-] HTML URL Encoding with uppercase characters
 * [-] Honor Cipher-list option 
@@ -199,6 +207,7 @@ Usage: openfortivpn <host>:<port> -u <user> -p <pass>
        openfortivpn --help 
        openfortivpn --version
 ```
+
 ### Details of the changes
 
 This is a high level changelog meant to provide a rough overview about the version history of openfortivpn. Please see the Github [commit history](https://github.com/adrienverge/openfortivpn/commits) for more details of the individual changes listed here, and for a complete list of the internal code changes.

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
-AC_INIT([openfortivpn], [1.8.0])
+AC_INIT([openfortivpn], [1.8.1])
 AC_CONFIG_SRCDIR([src/main.c])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 


### PR DESCRIPTION
We have two important fixes on master now (#416 and #399).

I would also like to land #361 just because it is not a big change, hanging around for such a long time (which causes trouble when the branches have diverged too much as we have seen). 
I have that description already in the updated CHANGELOG.md, so before merging this one we should either merge the fix for long passwords or update the high level changelog once again.