### PR TITLE
replace semicolon by space in dns-suffix string

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -1008,11 +1008,11 @@ int ipv4_restore_routes(struct tunnel *tunnel)
 
 static inline char* replace_char(char* str, char find, char replace)
 {
-	char *current_pos = strchr(str,find);
-	while (current_pos) {
-		*current_pos = replace;
-		current_pos = strchr(current_pos,find);
-	}
+	int i;
+
+	for (i = 0; i < strlen(str); i++)
+		if (str[i] == find)
+			str[i] = replace;
 	return str;
 }
 

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -1006,6 +1006,16 @@ int ipv4_restore_routes(struct tunnel *tunnel)
 	return 0;
 }
 
+static inline char* replace_char(char* str, char find, char replace)
+{
+	char *current_pos = strchr(str,find);
+	while (current_pos) {
+		*current_pos = replace;
+		current_pos = strchr(current_pos,find);
+	}
+	return str;
+}
+
 int ipv4_add_nameservers_to_resolv_conf(struct tunnel *tunnel)
 {
 	int ret = -1;
@@ -1076,6 +1086,7 @@ int ipv4_add_nameservers_to_resolv_conf(struct tunnel *tunnel)
 	if (tunnel->ipv4.dns_suffix != NULL) {
 		strcpy(dns_suffix, "search ");
 		strncat(dns_suffix, tunnel->ipv4.dns_suffix, MAX_DOMAIN_LENGTH);
+		replace_char(dns_suffix, ';', ' ');
 	} else {
 		dns_suffix[0] = '\0';
 	}


### PR DESCRIPTION
Forticlient supports semicolon as separator in the dns-suffix and
replaces them by spaces. For consistency openfortivpn should do the same.
This solves #504.