### PR TITLE
<unistd.h> is not needed

### DIFF
--- a/src/hdlc.h
+++ b/src/hdlc.h
@@ -18,7 +18,6 @@
 #ifndef OPENFORTIVPN_HDLC_H
 #define OPENFORTIVPN_HDLC_H
 
-#include <unistd.h>
 #include <sys/types.h>
 
 #include <stddef.h>


### PR DESCRIPTION
In C99:
* uint8_t is defined in <stdint.h>
* size_t is defined in <stddef.h>

In POSIX:
* ssize_t is defined in <sys/types.h>