### PR TITLE
Extend OTP support to also allow using FTM push

### DIFF
--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -11,6 +11,7 @@ openfortivpn \- Client for PPP+SSL VPN tunnel services
 [\fB\-\-otp=\fI<otp>\fR]
 [\fB\-\-otp\-prompt=\fI<prompt>\fR]
 [\fB\-\-otp\-delay=\fI<delay>\fR]
+[\fB\-\-no\-ftm\-push\fR]
 [\fB\-\-realm=\fI<realm>\fR]
 [\fB\-\-set\-routes=<bool>\fR]
 [\fB\-\-no\-routes\fR]
@@ -78,6 +79,12 @@ Search for the OTP password prompt starting with the string \fI<prompt>\fR.
 Set the amount of time to wait before sending the One-Time-Password.
 The delay time must be specified in seconds, where 0 means
 no wait (this is the default).
+.TP
+\fB\-\-no\-ftm\-push\fR
+Do not use FTM push if the server provides the option.
+The server may be configured to allow two factor authentication through a
+push notification to the mobile application. If this option is provided,
+authentication based on OTP will be used instead.
 .TP
 \fB\-\-realm=\fI<realm>\fR
 Connect to the specified authentication realm. Defaults to empty, which
@@ -285,6 +292,10 @@ password = bar
 # otp\-delay = 0
 .br
 # otp\-prompt = Please
+.br
+# This would disable FTM push notification support, and use OTP instead
+.br
+# no\-ftm\-push = 1
 .br
 # pinentry = pinentry program
 .br

--- a/src/config.c
+++ b/src/config.c
@@ -48,6 +48,7 @@ const struct vpn_config invalid_cfg = {
 	.otp = {'\0'},
 	.otp_prompt = NULL,
 	.otp_delay = -1,
+	.no_ftm_push = -1,
 	.pinentry = NULL,
 	.realm = {'\0'},
 	.set_routes = -1,
@@ -277,6 +278,15 @@ int load_config(struct vpn_config *cfg, const char *filename)
 				continue;
 			}
 			cfg->otp_delay = otp_delay;
+		} else if (strcmp(key, "no-ftm-push") == 0) {
+			int no_ftm_push = strtob(val);
+
+			if (no_ftm_push < 0) {
+				log_warn("Bad no-ftm-push in config file: \"%s\".\n",
+				         val);
+				continue;
+			}
+			cfg->no_ftm_push = no_ftm_push;
 		} else if (strcmp(key, "pinentry") == 0) {
 			free(cfg->pinentry);
 			cfg->pinentry = strdup(val);
@@ -500,6 +510,8 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 		strcpy(dst->otp, src->otp);
 	if (src->otp_delay != invalid_cfg.otp_delay)
 		dst->otp_delay = src->otp_delay;
+	if (src->no_ftm_push != invalid_cfg.no_ftm_push)
+		dst->no_ftm_push = src->no_ftm_push;
 	if (src->pinentry) {
 		free(dst->pinentry);
 		dst->pinentry = src->pinentry;

--- a/src/config.h
+++ b/src/config.h
@@ -85,6 +85,7 @@ struct vpn_config {
 	char		otp[FIELD_SIZE + 1];
 	char		*otp_prompt;
 	unsigned int  otp_delay;
+	int         no_ftm_push;
 	char		*pinentry;
 	char		realm[FIELD_SIZE + 1];
 

--- a/src/main.c
+++ b/src/main.c
@@ -117,6 +117,7 @@ PPPD_USAGE \
 "  -o <otp>, --otp=<otp>         One-Time-Password.\n" \
 "  --otp-prompt=<prompt>         Search for the OTP prompt starting with this string\n" \
 "  --otp-delay=<delay>           Wait <delay> seconds before sending the OTP.\n" \
+"  --no-ftm-push                 Do not use FTM push if the server provides the option.\n" \
 "  --pinentry=<program>          Use the program to supply a secret instead of asking for it\n" \
 "  --realm=<realm>               Use specified authentication realm.\n" \
 "  --set-routes=[01]             Set if openfortivpn should configure routes\n" \
@@ -197,6 +198,7 @@ int main(int argc, char **argv)
 		.otp = {'\0'},
 		.otp_prompt = NULL,
 		.otp_delay = 0,
+		.no_ftm_push = 0,
 		.pinentry = NULL,
 		.realm = {'\0'},
 		.set_routes = 1,
@@ -245,6 +247,7 @@ int main(int argc, char **argv)
 		{"otp",             required_argument, NULL, 'o'},
 		{"otp-prompt",      required_argument, NULL, 0},
 		{"otp-delay",       required_argument, NULL, 0},
+		{"no-ftm-push",     no_argument, &cli_cfg.no_ftm_push, 1},
 		{"set-routes",	    required_argument, NULL, 0},
 		{"no-routes",       no_argument, &cli_cfg.set_routes, 0},
 		{"half-internet-routes", required_argument, NULL, 0},


### PR DESCRIPTION
In our organization, the fortinet server is configured to be able to send a push notification to the FortiToken app. I figured I could give it a shot to add this feature to this client :).

Checking the requests the official client sends for this, I found it sends `ftmpush=1` instead of the `code=<OTP>&code2=` data in the `logincheck` post.

I've done my best to keep the code around this as clean as I could, but my C++ isn't that strong.  
The code does what I want it to do though; it sends me a push notification if I don't pre-configure the OTP, and uses the given OTP if I run `openfortivpn` with the `--otp=<OTP>` option.