### PR TITLE
Add dns suffix information to informative message

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -473,7 +473,7 @@ static void *ssl_read(void *arg)
 
 		if (tunnel->state == STATE_CONNECTING) {
 			if (packet_is_ip_plus_dns(packet)) {
-				char line[ARRAY_SIZE("[xxx.xxx.xxx.xxx], ns [xxx.xxx.xxx.xxx, xxx.xxx.xxx.xxx]")];
+				char line[ARRAY_SIZE("[xxx.xxx.xxx.xxx], ns [xxx.xxx.xxx.xxx, xxx.xxx.xxx.xxx], ns_suffix []") + MAX_DOMAIN_LENGTH];
 
 				set_tunnel_ips(tunnel, packet);
 				strcpy(line, "[");
@@ -482,6 +482,8 @@ static void *ssl_read(void *arg)
 				strncat(line, inet_ntoa(tunnel->ipv4.ns1_addr), 15);
 				strcat(line, ", ");
 				strncat(line, inet_ntoa(tunnel->ipv4.ns2_addr), 15);
+				strcat(line, "], ns_suffix [");
+				strncat(line, tunnel->ipv4.dns_suffix, MAX_DOMAIN_LENGTH);
 				strcat(line, "]");
 				log_info("Got addresses: %s\n", line);
 			}

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -64,6 +64,10 @@ struct rtentry {
 #define MAX_SPLIT_ROUTES 65535
 #define STEP_SPLIT_ROUTES 32
 
+// see https://unix.stackexchange.com/questions/245849
+// ... /resolv-conf-limited-to-six-domains-with-a-total-of-256-characters
+#define MAX_DOMAIN_LENGTH 256
+
 struct ipv4_config {
 	struct in_addr	ip_addr;
 

--- a/src/xml.c
+++ b/src/xml.c
@@ -16,6 +16,7 @@
  */
 
 #include "xml.h"
+#include "ipv4.h"
 #include "log.h"
 
 #include <string.h>

--- a/src/xml.h
+++ b/src/xml.h
@@ -18,10 +18,6 @@
 #ifndef OPENFORTIVPN_XML_H
 #define OPENFORTIVPN_XML_H
 
-#define MAX_DOMAIN_LENGTH 256
-// see https://unix.stackexchange.com/questions/245849
-// ... /resolv-conf-limited-to-six-domains-with-a-total-of-256-characters
-
 const char *xml_find(char t, const char *tag, const char *buf, int nest);
 char *xml_get(const char *buf);
 

--- a/tests/lint/line_length.py
+++ b/tests/lint/line_length.py
@@ -39,7 +39,7 @@ def endswithstring(line):
         True if line ends with string, False otherwise.
 
     """
-    for end in ('"', '",', '");', '";', '" \\', ')];'):
+    for end in ('"', '",', '");', '";', '" \\', '];'):
         if line.endswith(end):
             return True
     return False


### PR DESCRIPTION
Hi,
I found out that printing the dns suffixes could be a first step to enable networknanager-fortisslvpn to scrape this information, and then report it back to whatever handles resolv.conf in NetworkManager. For now this information is not used by pppd.

On the other end, I think adding a stable parsable output would be a more appropriate, proper solution.

Sample output:
```
VPN account password:
INFO:   Connected to gateway.
Two-factor authentication token:
INFO:   Authenticated.
INFO:   Remote gateway has allocated a VPN.
Using interface ppp0
Connect: ppp0 <--> /dev/pts/1
INFO:   Got addresses: [0.0.0.0], ns [0.0.0.0, 0.0.0.0], ns_suffix [sub.example.com example.com]
INFO:   negotiation complete
INFO:   negotiation complete
Cannot determine ethernet address for proxy ARP
local  IP address 0.0.0.0
remote IP address 0.0.0.0
INFO:   Interface ppp0 is UP.
INFO:   Setting new routes...
INFO:   Adding VPN nameservers...
INFO:   Tunnel is up and running.

```