### PR TITLE
Better error message when tunnel mode is forbidden

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -875,7 +875,7 @@ int auth_get_config(struct tunnel *tunnel)
 	if (ret == 1)
 		return ret;
 
-	log_warn("Configuration cannot be retrieved in XML format. This FortiGate appliance might be outdated and vulnerable, you might not be able to connect from systems with recent OpenSSL libraries.\n");
+	log_warn("Configuration cannot be retrieved in XML format. This VPN-SSL portal might be outdated and vulnerable, you might not be able to connect from systems with recent OpenSSL libraries.\n");
 
 	ret = http_request(tunnel, "GET", "/remote/fortisslvpn", "", &buffer, NULL);
 	if (ret == 1) {


### PR DESCRIPTION
The SSL-VPN may allow web mode but not tunnel mode.
In that case it sends an HTTP 403 error back to VPN
clients instead of the expected PPP header.

Catch that case and emit a meaningful error message.

Fixes #689.