### PR TITLE
Fix Coverity defects

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -231,7 +231,7 @@ int load_config(struct vpn_config *cfg, const char *filename)
 		} else if (strcmp(key, "port") == 0) {
 			unsigned long int port = strtoul(val, NULL, 0);
 			if (port <= 0 || port > 65535) {
-				log_warn("Bad port in config file: \"%d\".\n",
+				log_warn("Bad port in config file: \"%lu\".\n",
 				         port);
 				continue;
 			}

--- a/src/io.c
+++ b/src/io.c
@@ -205,7 +205,7 @@ static void *pppd_read(void *arg)
 			log_error("read: %s\n", strerror(errno));
 			break;
 		} else if (n == 0) {
-			log_warn("read returned %d\n", n);
+			log_warn("read returned %ld\n", n);
 			continue;
 		} else if (first_time) {
 			// pppd did talk, now we can write to it if we want
@@ -253,7 +253,7 @@ static void *pppd_read(void *arg)
 			packet = repacket;
 			packet->len = pktsize;
 
-			log_debug("%s ---> gateway (%d bytes)\n", PPP_DAEMON,
+			log_debug("%s ---> gateway (%lu bytes)\n", PPP_DAEMON,
 			          packet->len);
 #if HAVE_USR_SBIN_PPPD
 			log_packet("pppd:   ", packet->len, pkt_data(packet));
@@ -463,7 +463,7 @@ static void *ssl_read(void *arg)
 			goto exit;
 		}
 
-		log_debug("gateway ---> %s (%d bytes)\n", PPP_DAEMON, packet->len);
+		log_debug("gateway ---> %s (%lu bytes)\n", PPP_DAEMON, packet->len);
 		log_packet("gtw:    ", packet->len, pkt_data(packet));
 		pool_push(&tunnel->ssl_to_pty_pool, packet);
 

--- a/src/main.c
+++ b/src/main.c
@@ -473,7 +473,7 @@ int main(int argc, char **argv)
 	if (cli_cfg.password != NULL && cli_cfg.password[0] != '\0')
 		log_warn("You should not pass the password on the command line. Type it interactively or use a config file instead.\n");
 
-	log_debug("openfortivpn " VERSION "\n", config_file);
+	log_debug("openfortivpn " VERSION "\n");
 
 	// Load config file
 	if (config_file[0] != '\0') {

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -545,7 +545,7 @@ static int tcp_connect(struct tunnel *tunnel)
 			 */
 			ssize_t bytes_read = read(handle, &(request[j]), 1);
 			if (bytes_read < 1) {
-				log_error("Proxy response is unexpectedly large and cannot fit in the %d-bytes buffer.\n",
+				log_error("Proxy response is unexpectedly large and cannot fit in the %lu-bytes buffer.\n",
 				          ARRAY_SIZE(request));
 				goto err_proxy_response;
 			}


### PR DESCRIPTION
Defects detected by the new Coverity Build Tool version 2019.03:

CID 349824: Invalid type in argument to printf format specifier (PRINTF_ARGS)
	invalid_type: Argument packet->len to format specifier %d was expected
	to have type int but has type unsigned long.

CID 349825: Extra argument to printf format specifier (PRINTF_ARGS)
	extra_argument: This argument was not used by the format string:
	config_file.

CID 349827: Invalid type in argument to printf format specifier (PRINTF_ARGS)
	invalid_type: Argument port to format specifier %d was expected to have
	type int but has type unsigned long.

CID 349828: Invalid type in argument to printf format specifier (PRINTF_ARGS)
	invalid_type: Argument 128UL to format specifier %d was expected to
	have type int but has type unsigned long.

CID 349830: Invalid type in argument to printf format specifier (PRINTF_ARGS)
        invalid_type: Argument n to format specifier %d was expected to have
        type int but has type long.

CID 349833: Invalid type in argument to printf format specifier (PRINTF_ARGS)
	invalid_type: Argument packet->len to format specifier %d was expected
	to have type int but has type unsigned long.