### PR TITLE
Partial revert: header needed on FreeBSD after all

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -55,6 +55,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/wait.h>
+#include <sys/ioctl.h>
 #include <termios.h>
 #if HAVE_LIBUTIL_H
 #include <libutil.h>


### PR DESCRIPTION
`<sys/ioctl.h>`   needed in addition to `<libutil.h>` to define _forkpty()_