### PR TITLE
Add command line option to bind to a specific network interface

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -244,6 +244,7 @@ AC_ARG_WITH([rt_dst],
 )
 AS_IF([test "x$with_rt_dst" = "x"], [
 AC_MSG_CHECKING(whether rtentry is available and has rt_dst)
+AC_LANG(C)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -470,6 +471,23 @@ AS_IF([test "x$with_systemdsystemunitdir" = "xyes" -o "x$with_systemdsystemunitd
 AS_IF([test "x$with_systemdsystemunitdir" != "xno"],
       [AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])])
 AM_CONDITIONAL([HAVE_SYSTEMD], [test "x$with_systemdsystemunitdir" != "xno"])
+
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+#include <sys/types.h>
+#include <sys/socket.h>
+int main(int argc, char **argv){
+        int ret, handle;
+        handle = socket(AF_INET, SOCK_STREAM, 0);
+        ret = setsockopt(handle, SOL_SOCKET, SO_BINDTODEVICE,"lo",3);
+}
+])], [
+	AC_DEFINE(HAVE_SO_BINDTODEVICE, 1)
+	AC_MSG_NOTICE([HAVE_SO_BINDTODEVICE... 1])
+],[
+	AC_DEFINE(HAVE_SO_BINDTODEVICE, 0)
+	AC_MSG_NOTICE([HAVE_SO_BINDTODEVICE... 0])
+])
+
 
 # prepare to get rid of obsolete code (FortiOS 4)
 AC_ARG_ENABLE([obsolete],

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -13,6 +13,7 @@ openfortivpn \- Client for PPP+SSL VPN tunnel services
 [\fB\-\-otp\-delay=\fI<delay>\fR]
 [\fB\-\-no\-ftm\-push\fR]
 [\fB\-\-realm=\fI<realm>\fR]
+[\fB\-\-ifname=\fI<interface>\fR]
 [\fB\-\-set\-routes=<bool>\fR]
 [\fB\-\-no\-routes\fR]
 [\fB\-\-set\-dns=<bool>\fR]
@@ -89,6 +90,9 @@ authentication based on OTP will be used instead.
 \fB\-\-realm=\fI<realm>\fR
 Connect to the specified authentication realm. Defaults to empty, which
 is usually what you want.
+.TP
+\fB\-\-ifname=\fI<interface>\fR
+Bind the connection to the specified network interface.
 .TP
 \fB\-\-set\-routes=\fI<bool>\fR, \fB\-\-no-routes\fR
 Set if openfortivpn should try to configure IP routes through the VPN when

--- a/src/config.c
+++ b/src/config.c
@@ -51,6 +51,7 @@ const struct vpn_config invalid_cfg = {
 	.no_ftm_push = -1,
 	.pinentry = NULL,
 	.realm = {'\0'},
+	.iface_name = {'\0'},
 	.set_routes = -1,
 	.set_dns = -1,
 	.pppd_use_peerdns = -1,
@@ -514,6 +515,8 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 	}
 	if (src->realm[0])
 		strcpy(dst->realm, src->realm);
+	if (src->iface_name[0])
+		strcpy(dst->iface_name, src->iface_name);
 	if (src->set_routes != invalid_cfg.set_routes)
 		dst->set_routes = src->set_routes;
 	if (src->set_dns != invalid_cfg.set_dns)

--- a/src/config.h
+++ b/src/config.h
@@ -87,6 +87,7 @@ struct vpn_config {
 	unsigned int  otp_delay;
 	int         no_ftm_push;
 	char		*pinentry;
+	char		iface_name[FIELD_SIZE + 1];
 	char		realm[FIELD_SIZE + 1];
 
 	int	set_routes;

--- a/src/main.c
+++ b/src/main.c
@@ -51,16 +51,16 @@
 "                                resolver and routes directly.\n" \
 "  --pppd-ifname=<string>        Set the pppd interface name, if supported by pppd.\n" \
 "  --pppd-ipparam=<string>       Provides an extra parameter to the ip-up, ip-pre-up\n" \
-"                                and ip-down scripts. See man (8) pppd\n" \
+"                                and ip-down scripts. See man (8) pppd.\n" \
 "  --pppd-call=<name>            Move most pppd options from pppd cmdline to\n" \
 "                                /etc/ppp/peers/<name> and invoke pppd with\n" \
-"                                'call <name>'\n"
+"                                'call <name>'.\n"
 #elif HAVE_USR_SBIN_PPP
 #define PPPD_USAGE \
 "                    [--ppp-system=<system>]\n"
 #define PPPD_HELP \
 "  --ppp-system=<system>         Connect to the specified system as defined in\n" \
-"                                /etc/ppp/ppp.conf\n"
+"                                /etc/ppp/ppp.conf.\n"
 #else
 #error "Neither HAVE_USR_SBIN_PPPD nor HAVE_USR_SBIN_PPP have been defined."
 #endif
@@ -69,7 +69,7 @@
 #define RESOLVCONF_USAGE \
 "[--use-resolvconf=<0|1>] "
 #define RESOLVCONF_HELP \
-"  --use-resolvconf=[01]         If possible use resolvconf to update /etc/resolv.conf\n"
+"  --use-resolvconf=[01]         If possible use resolvconf to update /etc/resolv.conf.\n"
 #else
 #define RESOLVCONF_USAGE ""
 #define RESOLVCONF_HELP ""
@@ -77,14 +77,14 @@
 
 #define usage \
 "Usage: openfortivpn [<host>[:<port>]] [-u <user>] [-p <pass>]\n" \
-"                    [--pinentry=<program>]\n" \
-"                    [--realm=<realm>] [--otp=<otp>] [--otp-delay=<delay>]\n" \
-"                    [--otp-prompt=<prompt>] [--set-routes=<0|1>]\n" \
+"                    [--otp=<otp>] [--otp-delay=<delay>] [--otp-prompt=<prompt>]\n" \
+"                    [--pinentry=<program>] [--realm=<realm>]\n" \
+"                    [--ifname=<ifname>] [--set-routes=<0|1>]\n" \
 "                    [--half-internet-routes=<0|1>] [--set-dns=<0|1>]\n" \
 PPPD_USAGE \
 "                    " RESOLVCONF_USAGE "[--ca-file=<file>]\n" \
 "                    [--user-cert=<file>] [--user-key=<file>]\n" \
-"                    [--trusted-cert=<digest>] [--use-syslog]\n" \
+"                    [--use-syslog] [--trusted-cert=<digest>]\n" \
 "                    [--persistent=<interval>] [-c <file>] [-v|-q]\n" \
 "       openfortivpn --help\n" \
 "       openfortivpn --version\n" \
@@ -115,11 +115,12 @@ PPPD_USAGE \
 "  -u <user>, --username=<user>  VPN account username.\n" \
 "  -p <pass>, --password=<pass>  VPN account password.\n" \
 "  -o <otp>, --otp=<otp>         One-Time-Password.\n" \
-"  --otp-prompt=<prompt>         Search for the OTP prompt starting with this string\n" \
+"  --otp-prompt=<prompt>         Search for the OTP prompt starting with this string.\n" \
 "  --otp-delay=<delay>           Wait <delay> seconds before sending the OTP.\n" \
 "  --no-ftm-push                 Do not use FTM push if the server provides the option.\n" \
-"  --pinentry=<program>          Use the program to supply a secret instead of asking for it\n" \
+"  --pinentry=<program>          Use the program to supply a secret instead of asking for it.\n" \
 "  --realm=<realm>               Use specified authentication realm.\n" \
+"  --ifname=<interface>          Bind to interface.\n" \
 "  --set-routes=[01]             Set if openfortivpn should configure routes\n" \
 "                                when tunnel is up.\n" \
 "  --no-routes                   Do not configure routes, same as --set-routes=0.\n" \
@@ -128,7 +129,7 @@ PPPD_USAGE \
 "  --set-dns=[01]                Set if openfortivpn should add DNS name servers\n" \
 "                                and domain search list in /etc/resolv.conf.\n" \
 "                                If installed resolvconf is used for the update.\n" \
-"  --no-dns                      Do not reconfigure DNS, same as --set-dns=0\n" \
+"  --no-dns                      Do not reconfigure DNS, same as --set-dns=0.\n" \
 "  --ca-file=<file>              Use specified PEM-encoded certificate bundle\n" \
 "                                instead of system-wide store to verify the gateway\n" \
 "                                certificate.\n" \
@@ -201,6 +202,7 @@ int main(int argc, char **argv)
 		.no_ftm_push = 0,
 		.pinentry = NULL,
 		.realm = {'\0'},
+		.iface_name = {'\0'},
 		.set_routes = 1,
 		.set_dns = 1,
 		.use_syslog = 0,
@@ -249,6 +251,7 @@ int main(int argc, char **argv)
 		{"otp-prompt",      required_argument, NULL, 0},
 		{"otp-delay",       required_argument, NULL, 0},
 		{"no-ftm-push",     no_argument, &cli_cfg.no_ftm_push, 1},
+		{"ifname",          required_argument, NULL, 0},
 		{"set-routes",	    required_argument, NULL, 0},
 		{"no-routes",       no_argument, &cli_cfg.set_routes, 0},
 		{"half-internet-routes", required_argument, NULL, 0},
@@ -428,6 +431,12 @@ int main(int argc, char **argv)
 			if (strcmp(long_options[option_index].name,
 			           "otp-prompt") == 0) {
 				cli_cfg.otp_prompt = strdup(optarg);
+				break;
+			}
+			if (strcmp(long_options[option_index].name,
+			           "ifname") == 0) {
+				strncpy(cli_cfg.iface_name, optarg, FIELD_SIZE);
+				cli_cfg.iface_name[FIELD_SIZE] = '\0';
 				break;
 			}
 			if (strcmp(long_options[option_index].name,


### PR DESCRIPTION
On multiple interface devices, it can be necessary to bind the VPN to a specific network interface. This can be necessary in situations where you have multiple interfaces and need to connect the VPN on a secondary interface. This feature is supported in openconnect, and would be useful in openfortivpn.