### PR TITLE
allow logging in with smartcard and username+password

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -605,8 +605,7 @@ int auth_log_in(struct tunnel *tunnel)
 
 	tunnel->cookie[0] = '\0';
 
-	if (tunnel->config->use_engine > 0
-	    || (username[0] == '\0' && tunnel->config->password[0] == '\0')) {
+	if (username[0] == '\0' && tunnel->config->password[0] == '\0') {
 		snprintf(data, sizeof(data), "cert=&nup=1");
 		ret = http_request(tunnel, "GET", "/remote/login",
 		                   data, &res, &response_size);


### PR DESCRIPTION
This should perhaps be tested by someone who actively uses smartcard login without username and password. I remember that usual practice was to have dummy entries in username and password which is a configuration which would be broken by this commit. Anyhow, if those users change their config file to include an empty line for username and password, I would expect it to work again, but I would have a better feeling if someone could confirm this.
