### PR TITLE
Fix SIGILL because of out of bounds array access

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -1063,10 +1063,10 @@ int ipv4_add_nameservers_to_resolv_conf(struct tunnel *tunnel)
 	int ret = -1;
 	FILE *file;
 	struct stat stat;
-#define NS_SIZE ARRAY_SIZE("nameserver xxx.xxx.xxx.xxx")
+#define NS_SIZE ARRAY_SIZE("nameserver xxx.xxx.xxx.xxx\n")
 	char ns1[NS_SIZE], ns2[NS_SIZE];
 #undef NS_SIZE
-#define DNS_SUFFIX_SIZE (ARRAY_SIZE("search ") + MAX_DOMAIN_LENGTH)
+#define DNS_SUFFIX_SIZE (ARRAY_SIZE("search \n") + MAX_DOMAIN_LENGTH)
 	char dns_suffix[DNS_SUFFIX_SIZE];
 #undef DNS_SUFFIX_SIZE
 	char *buffer = NULL;

--- a/tests/lint/checkpatch.sh
+++ b/tests/lint/checkpatch.sh
@@ -12,7 +12,7 @@ for file in "$@"; do
 
   "$checkpatch_path" --no-tree --terse \
     --max-line-length=90 \
-    --ignore LEADING_SPACE,SPDX_LICENSE_TAG,CODE_INDENT,NAKED_SSCANF,VOLATILE,NEW_TYPEDEFS,LONG_LINE,LONG_LINE_STRING \
+    --ignore LEADING_SPACE,SPDX_LICENSE_TAG,CODE_INDENT,NAKED_SSCANF,VOLATILE,NEW_TYPEDEFS,LONG_LINE,LONG_LINE_STRING,QUOTED_WHITESPACE_BEFORE_NEWLINE \
     -f "$file" | tee "$tmp"
   
   if [ -s "$tmp" ]; then


### PR DESCRIPTION
Array size was short by one byte for the terminal `"\n"`.
This bug has been partly introduced by c81fde1 for arrays `ns1` and `ns2` but was already present for `dns_suffix`, which had confused me.

Anyway, this confusion precisely shows that c81fde1 was a good idea!