### PR TITLE
add a clear warning about sensitive information in the debug output

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -474,6 +474,8 @@ int main(int argc, char **argv)
 	if (cli_cfg.password != NULL && cli_cfg.password[0] != '\0')
 		log_warn("You should not pass the password on the command line. Type it interactively or use a config file instead.\n");
 
+	log_debug_all("ATTENTION: sensitive information like THE CLEAR TEXT PASSWORD is contained in the debug output.\n");
+
 	log_debug("openfortivpn " VERSION "\n");
 
 	// Load config file

--- a/src/main.c
+++ b/src/main.c
@@ -474,7 +474,7 @@ int main(int argc, char **argv)
 	if (cli_cfg.password != NULL && cli_cfg.password[0] != '\0')
 		log_warn("You should not pass the password on the command line. Type it interactively or use a config file instead.\n");
 
-	log_debug_all("ATTENTION: sensitive information like THE CLEAR TEXT PASSWORD is contained in the debug output.\n");
+	log_debug_all("ATTENTION: the output contains sensitive information such as the THE CLEAR TEXT PASSWORD.\n");
 
 	log_debug("openfortivpn " VERSION "\n");
 


### PR DESCRIPTION
We had another issue in which the password was disclosed. In openfortivpn we suppress it in the -vv output since #443 as a reaction on #407 and we have introduced -vvv as a new verbosity level, but now users submit -vvv debug output without a closer look, so a clear warning at the beginning of the output might help to avoid disclosure by accident.