### PR TITLE
support dns-suffix feature

### DIFF
--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -91,12 +91,14 @@ Set if openfortivpn should add two 0.0.0.0/1 and 128.0.0.0/1 routes with
 higher priority instead of replacing the default route.
 .TP
 \fB\-\-set\-dns=\fI<bool>\fR, \fB\-\-no\-dns\fR
-Set if openfortivpn should add VPN nameservers in /etc/resolv.conf when
+Set if openfortivpn should add DNS name servers in /etc/resolv.conf when
 tunnel is up. If used multiple times, the last one takes priority.
 This option requires that the DNS entries are requested from the peer.
 So, \fB\-\-pppd\-no\-peerdns\fR conflicts with \fB\-\-set\-dns=\fI1\fR.
 Note that there may be other mechanisms to update /etc/resolv.conf
 which may require that openfortivpn is called with \fB\-\-no\-dns\fR.
+Also a dns\-suffix may be received from the peer and added to
+/etc/resolv.conf in the turn of adding the name servers.
 
 \fB\-\-no\-dns\fR is the same as \fB\-\-set\-dns=\fI0\fR.
 .TP

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -1,4 +1,4 @@
-.TH OPENFORTIVPN 1 "March 12, 2019" ""
+.TH OPENFORTIVPN 1 "October 24, 2019" ""
 
 .SH NAME
 openfortivpn \- Client for PPP+SSL VPN tunnel services
@@ -93,9 +93,8 @@ higher priority instead of replacing the default route.
 \fB\-\-set\-dns=\fI<bool>\fR, \fB\-\-no\-dns\fR
 Set if openfortivpn should add DNS name servers in /etc/resolv.conf when
 tunnel is up. If used multiple times, the last one takes priority.
-This option requires that the DNS entries are requested from the peer.
-So, \fB\-\-pppd\-no\-peerdns\fR conflicts with \fB\-\-set\-dns=\fI1\fR.
-Note that there may be other mechanisms to update /etc/resolv.conf
+Note that there may be other mechanisms to update /etc/resolv.conf,
+e.g., \fB\-\-pppd\-use\-peerdns\fR in conjunction with an ip-up-script,
 which may require that openfortivpn is called with \fB\-\-no\-dns\fR.
 Also a dns\-suffix may be received from the peer and added to
 /etc/resolv.conf in the turn of adding the name servers.
@@ -150,12 +149,9 @@ $ openssl s_client -connect \fI<host:port>\fR
 (default: HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4)
 .TP
 \fB\-\-use\-peer\-dns=\fI<bool>\fR, \fB\-\-pppd\-no\-peerdns\fR
-Whether to ask peer ppp server for DNS server addresses and do not make pppd
-rewrite /etc/resolv.conf. If the DNS server addresses are not requested,
-also \fB\-\-set\-dns=\fI1\fR has no effect. On the other hand, with
-\fB\-\-set\-dns=\fI0\fR, when pppd requests DNS server addresses, there
-may be other mechanisms, such as an pppd\-ip\-up-script that do the update
-of /etc/resolv.conf.
+Whether to ask peer ppp server for DNS server addresses and let pppd
+rewrite /etc/resolv.conf. If the DNS server addresses are requested,
+also \fB\-\-set\-dns=\fI1\fR may race with the mechanisms in pppd.
 
 \fB\-\-pppd\-no\-peerdns\fR is the same as \fB\-\-pppd\-use\-peerdns=\fI0\fR.
 .TP

--- a/src/http.c
+++ b/src/http.c
@@ -699,12 +699,24 @@ static int parse_xml_config(struct tunnel *tunnel, const char *buffer)
 	// Skip the HTTP header
 	buffer = strstr(buffer, "\r\n\r\n");
 
+
 	// The address of a local end of a router
 	val = xml_find('<', "assigned-addr", buffer, 1);
 	gateway = xml_get(xml_find(' ', "ipv4=", val, 1));
 	if (!gateway)
 		log_warn("No gateway address, using interface for routing\n");
 
+	// The dns search string
+	val = buffer;
+	while ((val = xml_find('<', "dns", val, 2))) {
+		if (xml_find(' ', "domain=", val, 1)) {
+			tunnel->ipv4.dns_suffix
+			        = xml_get(xml_find(' ', "domain=", val, 1));
+			log_debug("found dns suffix %s in xml config",
+			          tunnel->ipv4.dns_suffix);
+			break;
+		}
+	}
 	// Routes the tunnel wants to push
 	val = xml_find('<', "split-tunnel-info", buffer, 1);
 	while ((val = xml_find('<', "addr", val, 2))) {

--- a/src/io.c
+++ b/src/io.c
@@ -376,11 +376,13 @@ static inline void set_tunnel_ips(struct tunnel *tunnel,
 {
 	memcpy(&tunnel->ipv4.ip_addr.s_addr, &pkt_data(packet)[8],
 	       sizeof(uint32_t));
-	if (packet->len >= 18 && pkt_data(packet)[12] == 0x81) {
+	if (packet->len >= 18 && pkt_data(packet)[12] == 0x81
+	    && tunnel->config->pppd_use_peerdns) {
 		memcpy(&tunnel->ipv4.ns1_addr.s_addr, &pkt_data(packet)[14],
 		       sizeof(uint32_t));
 	}
-	if (packet->len >= 24 && pkt_data(packet)[18] == 0x83) {
+	if (packet->len >= 24 && pkt_data(packet)[18] == 0x83
+	    && tunnel->config->pppd_use_peerdns) {
 		memcpy(&tunnel->ipv4.ns2_addr.s_addr, &pkt_data(packet)[20],
 		       sizeof(uint32_t));
 	}

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -68,7 +68,10 @@ struct ipv4_config {
 
 	struct in_addr	ns1_addr;
 	struct in_addr	ns2_addr;
-	int		ns_are_new; // were ns already in /etc/resolv.conf?
+	char		*dns_suffix;
+	int		ns1_was_there;  // were ns1 already in /etc/resolv.conf?
+	int		ns2_was_there;  // were ns2 already in /etc/resolv.conf?
+	int		dns_suffix_was_there; // was the dns suffix already there?
 	int		split_routes;
 	int		route_to_vpn_is_added;
 

--- a/src/main.c
+++ b/src/main.c
@@ -38,8 +38,8 @@
 #define PPPD_HELP \
 "  --pppd-use-peerdns=[01]       Whether to ask peer ppp server for DNS server\n" \
 "                                addresses and make pppd rewrite /etc/resolv.conf.\n" \
-"  --pppd-no-peerdns             Same as --pppd-use-peerdns=0. Neither pppd\n" \
-"                                nor openfortivpn will modify DNS resolution then.\n" \
+"  --pppd-no-peerdns             Same as --pppd-use-peerdns=0. pppd will not\n" \
+"                                modify DNS resolution then.\n" \
 "  --pppd-log=<file>             Set pppd in debug mode and save its logs into\n" \
 "                                <file>.\n" \
 "  --pppd-plugin=<file>          Use specified pppd plugin instead of configuring\n" \
@@ -187,7 +187,7 @@ int main(int argc, char **argv)
 		.half_internet_routes = 0,
 		.persistent = 0,
 #if HAVE_USR_SBIN_PPPD
-		.pppd_use_peerdns = 1,
+		.pppd_use_peerdns = 0,
 		.pppd_log = NULL,
 		.pppd_plugin = NULL,
 		.pppd_ipparam = NULL,

--- a/src/main.c
+++ b/src/main.c
@@ -108,8 +108,8 @@ PPPD_USAGE \
 "  --no-routes                   Do not configure routes, same as --set-routes=0.\n" \
 "  --half-internet-routes=[01]   Add two 0.0.0.0/1 and 128.0.0.0/1 routes with higher\n" \
 "                                priority instead of replacing the default route.\n" \
-"  --set-dns=[01]                Set if openfortivpn should add VPN name servers in\n" \
-"                                /etc/resolv.conf, pppd must provide the DNS servers.\n" \
+"  --set-dns=[01]                Set if openfortivpn should add DNS name servers \n" \
+"                                and domain seach list in /etc/resolv.conf.\n" \
 "  --no-dns                      Do not reconfigure DNS, same as --set-dns=0\n" \
 "  --ca-file=<file>              Use specified PEM-encoded certificate bundle\n" \
 "                                instead of system-wide store to verify the gateway\n" \

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -947,6 +947,7 @@ int run_tunnel(struct vpn_config *config)
 		.ssl_handle = NULL,
 		.ipv4.ns1_addr.s_addr = 0,
 		.ipv4.ns2_addr.s_addr = 0,
+		.ipv4.dns_suffix = NULL,
 		.on_ppp_if_up = on_ppp_if_up,
 		.on_ppp_if_down = on_ppp_if_down
 	};

--- a/src/xml.c
+++ b/src/xml.c
@@ -68,7 +68,7 @@ const char *xml_find(char t, const char *needle, const char *buf, int nest)
  */
 char *xml_get(const char *buf)
 {
-	char val[16];	// Just enough to hold an IPv4 address
+	char val[MAX_DOMAIN_LENGTH]; // just enough to hold a domain search string
 	char quote;
 	int i;
 
@@ -82,7 +82,7 @@ char *xml_get(const char *buf)
 	for (i = 1; buf[i]; i++) {
 		if (buf[i] == quote)
 			break;
-		if (i == 16) {
+		if (i == MAX_DOMAIN_LENGTH) {
 			log_warn("Value too long in config XML\n");
 			break;
 		}

--- a/src/xml.h
+++ b/src/xml.h
@@ -18,6 +18,10 @@
 #ifndef _OPENFORTIVPN_XML_H
 #define _OPENFORTIVPN_XML_H
 
+#define MAX_DOMAIN_LENGTH 256
+// see https://unix.stackexchange.com/questions/245849
+// ... /resolv-conf-limited-to-six-domains-with-a-total-of-256-characters
+
 const char *xml_find(char t, const char *tag, const char *buf, int nest);
 char *xml_get(const char *buf);
 


### PR DESCRIPTION
currently we just prepend a search line to resolv.conf when adding nameservers
only the first nameservers take effect and only the last search statement
openfortivpn competes with pppd when manipulating that file