### PR TITLE
These headers are not needed, even on FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,7 @@ net/if.h \
 netinet/in.h \
 netinet/tcp.h \
 pthread.h \
+strings.h \
 sys/ioctl.h \
 syslog.h \
 sys/socket.h \
@@ -78,7 +79,6 @@ AC_CHECK_HEADERS([net/route.h], [], AC_MSG_ERROR([Required header not found]), [
 
 # Checks for optional header files.
 AC_CHECK_HEADERS([ \
-libutil.h \
 mach/mach.h \
 pty.h \
 semaphore.h \

--- a/src/io.h
+++ b/src/io.h
@@ -18,8 +18,8 @@
 #ifndef OPENFORTIVPN_IO_H
 #define OPENFORTIVPN_IO_H
 
-#include <pthread.h>
 #include <sys/types.h>
+#include <pthread.h>
 
 #include <stddef.h>
 #include <stdint.h>

--- a/src/tunnel.h
+++ b/src/tunnel.h
@@ -32,9 +32,6 @@
 #include "config.h"
 #include "io.h"
 #include "ipv4.h"
-#if HAVE_LIBUTIL_H
-#include "libutil.h"
-#endif
 
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>


### PR DESCRIPTION
`<libutil.h>`   (and not `"lubutil.h"`) defines `pidfile_*` functions