### PR TITLE
Use C99 standard headers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,7 @@ PKG_CHECK_MODULES(LIBSYSTEMD, [libsystemd], [AC_DEFINE(HAVE_SYSTEMD)], [AC_MSG_R
 # limits.h
 # signal.h
 # stdarg.h
+# stddef.h
 # stdint.h
 # stdio.h
 # stdlib.h

--- a/src/config.c
+++ b/src/config.c
@@ -29,14 +29,16 @@
 #include "config.h"
 #include "log.h"
 
+#include <openssl/x509.h>  /* work around OpenSSL bug: missing definition of STACK_OF */
+#include <openssl/tls1.h>
+
+#include <sys/stat.h>
+
+#include <ctype.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
-#include <sys/stat.h>
-#include <limits.h>
-#include <openssl/x509.h>  /* work around OpenSSL bug: missing definition of STACK_OF */
-#include <openssl/tls1.h>
 
 const struct vpn_config invalid_cfg = {
 	.gateway_host = {'\0'},

--- a/src/config.h
+++ b/src/config.h
@@ -18,10 +18,11 @@
 #ifndef OPENFORTIVPN_CONFIG_H
 #define OPENFORTIVPN_CONFIG_H
 
-#include <errno.h>
-#include <string.h>
-#include <sys/types.h>
 #include <netinet/in.h>
+
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
 
 #define ERR_CFG_UNKNOWN		-1
 #define ERR_CFG_SEE_ERRNO	-2

--- a/src/hdlc.h
+++ b/src/hdlc.h
@@ -18,10 +18,12 @@
 #ifndef OPENFORTIVPN_HDLC_H
 #define OPENFORTIVPN_HDLC_H
 
-#include <stdint.h>
-#include <stdlib.h>
 #include <unistd.h>
 #include <sys/types.h>
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
 
 #define ERR_HDLC_BUFFER_TOO_SMALL	-1
 #define ERR_HDLC_NO_FRAME_FOUND		-2

--- a/src/http.c
+++ b/src/http.c
@@ -22,14 +22,15 @@
 #include "userinput.h"
 #include "log.h"
 
+#include <unistd.h>
+#include <arpa/inet.h>
+
 #include <assert.h>
 #include <ctype.h>
-#include <string.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
-#include <arpa/inet.h>
+#include <string.h>
 
 /*
  * Fixed size of the buffer for outgoing HTTP requests.

--- a/src/io.c
+++ b/src/io.c
@@ -32,12 +32,13 @@
 #include "tunnel.h"
 #include "log.h"
 
-#include <signal.h>
+#include <unistd.h>
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
-#include <unistd.h>
-#include <string.h>
+
 #include <errno.h>
+#include <signal.h>
+#include <string.h>
 
 #if HAVE_MACH_MACH_H
 /* this is typical for mach kernel used on Mac OS X */

--- a/src/io.h
+++ b/src/io.h
@@ -18,9 +18,11 @@
 #ifndef OPENFORTIVPN_IO_H
 #define OPENFORTIVPN_IO_H
 
-#include <stdint.h>
-#include <sys/types.h>
 #include <pthread.h>
+#include <sys/types.h>
+
+#include <stddef.h>
+#include <stdint.h>
 
 /*
  * For performance reasons, we store the 6-byte header used by the SSL

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -21,17 +21,18 @@
 #include "log.h"
 #include "xml.h"
 
+#include <unistd.h>
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdint.h>
+
 #include <errno.h>
 #include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
 
 #define IPV4_GET_ROUTE_BUFFER_CHUNK_SIZE 65536
 #define SHOW_ROUTE_BUFFER_SIZE 128

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -18,7 +18,6 @@
 #ifndef OPENFORTIVPN_IPV4_H
 #define OPENFORTIVPN_IPV4_H
 
-#include <sys/types.h>
 #include <sys/socket.h>
 #ifdef HAVE_SYS_MUTEX_H
 /* Mac OS X and BSD wants this explicit include */

--- a/src/log.c
+++ b/src/log.c
@@ -17,14 +17,15 @@
 
 #include "log.h"
 
+#include <unistd.h>
 #include <pthread.h>
 #include <syslog.h>
-#include <unistd.h>
+
+#include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
 
 static pthread_mutex_t mutex;
 static int do_syslog; //static variables of arithmetic type are initialized to zero in C99

--- a/src/log.h
+++ b/src/log.h
@@ -18,8 +18,8 @@
 #ifndef OPENFORTIVPN_LOG_H
 #define OPENFORTIVPN_LOG_H
 
+#include <stddef.h>
 #include <stdint.h>
-#include <sys/types.h>
 
 // Assign enum values explicitly, we're using them in a lookup
 enum log_verbosity {

--- a/src/main.c
+++ b/src/main.c
@@ -20,12 +20,13 @@
 #include "userinput.h"
 #include "log.h"
 
-#include <getopt.h>
 #include <unistd.h>
+#include <getopt.h>
+
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <limits.h>
 
 #define PWD_BUFSIZ	4096
 

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -29,11 +29,12 @@
 #ifndef OPENFORTIVPN_SSL_H
 #define OPENFORTIVPN_SSL_H
 
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+
 #include <errno.h>
 #include <stdint.h>
 #include <string.h>
-#include <openssl/err.h>
-#include <openssl/ssl.h>
 
 #ifdef __clang__
 /*

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -33,30 +33,32 @@
 #include "openssl_hostname_validation.h"
 #endif
 
+#include <openssl/err.h>
+#include <openssl/engine.h>
+#include <openssl/x509v3.h>
+#if HAVE_SYSTEMD
+#include <systemd/sd-daemon.h>
+#endif
+
 #include <unistd.h>
+#include <arpa/inet.h>
 #include <fcntl.h>
 #include <ifaddrs.h>
-#include <netdb.h>
-#include <errno.h>
-#include <string.h>
 #include <net/if.h>
-#include <arpa/inet.h>
-#include <sys/socket.h>
-#include <sys/ioctl.h>
-#include <openssl/err.h>
-#include <openssl/x509v3.h>
-#include <openssl/engine.h>
+#include <netdb.h>
 #if HAVE_PTY_H
 #include <pty.h>
 #elif HAVE_UTIL_H
 #include <util.h>
 #endif
-#include <termios.h>
-#include <signal.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
 #include <sys/wait.h>
-#if HAVE_SYSTEMD
-#include <systemd/sd-daemon.h>
-#endif
+#include <termios.h>
+
+#include <errno.h>
+#include <signal.h>
+#include <string.h>
 
 // we use this constant in the source, so define a fallback if not defined
 #ifndef OPENSSL_API_COMPAT

--- a/src/tunnel.h
+++ b/src/tunnel.h
@@ -38,6 +38,7 @@
 
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>
+
 #include <sys/types.h>
 
 #ifdef __clang__

--- a/src/userinput.c
+++ b/src/userinput.c
@@ -19,17 +19,18 @@
 #include "userinput.h"
 #include "log.h"
 
+#include <unistd.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <termios.h>
 
 #include <ctype.h>
 #include <errno.h>
 #include <stdarg.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <termios.h>
-#include <unistd.h>
 
 static char *uri_escape(const char *string)
 {

--- a/src/userinput.h
+++ b/src/userinput.h
@@ -18,7 +18,7 @@
 #ifndef OPENFORTIVPN_USERINPUT_H
 #define OPENFORTIVPN_USERINPUT_H
 
-#include <sys/types.h>
+#include <stddef.h>
 
 void read_password(const char *pinentry, const char *hint,
                    const char *prompt, char *pass, size_t len);


### PR DESCRIPTION
Use C99 headers instead of POSIX headers when possible:
* size_t is defined in <stddef.h>
* ssize_t still requires <sys/types.h>
* int_8 is defined in <stdint.h>

Reorganize header inclusion:
1. openfortivpn headers
2. 3rd party library headers (OpenSSL, systemd, etc.)
3. POSIX headers
4. C headers