### PR TITLE
free resolvconf_call after last usage

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -1057,13 +1057,14 @@ int ipv4_add_nameservers_to_resolv_conf(struct tunnel *tunnel)
 		use_resolvconf = 1;
 		log_debug("resolvconf_call: %s\n", resolvconf_call);
 		file = popen(resolvconf_call, "w");
-		free(resolvconf_call);
 		if (file == NULL) {
 			log_warn("Could not open pipe %s (%s).\n",
 			         resolvconf_call,
 			         strerror(errno));
+			free(resolvconf_call);
 			return 1;
 		}
+		free(resolvconf_call);
 	} else {
 		file = fopen("/etc/resolv.conf", "r+");
 		if (file == NULL) {


### PR DESCRIPTION
this  "Memory - illegal accesses  (USE_AFTER_FREE)" was found by coverity scan