### PR TITLE
These headers are not needed, even on FreeBSD

### DIFF
--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -19,18 +19,9 @@
 #define OPENFORTIVPN_IPV4_H
 
 #include <sys/types.h>
-#ifdef HAVE_SYS_MUTEX_H
-/* Mac OS X and BSD wants this explicit include */
-#include <sys/mutex.h>
-#endif
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <net/route.h>
-#include <net/if.h>
-#ifdef HAVE_NET_IF_IF_VAR_H
-/* on FreeBSD we need this additional header */
-#include <net/if_var.h>
-#endif
 
 #if !HAVE_RT_ENTRY_WITH_RT_DST
 /*


### PR DESCRIPTION
`<sys/mutex.h>`  defines mtx_* functions
`<net/if.h>`     defines if_* functions and if_nameindex structure
`<net/if_var.h>` ?