### PR TITLE
Small cleanup

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -57,7 +57,23 @@ struct x509_digest {
 };
 
 #define FIELD_SIZE	64
+
+/*
+ * RFC 6265 does not limit the size of cookies:
+ * https://www.rfc-editor.org/info/rfc6265
+ *
+ * Yet browsers typically limit themselves to ~4K so we are on the safe side:
+ * http://browsercookielimits.squawky.net/
+ */
 #define COOKIE_SIZE	4096
+
+/*
+ * GNU libc used to limit the search list to 256 characters:
+ * https://unix.stackexchange.com/questions/245849
+ *
+ * We believe we are on the safe side using this value.
+ */
+#define MAX_DOMAIN_LENGTH 256
 
 struct vpn_config {
 	char		gateway_host[FIELD_SIZE + 1];

--- a/src/hdlc.c
+++ b/src/hdlc.c
@@ -20,8 +20,7 @@
 /*
  * Encode and decode PPP packets from and into HDLC frames.
  *
- * RFC1622 describes the use of HDLC-like framing for PPP encapsulated packets:
- *
+ * RFC 1622 describes the use of HDLC-like framing for PPP encapsulated packets:
  * https://www.rfc-editor.org/info/rfc1662
  */
 
@@ -32,7 +31,7 @@
 	((byte) < 0x20)
 
 /*
- * Lookup table used to calculate the FCS, as generated in RFC1662.
+ * Lookup table used to calculate the FCS, as generated in RFC 1662.
  */
 static const uint16_t fcs_tab[] = {
 	0x0000, 0x1189, 0x2312, 0x329b, 0x4624, 0x57ad, 0x6536, 0x74bf,

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -64,10 +64,6 @@ struct rtentry {
 #define MAX_SPLIT_ROUTES 65535
 #define STEP_SPLIT_ROUTES 32
 
-// see https://unix.stackexchange.com/questions/245849
-// ... /resolv-conf-limited-to-six-domains-with-a-total-of-256-characters
-#define MAX_DOMAIN_LENGTH 256
-
 struct ipv4_config {
 	struct in_addr	ip_addr;
 

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -648,7 +648,7 @@ static int tcp_connect(struct tunnel *tunnel)
 			// detect end-of-line after "200"
 			if (response != NULL) {
 				/*
-				 * RFC2616 states in section 2.2 Basic Rules:
+				 * RFC 2616 states in section 2.2 Basic Rules:
 				 *      CR     = <US-ASCII CR, carriage return (13)>
 				 *      LF     = <US-ASCII LF, linefeed (10)>
 				 *      HTTP/1.1 defines the sequence CR LF as the
@@ -657,7 +657,7 @@ static int tcp_connect(struct tunnel *tunnel)
 				 *      for tolerant applications).
 				 *              CRLF   = CR LF
 				 *
-				 * RFC2616 states in section 19.3 Tolerant Applications:
+				 * RFC 2616 states in section 19.3 Tolerant Applications:
 				 *      The line terminator for message-header fields
 				 *      is the sequence CRLF. However, we recommend
 				 *      that applications, when parsing such headers,

--- a/src/xml.c
+++ b/src/xml.c
@@ -16,7 +16,7 @@
  */
 
 #include "xml.h"
-#include "ipv4.h"
+#include "config.h"
 #include "log.h"
 
 #include <string.h>


### PR DESCRIPTION
* Document some constants
* Move MAX_DOMAIN_LENGTH to config.h
* Consistency in RFC names and links
* Low-level functions should use log_debug()