### PR TITLE
fix openssl 1.1.x compatibility issues (#448)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -132,7 +132,7 @@ int parse_min_tls(const char *str)
 		return TLS1_1_VERSION;
 	case '2':
 		return TLS1_2_VERSION;
-#if OPENSSL_VERSION_NUMBER < 0x020000000L
+#ifdef TLS1_3_VERSION
 	/*
 	 * libressl uses version numbers starting with major version 2
 	 * but does not yet support TLS 1.3

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -55,6 +55,11 @@
 #include <systemd/sd-daemon.h>
 #endif
 
+// we use this constant in the source, so define a fallback if not defined
+#ifndef OPENSSL_API_COMPAT
+#define OPENSSL_API_COMPAT 0x0908000L
+#endif
+
 struct ofv_varr {
 	unsigned cap;		// current capacity
 	unsigned off;		// next slot to write, always < max(cap - 1, 1)
@@ -720,10 +725,13 @@ int ssl_connect(struct tunnel *tunnel)
 	if (tunnel->ssl_socket == -1)
 		return 1;
 
+	// registration is deprecated from openssl 1.1.0 onwards
+#if OPENSSL_API_COMPAT < 0x10100000L
 	// Register the error strings for libcrypto & libssl
 	SSL_load_error_strings();
 	// Register the available ciphers and digests
 	SSL_library_init();
+#endif
 
 	tunnel->ssl_context = SSL_CTX_new(SSLv23_client_method());
 	if (tunnel->ssl_context == NULL) {


### PR DESCRIPTION
starting with openssl 1.1.0 the library and error strings are
initialized automatically and no explicit initialization is needed anymore

in openssl 1.1.0 tls 1.3 is not yet present, so instead of comparing
version numbers it's better just to check if TLS1_3_VERSION is defined