### PR TITLE
SSL_OP_NO_SSLv3 is deprecated

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -142,21 +142,21 @@ int parse_min_tls(const char *str)
 	if (str[0] != '1' || str[1] != '.' || str[2] == 0 || str[3] != 0)
 		return -1;
 	switch (str[2]) {
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#ifdef TLS1_VERSION
 	case '0':
 		return TLS1_VERSION;
+#endif
+#ifdef TLS1_1_VERSION
 	case '1':
 		return TLS1_1_VERSION;
+#endif
+#ifdef TLS1_2_VERSION
 	case '2':
 		return TLS1_2_VERSION;
+#endif
 #ifdef TLS1_3_VERSION
-	/*
-	 * libressl uses version numbers starting with major version 2
-	 * but does not yet support TLS 1.3
-	 */
 	case '3':
 		return TLS1_3_VERSION;
-#endif
 #endif
 	default:
 		return -1;

--- a/src/main.c
+++ b/src/main.c
@@ -95,13 +95,6 @@ PPPD_USAGE \
 "the gateway and this process.\n" \
 "\n"
 
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
-#define help_min_tls ""
-#else
-#define help_min_tls " This option\n" \
-"                                is not supported by your OpenSSL library."
-#endif
-
 #ifdef TLS1_3_VERSION
 #define help_cipher_list " Applies to TLS v1.2 or\n" \
 "                                lower only, not to be used with TLS v1.3 ciphers."
@@ -159,7 +152,7 @@ PPPD_USAGE \
 "                                of 'openssl s_client -connect <host:port>'\n" \
 "                                (e.g. AES256-GCM-SHA384)." help_cipher_list "\n" \
 "  --min-tls                     Use minimum TLS version instead of system default.\n" \
-"                                Valid values are 1.0, 1.1, 1.2, 1.3." help_min_tls "\n" \
+"                                Valid values are 1.0, 1.1, 1.2, 1.3.\n" \
 "  --seclevel-1                  If --cipher-list is not specified, add @SECLEVEL=1 to\n" \
 "                                (compiled in) list of ciphers. This lowers limits on\n" \
 "                                dh key." help_seclevel_1 "\n" \
@@ -259,9 +252,7 @@ int main(int argc, char **argv)
 		{"trusted-cert",    required_argument, NULL, 0},
 		{"insecure-ssl",    no_argument, &cli_cfg.insecure_ssl, 1},
 		{"cipher-list",     required_argument, NULL, 0},
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 		{"min-tls",         required_argument, NULL, 0},
-#endif
 		{"seclevel-1",      no_argument, &cli_cfg.seclevel_1, 1},
 #if HAVE_USR_SBIN_PPPD
 		{"pppd-use-peerdns", required_argument, NULL, 0},
@@ -412,7 +403,6 @@ int main(int argc, char **argv)
 				cli_cfg.cipher_list = strdup(optarg);
 				break;
 			}
-#if OPENSSL_VERSION_NUMBER >= 0x10100000L
 			if (strcmp(long_options[option_index].name,
 			           "min-tls") == 0) {
 				int min_tls = parse_min_tls(optarg);
@@ -425,7 +415,6 @@ int main(int argc, char **argv)
 				}
 				break;
 			}
-#endif
 			if (strcmp(long_options[option_index].name,
 			           "otp-prompt") == 0) {
 				cli_cfg.otp_prompt = strdup(optarg);

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,8 @@
 #include "userinput.h"
 #include "log.h"
 
+#include <openssl/ssl.h>
+
 #include <unistd.h>
 #include <getopt.h>
 
@@ -220,7 +222,11 @@ int main(int argc, char **argv)
 		.user_cert = NULL,
 		.user_key = NULL,
 		.insecure_ssl = 0,
+#ifdef TLS1_2_VERSION
+		.min_tls = TLS1_2_VERSION,
+#else
 		.min_tls = 0,
+#endif
 		.seclevel_1 = 0,
 		.cipher_list = NULL,
 		.cert_whitelist = NULL,


### PR DESCRIPTION
Option SSL_OP_NO_SSLv3 is deprecated as of  OpenSSL 1.1.0, use SSL_CTX_set_min_proto_version() instead.

[List of SSL OP Flags](https://wiki.openssl.org/index.php/List_of_SSL_OP_Flags#Protocol_Version_Options)