### PR TITLE
Disable macOS and FreeBSD builds for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 os:
 - linux
-- osx
-- freebsd
 
 language: c
 


### PR DESCRIPTION
It looks like these builds take for ever on Travis CI.

I don't know whether this a temporary problem or not but we have been unable to validate pull requests since this change. WIll revert for now and think about it again...