### PR TITLE
Shell fixes

### DIFF
--- a/tests/lint/astyle.sh
+++ b/tests/lint/astyle.sh
@@ -2,7 +2,7 @@
 # Copyright (C) 2015 Adrien Vergé
 
 # Check that astyle is installed
-if ! which astyle &>/dev/null; then
+if ! command -v astyle &>/dev/null; then
   echo "error: astyle is not installed" >&2
   exit -1
 fi
@@ -20,7 +20,7 @@ for file in "$@"; do
     <"$file" >"$tmp"
 
   if ! cmp -s "$file" "$tmp"; then
-    echo "error: $file does not comply with coding style"
+    echo "error: $file does not comply with coding style" >&2
     git --no-pager diff --no-index -U0 "$file" "$tmp"
     rc=1
   fi

--- a/tests/lint/eol-at-eof.sh
+++ b/tests/lint/eol-at-eof.sh
@@ -5,12 +5,12 @@ rc=0
 
 for file in "$@"; do
   if [ "$(sed -n '$p' "$file")" = "" ]; then
-    echo "$file: too many newlines at end of file"
+    echo "$file: too many newlines at end of file" >&2
     rc=1
   fi
 
   if [ "$(tail -c 1 "$file")" != "" ]; then
-    echo "$file: no newline at end of file"
+    echo "$file: no newline at end of file" >&2
     rc=1
   fi
 done

--- a/tests/lint/run.sh
+++ b/tests/lint/run.sh
@@ -3,13 +3,10 @@
 
 rc=0
 
-bash tests/lint/eol-at-eof.sh $(git ls-files)
-[ $? -ne 0 ] && rc=1
+./tests/lint/eol-at-eof.sh $(git ls-files) || rc=1
 
-python3 tests/lint/line_length.py $(git ls-files '*.[ch]')
-[ $? -ne 0 ] && rc=1
+./tests/lint/line_length.py $(git ls-files '*.[ch]') || rc=1
 
-bash tests/lint/astyle.sh $(git ls-files '*.[ch]')
-[ $? -ne 0 ] && rc=1
+./tests/lint/astyle.sh $(git ls-files '*.[ch]') || rc=1
 
 exit $rc


### PR DESCRIPTION
Check exit code directly, not indirectly with $?.
Command which is non-standard. Use builtin 'command -v' instead.
Print error messages to stderr.