### PR TITLE
Put back <sys/types.h> for FreeBSD and macOS

### DIFF
--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -18,11 +18,12 @@
 #ifndef OPENFORTIVPN_IPV4_H
 #define OPENFORTIVPN_IPV4_H
 
-#include <sys/socket.h>
+#include <sys/types.h>
 #ifdef HAVE_SYS_MUTEX_H
 /* Mac OS X and BSD wants this explicit include */
 #include <sys/mutex.h>
 #endif
+#include <sys/socket.h>
 #include <netinet/in.h>
 #include <net/route.h>
 #include <net/if.h>


### PR DESCRIPTION
BSD headers are not self-sufficient, they may require other headers to
be included first. See complete analysis here:
https://github.com/adrienverge/openfortivpn/pull/699#issuecomment-625780460