### PR TITLE
More systemd notifications

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -132,6 +132,10 @@ static int on_ppp_if_up(struct tunnel *tunnel)
 
 static int on_ppp_if_down(struct tunnel *tunnel)
 {
+#if HAVE_SYSTEMD
+	sd_notify(0, "STOPPING=1");
+#endif
+
 	log_info("Setting ppp interface down.\n");
 
 	if (tunnel->config->set_routes) {


### PR DESCRIPTION
Notify that the service is beginning its shutdown (STOPPING=1) in addition
to notifying that service startup is finished (READY=1).

In the future we could perhaps add more events:
STATUS=…
ERRNO=…

See:
https://www.freedesktop.org/software/systemd/man/sd_notify.html