### PR TITLE
Attempt to warn of outdated FortiGate appliances

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -870,6 +870,8 @@ int auth_get_config(struct tunnel *tunnel)
 	if (ret == 1)
 		return ret;
 
+	log_warn("Configuration cannot be retrieved in XML format. This FortiGate appliance might be outdated and vulnerable, you might not be able to connect from systems with recent OpenSSL libraries.\n");
+
 	ret = http_request(tunnel, "GET", "/remote/fortisslvpn", "", &buffer, NULL);
 	if (ret == 1) {
 		ret = parse_config(tunnel, buffer);


### PR DESCRIPTION
FortiGate appliances that are unable to provide configuration
in XML format are probably running FortiOS 4 or earlier which
has been umaintained and vulnerable for some time now.

Warn the user that the FortiGate appliance is outadated and that
it might not be compatible with recent OpenSSL 1.1.1 libraries
with weak ciphers disabled - we've had a case on Ubuntu 20.04 for
example.