### PR TITLE
include git commit id as revision in debug output

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,8 @@ openfortivpn_CFLAGS = -Wall -pedantic -std=gnu99
 openfortivpn_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" \
 			-DPPP_PATH=\"@PPP_PATH@\" \
 			-DNETSTAT_PATH=\"@NETSTAT_PATH@\" \
-			-DRESOLVCONF_PATH=\"@RESOLVCONF_PATH@\"
+			-DRESOLVCONF_PATH=\"@RESOLVCONF_PATH@\" \
+			-DREVISION=\"@REVISION@\"
 
 openfortivpn_CPPFLAGS += $(OPENSSL_CFLAGS) $(LIBSYSTEMD_CFLAGS)
 openfortivpn_LDADD = $(OPENSSL_LIBS) $(LIBSYSTEMD_LIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,14 @@ AC_GNU_SOURCE
 m4_ifndef([PKG_PROG_PKG_CONFIG], [m4_fatal([Please install pkg-config.])])
 PKG_PROG_PKG_CONFIG
 
+AC_PATH_PROG(GIT, [git], [""], "$PATH:/sbin:/usr/sbin")
+AS_IF([test "x$GIT" = "x"], [
+	REVISION=unavailable
+], [
+	REVISION=`git -C . rev-parse --short HEAD`
+])
+AC_SUBST(REVISION)
+
 # Helps support multiarch by setting 'host_os' and 'host_cpu'
 AC_CANONICAL_HOST
 

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AC_PATH_PROG(GIT, [git], [""], "$PATH:/sbin:/usr/sbin")
 AS_IF([test "x$GIT" = "x"], [
 	REVISION=unavailable
 ], [
-	REVISION=`git -C . rev-parse --short HEAD`
+	REVISION=`git describe --tags | sed -e 's/-/+git/;y/-/./'`
 ])
 AC_SUBST(REVISION)
 

--- a/src/main.c
+++ b/src/main.c
@@ -518,6 +518,7 @@ int main(int argc, char **argv)
 	log_debug_all("ATTENTION: the output contains sensitive information such as the THE CLEAR TEXT PASSWORD.\n");
 
 	log_debug("openfortivpn " VERSION "\n");
+	log_debug("    revision " REVISION "\n");
 
 	// Load config file
 	if (config_file[0] != '\0') {


### PR DESCRIPTION
We update the version number only when we create a new release. When testing different branches, it sometimes makes sense to have a more fine grained hint at which level of the sources a binary was built. The commit id of the git HEAD could be such a little piece that may help to distinguish if it's the released version or if it includes (at least one) more patch(es).