### PR TITLE
Fix Coverity defects

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -1043,6 +1043,11 @@ int ipv4_add_nameservers_to_resolv_conf(struct tunnel *tunnel)
 		          + 20
 		          + strlen(tunnel->ppp_iface);
 		char *resolvconf_call = malloc(resolvconf_call_len);
+		if (resolvconf_call == NULL) {
+			log_warn("Could not create command to run resolvconf (%s).\n",
+			         strerror(errno));
+			return 1;
+		}
 
 		snprintf(resolvconf_call, resolvconf_call_len,
 		         "%s -a \"%s.openfortivpn\"",
@@ -1052,6 +1057,7 @@ int ipv4_add_nameservers_to_resolv_conf(struct tunnel *tunnel)
 		use_resolvconf = 1;
 		log_debug("resolvconf_call: %s\n", resolvconf_call);
 		file = popen(resolvconf_call, "w");
+		free(resolvconf_call);
 		if (file == NULL) {
 			log_warn("Could not open pipe %s (%s).\n",
 			         resolvconf_call,
@@ -1211,6 +1217,11 @@ int ipv4_del_nameservers_from_resolv_conf(struct tunnel *tunnel)
 		          + 20
 		          + strlen(tunnel->ppp_iface);
 		char *resolvconf_call = malloc(resolvconf_call_len);
+		if (resolvconf_call == NULL) {
+			log_warn("Could not create command to run resolvconf (%s).\n",
+			         strerror(errno));
+			return ERR_IPV4_SEE_ERRNO;
+		}
 
 		snprintf(resolvconf_call,
 		         resolvconf_call_len,
@@ -1221,6 +1232,7 @@ int ipv4_del_nameservers_from_resolv_conf(struct tunnel *tunnel)
 
 		log_debug("resolvconf_call: %s\n", resolvconf_call);
 		ret = system(resolvconf_call);
+		free(resolvconf_call);
 		if (ret == -1)
 			return ERR_IPV4_SEE_ERRNO;
 		return 0;


### PR DESCRIPTION
After a few weeks, the Coverity scan service is back from the dead and reporting a couple leaks:

CID 352819: Resource leak (RESOURCE_LEAK)
	leaked_storage: Variable resolvconf_call going out of scope leaks the storage it points to.

CID 352820: Resource leak (RESOURCE_LEAK)
	leaked_storage: Variable resolvconf_call going out of scope leaks the storage it points to.