### PR TITLE
Fix Coverity defects

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -159,7 +159,7 @@ int load_config(struct vpn_config *cfg, const char *filename)
 	int ret = ERR_CFG_UNKNOWN;
 	FILE *file;
 	struct stat stat;
-	char *buffer, *line, *saveptr;
+	char *buffer, *line, *saveptr = NULL;
 
 	file = fopen(filename, "r");
 	if (file == NULL)

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -671,7 +671,7 @@ static int ssl_verify_cert(struct tunnel *tunnel)
 	char *line;
 	int i;
 	X509_NAME *subj;
-	char *saveptr;
+	char *saveptr = NULL;
 
 	SSL_set_verify(tunnel->ssl_handle, SSL_VERIFY_PEER, NULL);
 


### PR DESCRIPTION
CID 355044:  Memory - illegal accesses  (UNINIT)
Using uninitialized value "saveptr" when calling "__strtok_r_1c".

This doesn't look like an actual issue since the strtok_r() man page reads:
On the first call to strtok_r [...] the value of saveptr is ignored.

Let's shut up Coverity Scan nevertheless...