### PR TITLE
Fix Coverity defects

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -166,6 +166,7 @@ static int pppd_run(struct tunnel *tunnel)
 
 	if (pid == -1) {
 		log_error("forkpty: %s\n", strerror(errno));
+		close(slave_stderr);
 		return 1;
 	} else if (pid == 0) { // child process
 
@@ -250,7 +251,6 @@ static int pppd_run(struct tunnel *tunnel)
 		fprintf(stderr, "execvp: %s\n", strerror(errno));
 		_exit(EXIT_FAILURE);
 	}
-	close(slave_stderr);
 
 	// Set non-blocking
 	int flags = fcntl(amaster, F_GETFL, 0);


### PR DESCRIPTION
Defects detected by the new Coverity Build Tool version 2019.03:

CID 349818: Resource leak (RESOURCE_LEAK)
	7. leaked_handle: Handle variable slave_stderr going out
	of scope leaks the handle.

CID 349820: Resource leak (RESOURCE_LEAK)
	49. leaked_storage: Variable buffer going out of scope
	leaks the storage it points to.

CID 349826: Resource leak (RESOURCE_LEAK)
	17. leaked_handle: Handle variable fd going out of scope
	leaks the handle.

CID 349831: Resource leak (RESOURCE_LEAK)
	32. leaked_storage: Variable buffer going out of scope
	leaks the storage it points to.