### PR TITLE
Add snapcraft packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ openfortivpn
 doc/*.1
 config.sub
 config.guess
+*.snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+---
+name: openfortivpn
+version: git
+base: core18
+summary: openfortivpn, a PPP+SSL VPN client
+description: |
+    Openfortivpn is a client for PPP+SSL VPN tunnel services.
+    It spawns a pppd process and operates the communication between
+    the gateway and this process.
+confinement: strict
+grade: stable
+
+apps:
+    openfortivpn:
+        command: openfortivpn
+        plugs: [network-bind]
+
+parts:
+    openfortivpn:
+        plugin: autotools
+        source: .
+        build-packages:
+            - build-essential
+            - pkg-config
+            - libssl-dev


### PR DESCRIPTION
Adds snapcraft packaging for openfortivpn.
I currently have an older snap published on the snapcraft store.
I have updated this snap to use the new core18 base, and have made it build directly from the git repository so it can use annotated tags as version information for the snap automatically. 
If this is merged, it will also be possible to register this repo with the snap store (would require someone with access to this repo directly to register it) to enable automatic builds based on repository pushes, if there is desire for that. Otherwise, I can push a new version manually as requested.

Signed-off-by: James Hebden <james@ec0.io>