### PR TITLE
Always define RESOLVCONF_USAGE / RESOLVCONF_HELP

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -64,6 +64,9 @@
 "[--use-resolvconf=<0|1>] "
 #define RESOLVCONF_HELP \
 "  --use-resolvconf=[01]         If possible use resolvconf to update /etc/resolv.conf\n"
+#else
+#define RESOLVCONF_USAGE ""
+#define RESOLVCONF_HELP ""
 #endif
 
 #define usage \


### PR DESCRIPTION
While either `HAVE_USR_SBIN_PPPD` or `HAVE_USR_SBIN_PPP` **must** be defined,
`HAVE_RESOLVCONF` might not be defined - typically when _resolvconf_ is not
available at build-time. `RESOLVCONF_USAGE` and `RESOLVCONF_HELP` should always
be defined, if needed as empty strings, so as to not break subsequent
_printf_() calls.