### PR TITLE
Partial revert: header needed on FreeBSD after all

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,6 +79,7 @@ AC_CHECK_HEADERS([net/route.h], [], AC_MSG_ERROR([Required header not found]), [
 
 # Checks for optional header files.
 AC_CHECK_HEADERS([ \
+libutil.h \
 mach/mach.h \
 pty.h \
 semaphore.h \

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -52,10 +52,13 @@
 #elif HAVE_UTIL_H
 #include <util.h>
 #endif
-#include <sys/socket.h>
 #include <sys/types.h>
+#include <sys/socket.h>
 #include <sys/wait.h>
 #include <termios.h>
+#if HAVE_LIBUTIL_H
+#include <libutil.h>
+#endif
 
 #include <errno.h>
 #include <signal.h>


### PR DESCRIPTION
`<libutil.h>`   needed in `tunnel.c` (but not in `tunnel.h` as previously) to
define _forkpty()_

This function is really not standard.

On Linux it can be found in `<pty.h>`:
[OPENPTY(3)](http://man7.org/linux/man-pages/man3/forkpty.3.html)

On Solaris it can be found in `<termios.h>`:
[forkpty (3C)](https://docs.oracle.com/cd/E88353_01/html/E37843/forkpty-3c.html)

And on FreeBSD, it can be found in a handful headers, as usual:
 [PTY(3)](https://www.freebsd.org/cgi/man.cgi?query=forkpty&sektion=3l)
> ### SYNOPSIS
> ```
>      #include <sys/types.h>
>      #include <sys/ioctl.h>
>      #include <termios.h>
>      #include <libutil.h>
> ```