### PR TITLE
Fix OpenSSL build

### DIFF
--- a/tests/ci/install_openssl.sh
+++ b/tests/ci/install_openssl.sh
@@ -7,7 +7,7 @@ PREFIX="$1"
 [ -x "${PREFIX}/bin/openssl" ] && exit 0
 
 VERSION=1.0.2o
-SRC="https://www.openssl.org/source/openssl-${VERSION}.tar.gz"
+SRC="https://www.openssl.org/source/old/1.0.2/openssl-${VERSION}.tar.gz"
 
 wget -O openssl.tar.gz "$SRC"
 tar -xf openssl.tar.gz -C "$HOME"


### PR DESCRIPTION
The location of old releases has been moved from:
https://www.openssl.org/source/
to:
https://www.openssl.org/source/old/1.0.2/