### PR TITLE
openfortivpn version 1.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Releases
 This high level changelog is usually updated when a release is tagged.
 On the master branch there may be changes that are not (yet) described here.
 
+### 1.13.3
+
+* [-] fix a coverity warning
+* [-] cross-compile: do not check resolvconf on the host system
+
 ### 1.13.2
 
 * [-] properly build on FreeBSD, even if ppp is not installed at configure time

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
-AC_INIT([openfortivpn], [1.13.2])
+AC_INIT([openfortivpn], [1.13.3])
 AC_CONFIG_SRCDIR([src/main.c])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 


### PR DESCRIPTION
* [-] fix a coverity warning
* [-] cross-compile: do not check resolvconf on the host system
