### PR TITLE
Revert "Use C99 standard headers"

### DIFF
--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -21,6 +21,8 @@
 #include <sys/socket.h>
 #ifdef HAVE_SYS_MUTEX_H
 /* Mac OS X and BSD wants this explicit include */
+#include <sys/param.h>
+#include <sys/lock.h>
 #include <sys/mutex.h>
 #endif
 #include <netinet/in.h>


### PR DESCRIPTION
Fix for #698
This reverts commit 77ec854eb601a1f691ab09b770158ff728aedc20.