### PR TITLE
do not check resolvconf again when disabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -414,7 +414,7 @@ AC_ARG_ENABLE([resolvconf],
 # * resolvconf in Ubuntu/Debian does not support listing but returns 99
 #   if invoked without parameters
 # * skip resolvectl which does not work as expected when invoked as resolveconf
-AS_IF([test "x$enable_resolvconf" = "x"], [
+AS_IF([test "x$enable_resolvconf" = "x" -a "x$RESOLVCONF_PATH" != "xDISABLED"], [
 	AC_CHECK_FILE([$RESOLVCONF_PATH],[
 		AS_IF([$RESOLVCONF_PATH -l >/dev/null 2>/dev/null], [
 			enable_resolvconf="yes"


### PR DESCRIPTION
when cross-compiling we should not attempt to run resolvconf,
especially not when it is set to DISABLED. In that case the whole
resolvconf code is not compiled in at all and it does not matter
how the default would be in the disabled code

In #598 I have found the workaround to specify both options 
`./configure --disable-resolvconf --with-resolvconf=DISABLED`
but when the code is disabled anyway by `--with-resolvconf=DISABLED` 
additionally specifying a default with `--disable-resolvconf` should not be necessary