### PR TITLE
Fix GPL + OpenSSL license clash

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -13,6 +13,17 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  In addition, as a special exception, the copyright holders give permission
+ *  to link the code of portions of this program with the OpenSSL library under
+ *  certain conditions as described in each individual source file, and
+ *  distribute linked combinations including the two.
+ *  You must obey the GNU General Public License in all respects for all of the
+ *  code used other than OpenSSL.  If you modify file(s) with this exception,
+ *  you may extend this exception to your version of the file(s), but you are
+ *  not obligated to do so.  If you do not wish to do so, delete this exception
+ *  statement from your version.  If you delete this exception statement from
+ *  all source files in the program, then also delete it here.
  */
 
 #include "config.h"


### PR DESCRIPTION
The license of config.c needs to be updated following 321fdfa5b58.