### PR TITLE
Standardize Automake use: final changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,28 +25,26 @@ datadir=$(prefix)/share/@PACKAGE@
 data_DATA=etc/openfortivpn/config.template
 
 etc/openfortivpn/config: $(srcdir)/etc/openfortivpn/config.template
-	$(MKDIR_P) etc/openfortivpn
-	$(SED) -e '3,$$ s/^/# /' $(srcdir)/etc/openfortivpn/config.template >$@
+	@$(MKDIR_P) etc/openfortivpn
+	$(AM_V_GEN)$(SED) -e '3,$$ s/^/# /' $(srcdir)/etc/openfortivpn/config.template >$@
 
 install-data-hook: etc/openfortivpn/config
 	if ! test -f $(DESTDIR)$(confdir)/config ; then \
 		$(MKDIR_P) $(DESTDIR)$(confdir) ; \
 		$(INSTALL) -m 600 etc/openfortivpn/config \
-		                  $(DESTDIR)$(confdir)/config ; \
+			$(DESTDIR)$(confdir)/config ; \
 	fi
+
+dist_man_MANS = doc/openfortivpn.1
+
+doc/openfortivpn.1: $(srcdir)/doc/openfortivpn.1.in
+	@$(MKDIR_P) doc
+	$(AM_V_GEN)$(SED) -e 's|[@]SYSCONFDIR[@]|$(sysconfdir)|g;s|[@]DATADIR[@]|$(datadir)|g' $(srcdir)/doc/openfortivpn.1.in >$@
 
 all-local: etc/openfortivpn/config
 
 clean-local:
 	-rm -f etc/openfortivpn/config
-
-uninstall-local:
-	-rm -f $(DESTDIR)$(confdir)/config
-
-dist_man_MANS = doc/openfortivpn.1
-
-doc/openfortivpn.1: $(srcdir)/doc/openfortivpn.1.in
-	$(MKDIR_P) doc
-	$(SED) -e 's|[@]SYSCONFDIR[@]|$(sysconfdir)|g;s|[@]DATADIR[@]|$(datadir)|g' $(srcdir)/doc/openfortivpn.1.in >$@
+	-rm -f doc/openfortivpn.1
 
 EXTRA_DIST = autogen.sh CHANGELOG.md LICENSE LICENSE.OpenSSL README.md doc/openfortivpn.1.in $(data_DATA)

--- a/configure.ac
+++ b/configure.ac
@@ -28,9 +28,6 @@ AS_IF([test "x$REVISION" = "x"], [
 
 AC_SUBST(REVISION)
 
-# Helps support multiarch by setting 'host_os' and 'host_cpu'
-AC_CANONICAL_HOST
-
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 # Checks for libraries.


### PR DESCRIPTION
* Be consistent and do not "make uninstall" `$(confdir)/config` as it is not clobbered by "make install" either.
* Silent rules for sed.