### PR TITLE
add set-default-route=[01]

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -59,6 +59,7 @@ const struct vpn_config invalid_cfg = {
 #endif
 	.use_syslog = -1,
 	.half_internet_routes = -1,
+	.set_default_route = -1,
 	.persistent = -1,
 #if HAVE_USR_SBIN_PPPD
 	.pppd_log = NULL,
@@ -320,6 +321,15 @@ int load_config(struct vpn_config *cfg, const char *filename)
 				continue;
 			}
 			cfg->half_internet_routes = half_internet_routes;
+		} else if (strcmp(key, "set-default-route") == 0) {
+			int set_default_route = strtob(val);
+
+			if (set_default_route < 0) {
+				log_warn("Bad set_default_route in config file: \"%s\".\n",
+				         val);
+				continue;
+			}
+			cfg->set_default_route = set_default_route;
 		} else if (strcmp(key, "persistent") == 0) {
 			unsigned long persistent = strtoul(val, NULL, 0);
 
@@ -532,6 +542,8 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 		dst->use_syslog = src->use_syslog;
 	if (src->half_internet_routes != invalid_cfg.half_internet_routes)
 		dst->half_internet_routes = src->half_internet_routes;
+	if (src->set_default_route != invalid_cfg.set_default_route)
+		dst->set_default_route = src->set_default_route;
 	if (src->persistent != invalid_cfg.persistent)
 		dst->persistent = src->persistent;
 #if HAVE_USR_SBIN_PPPD

--- a/src/config.h
+++ b/src/config.h
@@ -97,6 +97,7 @@ struct vpn_config {
 	int	use_resolvconf;
 #endif
 	int	half_internet_routes;
+	int	set_default_route;
 
 	unsigned int	persistent;
 

--- a/src/main.c
+++ b/src/main.c
@@ -86,6 +86,7 @@ PPPD_USAGE \
 "                    [--user-cert=<file>] [--user-key=<file>]\n" \
 "                    [--trusted-cert=<digest>] [--use-syslog]\n" \
 "                    [--persistent=<interval>] [-c <file>] [-v|-q]\n" \
+"                    [--set-default-route=<0|1>]" \
 "       openfortivpn --help\n" \
 "       openfortivpn --version\n" \
 "\n"
@@ -122,6 +123,8 @@ PPPD_USAGE \
 "  --realm=<realm>               Use specified authentication realm.\n" \
 "  --set-routes=[01]             Set if openfortivpn should configure routes\n" \
 "                                when tunnel is up.\n" \
+"  --set-default-route=[01]      Configure the default route through the VPN when set to 1\n" \
+"                                Default is 1.\n" \
 "  --no-routes                   Do not configure routes, same as --set-routes=0.\n" \
 "  --half-internet-routes=[01]   Add two 0.0.0.0/1 and 128.0.0.0/1 routes with higher\n" \
 "                                priority instead of replacing the default route.\n" \
@@ -205,6 +208,7 @@ int main(int argc, char **argv)
 		.set_dns = 1,
 		.use_syslog = 0,
 		.half_internet_routes = 0,
+		.set_default_route = 1,
 		.persistent = 0,
 #if HAVE_RESOLVCONF
 		.use_resolvconf = USE_RESOLVCONF,
@@ -251,6 +255,7 @@ int main(int argc, char **argv)
 		{"set-routes",	    required_argument, NULL, 0},
 		{"no-routes",       no_argument, &cli_cfg.set_routes, 0},
 		{"half-internet-routes", required_argument, NULL, 0},
+		{"set-default-route", required_argument, NULL, 0},
 		{"set-dns",         required_argument, NULL, 0},
 		{"no-dns",          no_argument, &cli_cfg.set_dns, 0},
 		{"use-syslog",      no_argument, &cli_cfg.use_syslog, 1},
@@ -451,6 +456,18 @@ int main(int argc, char **argv)
 					break;
 				}
 				cli_cfg.half_internet_routes = half_internet_routes;
+				break;
+			}
+			if (strcmp(long_options[option_index].name,
+			           "set-default-route") == 0) {
+				int set_default_route = strtob(optarg);
+
+				if (set_default_route < 0) {
+					log_warn("Bad set-default-route option: \"%s\"\n",
+					         optarg);
+					break;
+				}
+				cli_cfg.set_default_route = set_default_route;
 				break;
 			}
 			if (strcmp(long_options[option_index].name,


### PR DESCRIPTION
Ability to disable default route for VPN with explicit routing only.
Few fixes to split routes to avoid routes with 0.0.0.0 as their destination to be unaccessible.