### PR TITLE
Connect to old TLSv1.0 software - override new openssl defaults.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -25,6 +25,7 @@
 #include <sys/stat.h>
 #include <limits.h>
 #include <openssl/tls1.h>
+#include <openssl/x509.h.h>  /* work around OpenSSL bug, missing STACK_OF definition */
 
 const struct vpn_config invalid_cfg = {
 	.gateway_host = {'\0'},

--- a/src/config.c
+++ b/src/config.c
@@ -133,8 +133,8 @@ int parse_min_tls(const char *str)
 	case '2':
 		return TLS1_2_VERSION;
 #if OPENSSL_VERSION_NUMBER < 0x020000000L
-	/* 
-	 * libressl uses version numbers starting with major version 2 
+	/*
+	 * libressl uses version numbers starting with major version 2
 	 * but does not yet support TLS 1.3
 	 */
 	case '3':

--- a/src/config.c
+++ b/src/config.c
@@ -132,8 +132,14 @@ int parse_min_tls(const char *str)
 		return TLS1_1_VERSION;
 	case '2':
 		return TLS1_2_VERSION;
+#if OPENSSL_VERSION_NUMBER < 0x020000000L
+	/* 
+	 * libressl uses version numbers starting with major version 2 
+	 * but does not yet support TLS 1.3
+	 */
 	case '3':
 		return TLS1_3_VERSION;
+#endif
 #endif
 	default:
 		return -1;

--- a/src/config.c
+++ b/src/config.c
@@ -24,7 +24,7 @@
 #include <ctype.h>
 #include <sys/stat.h>
 #include <limits.h>
-
+#include <openssl/tls1.h>
 
 const struct vpn_config invalid_cfg = {
 	.gateway_host = {'\0'},
@@ -57,6 +57,8 @@ const struct vpn_config invalid_cfg = {
 	.user_key = NULL,
 	.insecure_ssl = -1,
 	.cipher_list = NULL,
+	.min_tls = -1,
+	.seclevel_1 = -1,
 	.cert_whitelist = NULL
 };
 
@@ -108,6 +110,33 @@ int strtob(const char *str)
 	if (i < 0 || i > 1)
 		return -1;
 	return i;
+}
+
+/*
+ * Converts string to tls version
+ *
+ * @params[in] str  the string to read from
+ * @return          openssl version or -1
+ */
+int parse_min_tls(const char *str)
+{
+	if (str[0] != '1' || str[1] != '.' || str[2] == 0 || str[3] != 0) {
+		return -1;
+	}
+	switch (str[2]) {
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	case '0':
+		return TLS1_VERSION;
+	case '1':
+		return TLS1_1_VERSION;
+	case '2':
+		return TLS1_2_VERSION;
+	case '3':
+		return TLS1_3_VERSION;
+#endif
+	default:
+		return -1;
+	}
 }
 
 /*
@@ -328,6 +357,25 @@ int load_config(struct vpn_config *cfg, const char *filename)
 		} else if (strcmp(key, "cipher-list") == 0) {
 			free(cfg->cipher_list);
 			cfg->cipher_list = strdup(val);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+		} else if (strcmp(key, "min-tls") == 0) {
+			int min_tls = parse_min_tls(val);
+			if (min_tls == -1) {
+				log_warn("Bad min-tls in config file: \"%s\".\n",
+				         val);
+				continue;
+			} else {
+				cfg->min_tls = min_tls;
+			}
+#endif
+		} else if (strcmp(key, "seclevel-1") == 0) {
+			int seclevel_1 = strtob(val);
+			if (seclevel_1 < 0) {
+				log_warn("Bad seclevel-1 in config file: \"%s\".\n",
+				         val);
+				continue;
+			}
+			cfg->seclevel_1 = seclevel_1;
 		} else {
 			log_warn("Bad key in config file: \"%s\".\n", key);
 			goto err_free;
@@ -448,6 +496,11 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 		free(dst->cipher_list);
 		dst->cipher_list = src->cipher_list;
 	}
+	if (src->min_tls > 0) {
+		dst->min_tls = src->min_tls;
+	}
+	if (src->seclevel_1 != invalid_cfg.seclevel_1)
+		dst->seclevel_1 = src->seclevel_1;
 	if (src->cert_whitelist) {
 		while (dst->cert_whitelist != NULL) {
 			struct x509_digest *tmp = dst->cert_whitelist->next;

--- a/src/config.c
+++ b/src/config.c
@@ -24,8 +24,8 @@
 #include <ctype.h>
 #include <sys/stat.h>
 #include <limits.h>
+#include <openssl/x509.h>  /* work around OpenSSL bug: missing definition of STACK_OF */
 #include <openssl/tls1.h>
-#include <openssl/x509.h.h>  /* work around OpenSSL bug, missing STACK_OF definition */
 
 const struct vpn_config invalid_cfg = {
 	.gateway_host = {'\0'},

--- a/src/config.h
+++ b/src/config.h
@@ -94,12 +94,15 @@ struct vpn_config {
 	char			*user_cert;
 	char			*user_key;
 	int			insecure_ssl;
+	int			min_tls;
+	int			seclevel_1;
 	char			*cipher_list;
 	struct x509_digest	*cert_whitelist;
 };
 
 int add_trusted_cert(struct vpn_config *cfg, const char *digest);
 int strtob(const char *str);
+int parse_min_tls(const char *str);
 
 int load_config(struct vpn_config *cfg, const char *filename);
 void destroy_vpn_config(struct vpn_config *cfg);


### PR DESCRIPTION
Openssl 1.1 sets min tls version to 1.2. This prevents me to connect to fortivpn at my work.
I do not want to fiddle with system defaults, thus I added min_tls option. And then I added
seclevel-1 option, because I realised, that compiled-in list of ciphers is sufficient for me.

Inspired by similar wpa_supplicant bug, triggered by libssl1.1
  https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=907518#95
  https://w1.fi/cgit/hostap/commit/?id=cc9c4feccc5588137f66c40a4a6729476556853e