### PR TITLE
Add systemd service file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ openfortivpn
 doc/*.1
 config.sub
 config.guess
+openfortivpn@.service

--- a/Makefile.am
+++ b/Makefile.am
@@ -18,33 +18,76 @@ openfortivpn_CPPFLAGS = -DSYSCONFDIR=\"$(sysconfdir)\" \
 openfortivpn_CPPFLAGS += $(OPENSSL_CFLAGS) $(LIBSYSTEMD_CFLAGS)
 openfortivpn_LDADD = $(OPENSSL_LIBS) $(LIBSYSTEMD_LIBS)
 
-DISTCHECK_CONFIGURE_FLAGS = CFLAGS=-Werror
+PATHFILES =
+CLEAN_LOCALS =
+EXTRA_DIST = \
+	autogen.sh \
+	CHANGELOG.md \
+	LICENSE \
+	LICENSE.OpenSSL \
+	README.md
 
-confdir=$(sysconfdir)/@PACKAGE@
+DISTCHECK_CONFIGURE_FLAGS = \
+	CFLAGS=-Werror \
+	--with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)
+
+# configuration file template
 datadir=$(prefix)/share/@PACKAGE@
 data_DATA=etc/openfortivpn/config.template
+
+EXTRA_DIST += $(data_DATA)
+
+# initial configuration file
+confdir=$(sysconfdir)/@PACKAGE@
 
 etc/openfortivpn/config: $(srcdir)/etc/openfortivpn/config.template
 	@$(MKDIR_P) etc/openfortivpn
 	$(AM_V_GEN)$(SED) -e '/^#/n;/^\s*$$/n;s/^/# /' $(srcdir)/etc/openfortivpn/config.template >$@
 
-install-data-hook: etc/openfortivpn/config
+install-data-hook: etc/openfortivpn/config lib/systemd/system/openfortivpn@.service
 	if ! test -f $(DESTDIR)$(confdir)/config ; then \
 		$(MKDIR_P) $(DESTDIR)$(confdir) ; \
 		$(INSTALL) -m 600 etc/openfortivpn/config \
 			$(DESTDIR)$(confdir)/config ; \
 	fi
 
+clean-local-config:
+	-rm -f $(top_builddir)/etc/openfortivpn/config
+
+CLEAN_LOCALS += clean-local-config
+
+# systemd service file
+PATHFILES += lib/systemd/system/openfortivpn@.service
+
+if HAVE_SYSTEMD
+lib/systemd/system/openfortivpn@.service: $(srcdir)/lib/systemd/system/openfortivpn@.service.in
+	@$(MKDIR_P) lib/systemd/system
+	$(AM_V_GEN)$(SED) -e 's|[@]BINDIR[@]|$(bindir)|g;s|[@]SYSCONFDIR[@]|$(sysconfdir)|g' $(srcdir)/lib/systemd/system/openfortivpn@.service.in >$@
+
+systemdsystemunit_DATA = lib/systemd/system/openfortivpn@.service
+
+clean-local-systemd:
+	-rm -f $(top_builddir)/lib/systemd/system/openfortivpn@.service
+
+CLEAN_LOCALS += clean-local-systemd
+endif
+
+# man page
+PATHFILES += doc/openfortivpn.1
 dist_man_MANS = doc/openfortivpn.1
 
 doc/openfortivpn.1: $(srcdir)/doc/openfortivpn.1.in
 	@$(MKDIR_P) doc
 	$(AM_V_GEN)$(SED) -e 's|[@]SYSCONFDIR[@]|$(sysconfdir)|g;s|[@]DATADIR[@]|$(datadir)|g' $(srcdir)/doc/openfortivpn.1.in >$@
 
+clean-local-man:
+	-rm -f $(top_builddir)/doc/openfortivpn.1
+
+CLEAN_LOCALS += clean-local-man
+
+
+EXTRA_DIST += $(PATHFILES:=.in)
+
 all-local: etc/openfortivpn/config
 
-clean-local:
-	-rm -f etc/openfortivpn/config
-	-rm -f doc/openfortivpn.1
-
-EXTRA_DIST = autogen.sh CHANGELOG.md LICENSE LICENSE.OpenSSL README.md doc/openfortivpn.1.in $(data_DATA)
+clean-local: $(CLEAN_LOCALS)

--- a/configure.ac
+++ b/configure.ac
@@ -452,5 +452,22 @@ AS_IF([test "x$enable_resolvconf" = "xyes"], [
 	AC_MSG_NOTICE([USE_RESOLVCONF... 0])
 ])
 
+# install systemd service file
+AC_ARG_WITH([systemdsystemunitdir],
+     [AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files])],,
+     [with_systemdsystemunitdir=auto])
+AS_IF([test "x$with_systemdsystemunitdir" = "xyes" -o "x$with_systemdsystemunitdir" = "xauto"], [
+     def_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)
+
+     AS_IF([test "x$def_systemdsystemunitdir" = "x"],
+   [AS_IF([test "x$with_systemdsystemunitdir" = "xyes"],
+    [AC_MSG_ERROR([systemd support requested but pkg-config unable to query systemd package])])
+    with_systemdsystemunitdir=no],
+   [with_systemdsystemunitdir="$def_systemdsystemunitdir"])])
+AS_IF([test "x$with_systemdsystemunitdir" != "xno"],
+      [AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])])
+AM_CONDITIONAL([HAVE_SYSTEMD], [test "x$with_systemdsystemunitdir" != "xno"])
+
+
 AC_CONFIG_COMMANDS([timestamp], [touch src/.dirstamp])
 AC_OUTPUT(Makefile)

--- a/lib/systemd/system/openfortivpn@.service.in
+++ b/lib/systemd/system/openfortivpn@.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=OpenFortiVPN for %I
+After=network-online.target
+
+[Service]
+Type=simple
+PrivateTmp=true
+ExecStart=@BINDIR@/openfortivpn -c @SYSCONFDIR@/openfortivpn/%I.conf
+OOMScoreAdjust=-100
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Fixes #623.

The `configure.ac` changes are documented in the _systemd_ man page:
https://www.freedesktop.org/software/systemd/man/daemon.html#Installing%20systemd%20Service%20Files

Allows _openfortivpn_ to act as system service.

There are a couple issues that bother me:
* _openfortivpn_ used to be entirely installed under `${prefix}`, including the default configuration file under `$(sysconfdir)/openfortivpn` → `$(prefix)/etc/openfortivpn`. With this change _openfortivpn_ installs its _systemd_ service file outside `$(prefix)`, under `$(systemdsystemunitdir)` → `/lib/systemd/system/`. That's by design of course but I thought I'd mention it.
* I'm not certain I have got the `Makefile.am` right, on the contrary. My concern is conditionals in the Makefile - with/without _systemd_ service files. The Makefile should function properly whatever the conditions. It seems to be working but I'm not convinced. Some help appreciated here.
