### PR TITLE
Explicitly initialize use_engine

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -578,7 +578,7 @@ int auth_log_in(struct tunnel *tunnel)
 
 	tunnel->cookie[0] = '\0';
 
-	if (tunnel->config->use_engine
+	if (tunnel->config->use_engine > 0
 	    || (username[0] == '\0' && tunnel->config->password[0] == '\0')) {
 		snprintf(data, sizeof(data), "cert=&nup=1");
 		ret = http_request(tunnel, "GET", "/remote/login",

--- a/src/main.c
+++ b/src/main.c
@@ -204,7 +204,8 @@ int main(int argc, char **argv)
 		.min_tls = 0,
 		.seclevel_1 = 0,
 		.cipher_list = NULL,
-		.cert_whitelist = NULL
+		.cert_whitelist = NULL,
+		.use_engine = 0
 	};
 	struct vpn_config cli_cfg = invalid_cfg;
 


### PR DESCRIPTION
It actually worked because use_engine is intialized to 0 here or -1 elsewhere
and we later test:
	use_engine > 0
Yet the expected values seem to be -1 and 1, not 0. Perhaps we should
make use_engine a "boolean" with 0/1 values, but the expected values
clearly seem to be -1/1 for now.