### PR TITLE
suppress cleartext password in debug detail output

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -39,11 +39,12 @@ struct log_param_s {
 	int syslog_prio;
 };
 
-static const struct log_param_s log_params[OFV_LOG_DEBUG_DETAILS + 1] = {
+static const struct log_param_s log_params[OFV_LOG_DEBUG_ALL + 1] = {
 	{ "        ", "",           LOG_ERR},
 	{ "ERROR:  ", "\033[0;31m", LOG_ERR},
 	{ "WARN:   ", "\033[0;33m", LOG_WARNING},
 	{ "INFO:   ", "",           LOG_INFO},
+	{ "DEBUG:  ", "\033[0;90m", LOG_DEBUG},
 	{ "DEBUG:  ", "\033[0;90m", LOG_DEBUG},
 	{ "DEBUG:  ", "\033[0;90m", LOG_DEBUG},
 };
@@ -71,7 +72,7 @@ void set_syslog(int use_syslog)
 
 void increase_verbosity(void)
 {
-	if (loglevel < OFV_LOG_DEBUG_DETAILS)
+	if (loglevel < OFV_LOG_DEBUG_ALL)
 		loglevel++;
 }
 void decrease_verbosity(void)
@@ -88,7 +89,7 @@ void do_log(int verbosity, const char *format, ...)
 	pthread_mutex_lock(&mutex);
 
 	// Use sane default if wrong verbosity specified
-	if (verbosity > OFV_LOG_DEBUG_DETAILS || verbosity < 0)
+	if (verbosity > OFV_LOG_DEBUG_ALL || verbosity < 0)
 		verbosity = OFV_LOG_MUTE;
 	lp = &log_params[verbosity];
 

--- a/src/log.h
+++ b/src/log.h
@@ -28,7 +28,8 @@ enum log_verbosity {
 	OFV_LOG_WARN  = 2,
 	OFV_LOG_INFO  = 3,
 	OFV_LOG_DEBUG = 4,
-	OFV_LOG_DEBUG_DETAILS = 5
+	OFV_LOG_DEBUG_DETAILS = 5,
+	OFV_LOG_DEBUG_ALL = 6
 };
 
 extern enum log_verbosity loglevel;
@@ -57,6 +58,8 @@ void do_log(int verbosity, const char *format, ...);
 	log_level(OFV_LOG_DEBUG, __VA_ARGS__)
 #define log_debug_details(...) \
 	log_level(OFV_LOG_DEBUG_DETAILS, __VA_ARGS__)
+#define log_debug_all(...) \
+	log_level(OFV_LOG_DEBUG_ALL, __VA_ARGS__)
 
 #define log_packet(...) \
 	do { \

--- a/src/main.c
+++ b/src/main.c
@@ -501,7 +501,7 @@ int main(int argc, char **argv)
 	log_debug("Config realm = \"%s\"\n", cfg.realm);
 	log_debug("Config port = \"%d\"\n", cfg.gateway_port);
 	log_debug("Config username = \"%s\"\n", cfg.username);
-	log_debug("Config password = \"%s\"\n", "********");
+	log_debug_all("Config password = \"%s\"\n", cfg.password);
 	if (cfg.otp[0] != '\0')
 		log_debug("One-time password = \"%s\"\n", cfg.otp);
 


### PR DESCRIPTION
...and introduce another log level "debug all" to even show the password
for debugging encoding stuff. Currently only the password is cleared,
otp, cookie and perhaps other information during the authentication
process is considered less critical.