### PR TITLE
Release 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ Releases
 This high level changelog is usually updated when a release is tagged.
 On the master branch there may be changes that are not (yet) described here.
 
+### 1.11.0
+
+* [+] allow to connect with empty password (and with smartcard instead of username)
+* [~] properly handle manipulations of resolv.conf
+* [+] support dns-suffix feature
+* [-] several codacy fixes
+* [+] Add smartcard support with openssl-engine
+* [-] correctly shift masks for cidr notation on MAC
+* [-] one-byte fix to build with lcc compiler
+* [-] pass space character as %20 instead of encoding it as '+'
+
 ### 1.10.0
 
 * [-] fix openssl 1.1.x compatibility issues

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
-AC_INIT([openfortivpn], [1.10.0])
+AC_INIT([openfortivpn], [1.11.0])
 AC_CONFIG_SRCDIR([src/main.c])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 


### PR DESCRIPTION
I have prepared the update of  CHANGELOG.md

this PR is based on the branch for #493 and the change assumes that this PR will be merged before tagging the new release. 

We also should consider if we had enough testing. IMHO these critical changes are on the current master:
- smartcard support
- properly handle manipulations of resolv.conf (we had a first attempt of this change of behavior already)
- maybe new defects introduced by #493 because I don't know how to set up a test environment for this kind of authentication