### PR TITLE
Fix Coverity defects

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -351,7 +351,7 @@ int load_config(struct vpn_config *cfg, const char *filename)
 		} else if (strcmp(key, "user-cert") == 0) {
 			free(cfg->user_cert);
 			cfg->user_cert = strdup(val);
-			if (strncmp(strdup(val), "pkcs11:", 7) == 0)
+			if (strncmp(cfg->user_cert, "pkcs11:", 7) == 0)
 				cfg->use_engine = 1;
 		} else if (strcmp(key, "user-key") == 0) {
 			free(cfg->user_key);


### PR DESCRIPTION
Defects detected by the new Coverity Build Tool version 2019.03:

CID 349834: Resource leak (RESOURCE_LEAK)
	62. leaked_storage: Failing to save or free storage
	allocated by strdup(val) leaks it.