### PR TITLE
userinput: add capability of spawning a helper to get a secret

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -34,6 +34,7 @@ const struct vpn_config invalid_cfg = {
 	.otp = {'\0'},
 	.otp_prompt = NULL,
 	.otp_delay = -1,
+	.pinentry = NULL,
 	.realm = {'\0'},
 	.set_routes = -1,
 	.set_dns = -1,
@@ -218,6 +219,9 @@ int load_config(struct vpn_config *cfg, const char *filename)
 				continue;
 			}
 			cfg->otp_delay = otp_delay;
+		} else if (strcmp(key, "pinentry") == 0) {
+			free(cfg->pinentry);
+			cfg->pinentry = strdup(val);
 		} else if (strcmp(key, "realm") == 0) {
 			strncpy(cfg->realm, val, FIELD_SIZE - 1);
 			cfg->realm[FIELD_SIZE] = '\0';
@@ -344,6 +348,7 @@ void destroy_vpn_config(struct vpn_config *cfg)
 {
 	free(cfg->password);
 	free(cfg->otp_prompt);
+	free(cfg->pinentry);
 #if HAVE_USR_SBIN_PPPD
 	free(cfg->pppd_log);
 	free(cfg->pppd_plugin);
@@ -379,6 +384,10 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 		strcpy(dst->otp, src->otp);
 	if (src->otp_delay != invalid_cfg.otp_delay)
 		dst->otp_delay = src->otp_delay;
+	if (src->pinentry) {
+		free(dst->pinentry);
+		dst->pinentry = src->pinentry;
+	}
 	if (src->realm[0])
 		strcpy(dst->realm, src->realm);
 	if (src->set_routes != invalid_cfg.set_routes)

--- a/src/config.h
+++ b/src/config.h
@@ -68,6 +68,7 @@ struct vpn_config {
 	char		otp[FIELD_SIZE + 1];
 	char		*otp_prompt;
 	unsigned int  otp_delay;
+	char		*pinentry;
 	char		realm[FIELD_SIZE + 1];
 
 	int	set_routes;

--- a/src/http.c
+++ b/src/http.c
@@ -500,7 +500,8 @@ int try_otp_auth(
 			size_t l;
 			v = NULL;
 			if (cfg->otp[0] == '\0') {
-				read_password(cfg->pinentry, p, cfg->otp, FIELD_SIZE);
+				read_password(cfg->pinentry, "otp",
+				              p, cfg->otp, FIELD_SIZE);
 				if (cfg->otp[0] == '\0') {
 					log_error("No OTP specified\n");
 					return 0;
@@ -611,7 +612,7 @@ int auth_log_in(struct tunnel *tunnel)
 		get_value_from_response(res, "polid=", polid, 32);
 
 		if (cfg->otp[0] == '\0') {
-			read_password(cfg->pinentry,
+			read_password(cfg->pinentry, "otp",
 			              "Two-factor authentication token: ",
 			              cfg->otp, FIELD_SIZE);
 			if (cfg->otp[0] == '\0') {

--- a/src/http.c
+++ b/src/http.c
@@ -500,7 +500,7 @@ int try_otp_auth(
 			size_t l;
 			v = NULL;
 			if (cfg->otp[0] == '\0') {
-				read_password(p, cfg->otp, FIELD_SIZE);
+				read_password(cfg->pinentry, p, cfg->otp, FIELD_SIZE);
 				if (cfg->otp[0] == '\0') {
 					log_error("No OTP specified\n");
 					return 0;
@@ -611,7 +611,8 @@ int auth_log_in(struct tunnel *tunnel)
 		get_value_from_response(res, "polid=", polid, 32);
 
 		if (cfg->otp[0] == '\0') {
-			read_password("Two-factor authentication token: ",
+			read_password(cfg->pinentry,
+			              "Two-factor authentication token: ",
 			              cfg->otp, FIELD_SIZE);
 			if (cfg->otp[0] == '\0') {
 				log_error("No token specified\n");

--- a/src/main.c
+++ b/src/main.c
@@ -61,6 +61,7 @@
 
 #define usage \
 "Usage: openfortivpn [<host>[:<port>]] [-u <user>] [-p <pass>]\n" \
+"                    [--pinentry=<program>]\n" \
 "                    [--realm=<realm>] [--otp=<otp>] [--otp-delay=<delay>]\n" \
 "                    [--otp-prompt=<prompt>] [--set-routes=<0|1>]\n" \
 "                    [--half-internet-routes=<0|1>] [--set-dns=<0|1>]\n" \
@@ -91,6 +92,7 @@ PPPD_USAGE \
 "  -o <otp>, --otp=<otp>         One-Time-Password.\n" \
 "  --otp-prompt=<prompt>         Search for the otp prompt starting with this string\n" \
 "  --otp-delay=<delay>	         Wait <delay> seconds before sending the OTP.\n" \
+"  --pinentry=<program>          Use the program to supply a secret instead of asking for it\n" \
 "  --realm=<realm>               Use specified authentication realm on VPN gateway\n" \
 "                                when tunnel is up.\n" \
 "  --set-routes=[01]             Set if openfortivpn should configure output routes through\n" \
@@ -162,6 +164,7 @@ int main(int argc, char **argv)
 		.otp = {'\0'},
 		.otp_prompt = NULL,
 		.otp_delay = 0,
+		.pinentry = NULL,
 		.realm = {'\0'},
 		.set_routes = 1,
 		.set_dns = 1,
@@ -192,6 +195,7 @@ int main(int argc, char **argv)
 		{"help",            no_argument,       0, 'h'},
 		{"version",         no_argument,       0, 0},
 		{"config",          required_argument, 0, 'c'},
+		{"pinentry",        required_argument, 0, 0},
 		{"realm",           required_argument, 0, 0},
 		{"username",        required_argument, 0, 'u'},
 		{"password",        required_argument, 0, 'p'},
@@ -316,6 +320,11 @@ int main(int argc, char **argv)
 			if (strcmp(long_options[option_index].name,
 			           "user-key") == 0) {
 				cli_cfg.user_key = strdup(optarg);
+				break;
+			}
+			if (strcmp(long_options[option_index].name,
+			           "pinentry") == 0) {
+				cli_cfg.pinentry = strdup(optarg);
 				break;
 			}
 			if (strcmp(long_options[option_index].name,
@@ -477,7 +486,8 @@ int main(int argc, char **argv)
 	if (cfg.password == NULL || cfg.password[0] == '\0') {
 		free(cfg.password);
 		char *tmp_password = malloc(PWD_BUFSIZ); // allocate large buffer
-		read_password("VPN account password: ", tmp_password, PWD_BUFSIZ);
+		read_password(cfg.pinentry, "VPN account password: ",
+		              tmp_password, PWD_BUFSIZ);
 		cfg.password = strdup(tmp_password); // copy string of correct size
 		free(tmp_password);
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -486,8 +486,8 @@ int main(int argc, char **argv)
 	if (cfg.password == NULL || cfg.password[0] == '\0') {
 		free(cfg.password);
 		char *tmp_password = malloc(PWD_BUFSIZ); // allocate large buffer
-		read_password(cfg.pinentry, "VPN account password: ",
-		              tmp_password, PWD_BUFSIZ);
+		read_password(cfg.pinentry, "password",
+		              "VPN account password: ", tmp_password, PWD_BUFSIZ);
 		cfg.password = strdup(tmp_password); // copy string of correct size
 		free(tmp_password);
 	}

--- a/src/userinput.h
+++ b/src/userinput.h
@@ -20,6 +20,6 @@
 
 #include <sys/types.h>
 
-void read_password(const char *prompt, char *pass, size_t len);
+void read_password(const char *pinentry, const char *prompt, char *pass, size_t len);
 
 #endif

--- a/src/userinput.h
+++ b/src/userinput.h
@@ -20,6 +20,7 @@
 
 #include <sys/types.h>
 
-void read_password(const char *pinentry, const char *prompt, char *pass, size_t len);
+void read_password(const char *pinentry, const char *hint,
+                   const char *prompt, char *pass, size_t len);
 
 #endif


### PR DESCRIPTION
This adds the --pinentry option that allows passing a name of a program
that can supply a password. This is going to be useful in order to relay
the password requestes to the NetworkManager plugin.

The protocol used is compatible with what GnuPG's pinentry program uses
(documented in pinentry GNU Info manual), so that this could be tested
or used without the NetworkManager plugin.