### PR TITLE
Fix password condition check

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -578,7 +578,7 @@ int main(int argc, char **argv)
 		goto user_error;
 	}
 	// If username but no password given, interactively ask user
-	if (cfg.password == NULL && cfg.username[0] != '\0') {
+	if (cfg.password[0] == '\0' && cfg.username[0] != '\0') {
 		char *tmp_password = malloc(PWD_BUFSIZ); // allocate large buffer
 
 		if (tmp_password == NULL) {


### PR DESCRIPTION
Hello,

we recommend our users to let the password attribute at the config file empty and use the request `VPN account password:` if they start a connection. 

This worked only till `1.10`. This problem is fixed with this PR.