### PR TITLE
implement --pppd-use-peerdns command line option for consistency

### DIFF
--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -1,4 +1,4 @@
-.TH OPENFORTIVPN 1 "March 11, 2019" ""
+.TH OPENFORTIVPN 1 "March 12, 2019" ""
 
 .SH NAME
 openfortivpn \- Client for PPP+SSL VPN tunnel services
@@ -18,7 +18,7 @@ openfortivpn \- Client for PPP+SSL VPN tunnel services
 [\fB\-\-no\-dns\fR]
 [\fB\-\-half\-internet\-routes=<bool>\fR]
 [\fB\-\-ca\-file=\fI<file>\fR]
-[\fB\-\-user-cert=\fI<file>\fR]
+[\fB\-\-user\-cert=\fI<file>\fR]
 [\fB\-\-user\-key=\fI<file>\fR]
 [\fB\-\-use\-syslog\fR]
 [\fB\-\-trusted\-cert=\fI<digest>\fR]
@@ -31,6 +31,7 @@ openfortivpn \- Client for PPP+SSL VPN tunnel services
 [\fB\-\-pppd\-ipparam=\fI<string>\fR]
 [\fB\-\-pppd\-ifname=\fI<string>\fR]
 [\fB\-\-pppd\-call=\fI<name>\fR]
+[\fB\-\-ppp\-system=\fI<string>\fR]
 [\fB\-\-persistent=\fI<interval>\fR]
 [\fB\-c\fR \fI<file>\fR]
 [\fB\-v|\-q\fR]
@@ -133,13 +134,15 @@ $ openssl s_client -connect \fI<host:port>\fR
 
 (default: HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4)
 .TP
-\fB\-\-pppd\-no\-peerdns\fR
-Do not ask peer ppp server for DNS server addresses and do not make pppd
+\fB\-\-use\-peer\-dns=\fI<bool>\fR, \fB\-\-pppd\-no\-peerdns\fR
+Whether to ask peer ppp server for DNS server addresses and do not make pppd
 rewrite /etc/resolv.conf. If the DNS server addresses are not requested,
 also \fB\-\-set\-dns=\fI1\fR has no effect. On the other hand, with
 \fB\-\-set\-dns=\fI0\fR, when pppd requests DNS server addresses, there
 may be othter mechanisms, such as an pppd\-ip\-up-script that do the update
 of /etc/resolv.conf.
+
+\fB\-\-pppd\-no\-peerdns\fR is the same as \fB\-\-pppd\-use\-peerdns=\fI0\fR.
 .TP
 \fB\-\-pppd\-log=\fI<file>\fR
 Set pppd in debug mode and save its logs into \fI<file>\fR.

--- a/src/main.c
+++ b/src/main.c
@@ -31,13 +31,14 @@
 
 #if HAVE_USR_SBIN_PPPD
 #define PPPD_USAGE \
-"                    [--pppd-no-peerdns] [--pppd-log=<file>]\n" \
+"                    [--pppd-use-peerdns=<0|1>] [--pppd-log=<file>]\n" \
 "                    [--pppd-ifname=<string>] [--pppd-ipparam=<string>]\n" \
 "                    [--pppd-call=<name>] [--pppd-plugin=<file>]\n"
 
 #define PPPD_HELP \
-"  --pppd-no-peerdns             Do not ask peer ppp server for DNS server addresses\n" \
-"                                and do not make pppd rewrite /etc/resolv.conf,\n" \
+"  --pppd-use-peerdns=[01]       Whether to ask peer ppp server for DNS server\n" \
+"                                addresses and make pppd rewrite /etc/resolv.conf.\n" \
+"  --pppd-no-peerdns             Same as --pppd-use-peerdns=0. Neiter pppd\n" \
 "                                nor openfortivpn will modify DNS resolution then.\n" \
 "  --pppd-log=<file>             Set pppd in debug mode and save its logs into\n" \
 "                                <file>.\n" \
@@ -211,6 +212,7 @@ int main(int argc, char **argv)
 		{"insecure-ssl",    no_argument, &cli_cfg.insecure_ssl, 1},
 		{"cipher-list",     required_argument, 0, 0},
 #if HAVE_USR_SBIN_PPPD
+		{"pppd-use-peerdns", required_argument, 0, 0},
 		{"pppd-no-peerdns", no_argument, &cli_cfg.pppd_use_peerdns, 0},
 		{"pppd-log",        required_argument, 0, 0},
 		{"pppd-plugin",     required_argument, 0, 0},
@@ -250,6 +252,17 @@ int main(int argc, char **argv)
 				goto exit;
 			}
 #if HAVE_USR_SBIN_PPPD
+			if (strcmp(long_options[option_index].name,
+			           "pppd-use-peerdns") == 0) {
+				int pppd_use_peerdns = strtob(optarg);
+				if (pppd_use_peerdns < 0) {
+					log_warn("Bad pppd-use-peerdns option: \"%s\"\n",
+					         optarg);
+					break;
+				}
+				cli_cfg.pppd_use_peerdns = pppd_use_peerdns;
+				break;
+			}
 			if (strcmp(long_options[option_index].name,
 			           "pppd-log") == 0) {
 				cli_cfg.pppd_log = strdup(optarg);


### PR DESCRIPTION
In the config file we accept pppd-use-peerdns whereas on the command line only --pppd-no-peerdns is allowed. Usually we have the "--no-xy" options as an alias for a similar "--xy=0" option.
Maybe this helps to clarify the confusion around the dns options?