### PR TITLE
fix (http request): pass single space as-is

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -43,10 +43,8 @@ static void url_encode(char *dest, const char *str)
 {
 	while (*str != '\0') {
 		if (isalnum(*str) || *str == '-' || *str == '_'
-		    || *str == '.' || *str == '~')
+		    || *str == '.' || *str == '~' || *str == ' ')
 			*dest++ = *str;
-		else if (*str == ' ')
-			*dest++ = '+';
 		else {
 			static const char hex[] = "0123456789ABCDEF";
 


### PR DESCRIPTION
#351 : a very dumb fix.

I am sure I am not the first one to think about this but I was facing the same issue where my username at work has a space in it. I tried by passing space as-is and it actually worked for me. I could create the tunnel!

Please feel free to close etc. if need be.