### PR TITLE
These headers are not needed, even on FreeBSD

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -52,8 +52,8 @@
 #elif HAVE_UTIL_H
 #include <util.h>
 #endif
-#include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <termios.h>
 


### PR DESCRIPTION
`<sys/ioctl.h>`   defines _ioctl()_

On the other hand we do need `<sys/types.h>` for `pid_t` and such.