### PR TITLE
work around EAGAIN issue on FreeBSD

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -330,7 +330,8 @@ static void *pppd_write(void *arg)
 			}
 			n = write(tunnel->pppd_pty, &hdlc_buffer[written],
 			          len - written);
-			// sometimes write() even returns EAGAIN after a successful select()
+			// sometimes write() even returns EAGAIN 
+			// even after a successful select()
 			if ((n == -1) && (errno != EAGAIN)) {
 				log_error("write: %s\n", strerror(errno));
 				goto err_free_buf;

--- a/src/io.c
+++ b/src/io.c
@@ -330,7 +330,8 @@ static void *pppd_write(void *arg)
 			}
 			n = write(tunnel->pppd_pty, &hdlc_buffer[written],
 			          len - written);
-			if (n == -1) {
+			// sometimes write() even returns EAGAIN after a successful select()
+			if ((n == -1) && (errno != EAGAIN)) {
 				log_error("write: %s\n", strerror(errno));
 				goto err_free_buf;
 			}

--- a/src/io.c
+++ b/src/io.c
@@ -330,8 +330,7 @@ static void *pppd_write(void *arg)
 			}
 			n = write(tunnel->pppd_pty, &hdlc_buffer[written],
 			          len - written);
-			// sometimes write() even returns EAGAIN 
-			// even after a successful select()
+			// retry on repeatable failure
 			if ((n == -1) && (errno != EAGAIN)) {
 				log_error("write: %s\n", strerror(errno));
 				goto err_free_buf;


### PR DESCRIPTION
FreeBSD seems to have the issue that `write()` can return `EAGAIN` even when an immediately preceding `select()` indicated a writable socket.

Work around this issue by retrying.

Note that this creates a potential busy loop around failing `write()`, which this change does nothing to avoid.