### PR TITLE
Fix Coverity defects

### DIFF
--- a/src/userinput.c
+++ b/src/userinput.c
@@ -153,6 +153,7 @@ static int pinentry_exchange(int to, int from, char **retstr,
 	if (vdprintf(to, format, ap) == 0) {
 		if (retstr)
 			*retstr = strdup(strerror(errno));
+		va_end(ap);
 		return -1;
 	}
 	va_end(ap);


### PR DESCRIPTION
Defects detected by the new Coverity Build Tool version 2019.03:

CID 349821: Missing varargs init or cleanup (VARARGS)
	4. missing_va_end: va_end was not called for ap.