### PR TITLE
configure.ac: rt_dst: don't run tests when option is passed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -216,6 +216,16 @@ CPPFLAGS="${save_openssl_CPPFLAGS}"
 LIBS="${save_openssl_LIBS}"
 
 # Specialised checks for particular features.
+# When cross compile, don't run the tests.
+AC_ARG_WITH([rt_dst],
+	AS_HELP_STRING([--with-rt_dst],
+			  [disable rtentry with rt_dst testing (for linux target when cross compile)]),
+	AS_IF([test "x$with_rt_dst" = "xyes"],[
+	AC_MSG_NOTICE([HAVE_RT_ENTRY_WITH_RT_DST... 1])
+	AC_DEFINE(HAVE_RT_ENTRY_WITH_RT_DST)
+	])
+)
+AS_IF([test "x$with_rt_dst" = "x" ], [
 AC_MSG_CHECKING(whether rtentry is available and has rt_dst )
 AC_TRY_RUN([
 #include <sys/types.h>
@@ -233,6 +243,7 @@ int main() {
   AC_DEFINE(HAVE_RT_ENTRY_WITH_RT_DST)
   AC_MSG_RESULT(yes)
 ], AC_MSG_RESULT(no) )
+])
 
 NETSTAT_PATH=""
 PPP_PATH=""

--- a/configure.ac
+++ b/configure.ac
@@ -302,7 +302,7 @@ AC_CHECK_FILE([/proc/net/route],[
 
 # check for ppp user space client if not specified
 AC_PATH_PROG(PPP, [ppp], [/usr/sbin/ppp], "$PATH:/sbin:/usr/sbin")
-AS_IF([test "x$PPP" = "x" ], [
+AS_IF([test "x$PPP_PATH" = "x" ], [
 AC_CHECK_FILE([$PPP], [
   AS_IF([test "x$PPP_PATH" = "x" ], [
     PPP_PATH="$PPP"
@@ -314,7 +314,7 @@ AC_CHECK_FILE([$PPP], [
 ])
 # check for pppd if not specified
 AC_PATH_PROG(PPPD, [pppd], [/usr/sbin/pppd], "$PATH:/sbin:/usr/sbin")
-AS_IF([test "x$PPPD" = "x" ], [
+AS_IF([test "x$PPP_PATH" = "x" ], [
 AC_CHECK_FILE([$PPPD], [
   AS_IF([test "x$PPP_PATH" = "x" ], [
     PPP_PATH="$PPPD"


### PR DESCRIPTION
when cross compile, running tests will always fail, don't run them when
the option is passed

Signed-off-by: Lucian Cristian <lucian.cristian@gmail.com>