### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,7 @@ install-data-hook:
 		mkdir -p $(DESTDIR)$(sysconfdir)/openfortivpn ; \
 		cp -a $(DESTDIR)$(datadir)/config.template \
 			 $(DESTDIR)$(sysconfdir)/openfortivpn/config ; \
-		sed -i'.bak' -e '3,$ s/^/# /' $(DESTDIR)$(sysconfdir)/openfortivpn/config ; \
+		sed -i'.bak' -e '3,$$ s/^/# /' $(DESTDIR)$(sysconfdir)/openfortivpn/config ; \
 		rm $(DESTDIR)$(sysconfdir)/openfortivpn/config.bak ; \
 		chmod 0600 $(DESTDIR)$(sysconfdir)/openfortivpn/config ; \
 	fi


### PR DESCRIPTION
> This special significance of '$' is why you must write '$$' to
> have the effect of a single dollar sign in a file name or command.

See:
	https://ftp.gnu.org/old-gnu/Manuals/make/html_chapter/make_6.html#SEC66