### PR TITLE
Reorganize http_receive()

### DIFF
--- a/src/http.h
+++ b/src/http.h
@@ -20,6 +20,8 @@
 
 #include "tunnel.h"
 
+#include <stdint.h>
+
 #define ERR_HTTP_INVALID	-1
 #define ERR_HTTP_TOO_LONG	-2
 #define ERR_HTTP_NO_MEM		-3

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -30,6 +30,7 @@
 #define OPENFORTIVPN_SSL_H
 
 #include <errno.h>
+#include <stdint.h>
 #include <string.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
@@ -76,7 +77,7 @@ static inline const char *err_ssl_str(int code)
 	else if (code == ERR_SSL_SEE_ERRNO)
 		return strerror(errno);
 	else if (code == ERR_SSL_SEE_SSLERR)
-		return ERR_error_string(ERR_peek_last_error(), NULL);
+		return ERR_reason_error_string(ERR_peek_last_error());
 	return "unknown";
 }
 


### PR DESCRIPTION
Prepare for adding an external HTTP library later on.

The pull request will help use external HTTP / XML libraries later on. At this point I am not certain we will benefit from using [PicoHTTPParser](https://github.com/h2o/picohttpparser) in terms of maintainability and less code. Yet I'm opening the pull request to perform some code clean up, add a few assertions here and there, and raise a few issues.

For example we do not catch SSL errors if the header has already been read. Here is the relevant part in the new code:
https://github.com/DimitriPapadopoulos/openfortivpn/blob/230b158/src/http.c#L177-L181
and in the old code:
https://github.com/adrienverge/openfortivpn/blob/8b0c235/src/http.c#L217-L221
@adrienverge Is this on purpose? Are we lenient on purpose? On my machine I have modified the code to be strict on SSL errors, whether the HTTP header has been read or not. I haven't seen any occurrence of SSL errors.