### PR TITLE
Destroy password supplied via CLI

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -510,6 +510,8 @@ int main(int argc, char **argv)
 			break;
 		case 'p':
 			cli_cfg.password = strdup(optarg);
+			while (*optarg)
+				*optarg++ = '*';  // nuke it
 			break;
 		case 'o':
 			strncpy(cli_cfg.otp, optarg, FIELD_SIZE);


### PR DESCRIPTION
Some other programs like mysql do it. It's not 100% safe. One can still view it in output of `ps` **if** invoked at the _right_ time.

![much-security-so-safe-wow](https://user-images.githubusercontent.com/1779189/87236687-1d3b9980-c3ba-11ea-81d1-7f80cc905c53.jpg)
