### PR TITLE
Use AX_PTHREAD autoconf macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ env:
     - secure: "HuYAk43itUiq0YJjmyvCyOM3mnRo8bFqSwksOmQ5fjvQscVWqZg6M9h8Abb+lKAc9L9avrwObjhu3EmOqoZ9Cjtp4WS4IdESK/UNe/jHpODFknsKefPgP67Z/yEFNVU1+5pS0+r+gTWQcZMyJrWrDde0lWpWHR/W7rTtqIbZH8Bp/T7oUN5q10x8PBcOZi/yVqNNicyuERIvUkobro5k+e4rY1N1HkptKs4wVY8M4WZUHwokNtuVfs0yoGQtrpi1KVRWq8sDkb8DNTeNv0MMEoQYUmNlEWxPaKJ9DBr65ajGLHzwUkWaNJGYw7mXwXoBwn5uKOyoytRA6Tj1wbVj4ggqqq6P6tbIcZ4YUW6N72gRaqvCnm6mRnbDHQtvzpqqxtr585mD11mh0DNmB15rvjNcZU/4wHHNQBsFcYEr+fN2/2ef/T3n0dymnnv2uZ05d11V5uSC6XYt3h0VxMDwarOVvOcWKYIQqzs4Bhigd2982v3OlIi5tbOSzHkbiCSP1msOKd6/XpCiCFpqed2UtSGZukisp3wQNfPnUOWoguOJ38nNe2o2G/l6HNOLd6u3sFlhzzthnJ6LPFD1CD9LPaOVYIVrRr90l0B2j1vPQM03eiiw7P6XvI6hPdqAM3VSEyjyrzUJRCUXAA8tovRwKTFlc506FWiFlGBFXFFI3zs="
 
 addons:
+  apt:
+    packages:
+    - autoconf-archive
   homebrew:
     packages:
     - openssl@1.0

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,15 +8,13 @@ openfortivpn_SOURCES = src/config.c src/config.h src/hdlc.c src/hdlc.h \
 		       src/xml.h src/userinput.c src/userinput.h \
 		       src/openssl_hostname_validation.c \
 		       src/openssl_hostname_validation.h
-openfortivpn_CFLAGS = -Wall -pedantic
 openfortivpn_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" \
 			-DPPP_PATH=\"@PPP_PATH@\" \
 			-DNETSTAT_PATH=\"@NETSTAT_PATH@\" \
 			-DRESOLVCONF_PATH=\"@RESOLVCONF_PATH@\" \
 			-DREVISION=\"@REVISION@\"
-
-openfortivpn_CPPFLAGS += $(OPENSSL_CFLAGS) $(LIBSYSTEMD_CFLAGS)
-openfortivpn_LDADD = $(OPENSSL_LIBS) $(LIBSYSTEMD_LIBS)
+openfortivpn_CFLAGS = -Wall -pedantic $(OPENSSL_CFLAGS) $(LIBSYSTEMD_CFLAGS) $(PTHREAD_CFLAGS)
+openfortivpn_LDADD = $(OPENSSL_LIBS) $(LIBSYSTEMD_LIBS) $(PTHREAD_LIBS)
 
 PATHFILES =
 CLEAN_LOCALS =

--- a/configure.ac
+++ b/configure.ac
@@ -33,7 +33,13 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 # Checks for libraries.
 PKG_CHECK_MODULES(OPENSSL, [libssl >= 0.9.8 libcrypto >= 0.9.8], [], [AC_MSG_ERROR([Cannot find OpenSSL 0.9.8 or higher.])])
-AC_CHECK_LIB([pthread], [pthread_create], [], [AC_MSG_ERROR([Cannot find libpthread.])])
+AC_MSG_CHECKING([POSIX threads support])
+AX_PTHREAD([
+	CLIBS="$LIBS $PTHREAD_LIBS"
+	CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+	LDFLAGS="$LDFLAGS $PTHREAD_CFLAGS"
+	CC="$PTHREAD_CC"],
+AC_MSG_ERROR([Cannot configure POSIX threads support.]))
 AC_CHECK_LIB([util], [forkpty], [], [AC_MSG_ERROR([Cannot find libutil.])])
 PKG_CHECK_MODULES(LIBSYSTEMD, [libsystemd], [AC_DEFINE(HAVE_SYSTEMD)], [AC_MSG_RESULT([libsystemd not present])])
 


### PR DESCRIPTION
[AX_PTHREAD](https://www.gnu.org/software/autoconf-archive/ax_pthread.html) is supposed to be more portable/standard.
Not sure I'm using it properly though. Not sure it's very useful either.