### PR TITLE
Suggest broader scope of causes in error message

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -451,7 +451,7 @@ static void *ssl_read(void *arg)
 			 * a PPP packet:
 			 * HTTP/1.1 403 Forbidden
 			 */
-			log_error("This SSL-VPN portal does not allow tunnel mode.\n");
+			log_error("Could not authenticate to the gateway. Please make sure tunnel mode is allowed by the gateway, check the realm, etc.\n");
 			break;
 		}
 


### PR DESCRIPTION
The gateway may return a 403 HTTP error not only when tunnel mode is not enabled, but also when the realm is incorrect.

See https://github.com/adrienverge/openfortivpn/issues/689#issuecomment-625131878.