### PR TITLE
openfortivpn version 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ Releases
 This high level changelog is usually updated when a release is tagged.
 On the master branch there may be changes that are not (yet) described here.
 
+### 1.9.0
+
+* [+] update of the man page, especially about the dns settings
+* [+] improved configure output: show detected paths for use at runtime
+* [-] correctly convert parsed values, fix for an issue e.g. on Raspbian
+* [+] make search string for the otp-prompt configurable
+* [+] add an option to specify a configurable delay during otp authentication
+* [~] make the options that control usepeerdns more consistent
+
 ### 1.8.1
 
 * [~] Support longer passowrds by allocation of a larger buffer

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
-AC_INIT([openfortivpn], [1.8.1])
+AC_INIT([openfortivpn], [1.9.0])
 AC_CONFIG_SRCDIR([src/main.c])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 


### PR DESCRIPTION
time to tag a new release?

first I had in mind to tag 1.8.2 with the latest fixes and documentation updates, but when putting together the high level changelog I have noticed that most of the commits contained at least a new command line option or an improvement of an existing feature.  Therefore, we should make it the 1.9.0 release, even though it doesn't contain a very exciting new feature.

Of course we could wait for something, but at least I don't have big things in the queue at the moment.