### PR TITLE
Fix compiler warnings produced by Clang

### DIFF
--- a/src/hdlc.c
+++ b/src/hdlc.c
@@ -123,10 +123,10 @@ void init_hdlc(void)
 ssize_t hdlc_encode(uint8_t *frame, size_t frmsize,
                     const uint8_t *packet, size_t pktsize)
 {
-	ssize_t written = 0;
+	size_t written = 0;
 	uint16_t checksum;
 	const uint8_t address_control_fields[] = { 0xff, 0x03 };
-	int i;
+	size_t i;
 	uint8_t byte;
 
 	if (frmsize < 7)
@@ -197,7 +197,7 @@ ssize_t hdlc_encode(uint8_t *frame, size_t frmsize,
  */
 ssize_t hdlc_find_frame(const uint8_t *buffer, size_t bufsize, off_t *start)
 {
-	int i, s = -1, e = -1;
+	size_t i, s = -1, e = -1;
 
 	// Look for frame start
 	for (i = *start; i < bufsize - 2; i++) {
@@ -206,7 +206,7 @@ ssize_t hdlc_find_frame(const uint8_t *buffer, size_t bufsize, off_t *start)
 			break;
 		}
 	}
-	if (s == -1)
+	if (s == (size_t)-1)
 		return ERR_HDLC_NO_FRAME_FOUND;
 
 	// Discard empty frames
@@ -220,7 +220,7 @@ ssize_t hdlc_find_frame(const uint8_t *buffer, size_t bufsize, off_t *start)
 			break;
 		}
 	}
-	if (e == -1)
+	if (e == (size_t)-1)
 		return ERR_HDLC_NO_FRAME_FOUND;
 
 	*start = s;
@@ -243,9 +243,9 @@ ssize_t hdlc_decode(const uint8_t *frame, size_t frmsize,
                     uint8_t *packet, size_t pktsize)
 {
 	off_t start = 0;
-	ssize_t written = 0;
+	size_t written = 0;
 	int has_address_control_fields = 0;
-	int i;
+	size_t i;
 	int in_escape;
 	uint16_t checksum;
 

--- a/src/http.c
+++ b/src/http.c
@@ -473,7 +473,7 @@ static int try_otp_auth(struct tunnel *tunnel, const char *buffer,
 	char *d = data;
 	const char *p = NULL;
 	/* Length-check for destination buffer */
-#define SPACE_AVAILABLE(sz) (sizeof(data) - (d - data) >= (sz))
+#define SPACE_AVAILABLE(sz) ((long)sizeof(data) - (long)(d - data) >= (long)(sz))
 	/* Get the form action */
 	s = strcasestr(s, "<FORM");
 	if (s == NULL)
@@ -485,7 +485,7 @@ static int try_otp_auth(struct tunnel *tunnel, const char *buffer,
 	e = strchr(s, '"');
 	if (e == NULL)
 		return -1;
-	if (e - s + 1 > sizeof(path))
+	if (e - s + 1 > (long)sizeof(path))
 		return -1;
 	strncpy(path, s, e - s);
 	path[e - s] = '\0';
@@ -499,7 +499,7 @@ static int try_otp_auth(struct tunnel *tunnel, const char *buffer,
 	if (p) {
 		e = strchr(p, '<');
 		if (e != NULL) {
-			if (e - p + 1 < sizeof(prompt)) {
+			if (e - p + 1 < (long)sizeof(prompt)) {
 				strncpy(prompt, p, e - p);
 				prompt[e - p] = '\0';
 				p = prompt;
@@ -545,7 +545,7 @@ static int try_otp_auth(struct tunnel *tunnel, const char *buffer,
 			e = strchr(n, '"');
 			if (e == NULL)
 				return -1;
-			if (e - n + 1 > sizeof(tmp))
+			if (e - n + 1 > (long)sizeof(tmp))
 				return -1;
 			strncpy(tmp, n, e - n);
 			tmp[e - n] = '\0';
@@ -565,7 +565,7 @@ static int try_otp_auth(struct tunnel *tunnel, const char *buffer,
 			e = strchr(v, '"');
 			if (e == NULL)
 				return -1;
-			if (e - v + 1 > sizeof(tmp))
+			if (e - v + 1 > (long)sizeof(tmp))
 				return -1;
 			strncpy(tmp, v, e - v);
 			tmp[e - v] = '\0';

--- a/src/io.c
+++ b/src/io.c
@@ -71,7 +71,7 @@ typedef sem_t os_semaphore_t;
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 static pthread_mutex_t *lockarray;
 
-static void lock_callback(int mode, int type, const char *file, int line)
+static void lock_callback(int mode, int type)
 {
 	if (mode & CRYPTO_LOCK)
 		pthread_mutex_lock(&lockarray[type]);

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -1052,7 +1052,7 @@ int ipv4_restore_routes(struct tunnel *tunnel)
 
 static inline char *replace_char(char *str, char find, char replace)
 {
-	int i;
+	size_t i;
 
 	for (i = 0; i < strlen(str); i++)
 		if (str[i] == find)

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -397,7 +397,7 @@ static int pppd_terminate(struct tunnel *tunnel)
 		log_debug("waitpid: %s exit status code %d\n",
 		          PPP_DAEMON, exit_status);
 #if HAVE_USR_SBIN_PPPD
-		if (exit_status >= ARRAY_SIZE(pppd_message) || exit_status < 0) {
+		if (exit_status >= (int)ARRAY_SIZE(pppd_message) || exit_status < 0) {
 			log_error("%s: Returned an unknown exit status: %d\n",
 			          PPP_DAEMON, exit_status);
 		} else {
@@ -614,7 +614,7 @@ static int tcp_connect(struct tunnel *tunnel)
 		        inet_ntoa(tunnel->config->gateway_ip),
 		        tunnel->config->gateway_port);
 
-		ssize_t bytes_written = write(handle, request, strlen(request));
+		size_t bytes_written = write(handle, request, strlen(request));
 
 		if (bytes_written != strlen(request)) {
 			log_error("write error while talking to proxy: %s\n",
@@ -627,7 +627,7 @@ static int tcp_connect(struct tunnel *tunnel)
 		const char *response = NULL;
 
 		memset(&(request), '\0', sizeof(request));
-		for (int j = 0; response == NULL; j++) {
+		for (size_t j = 0; response == NULL; j++) {
 			if (j >= ARRAY_SIZE(request) - 1) {
 				log_error("Proxy response is unexpectedly large and cannot fit in the %lu-bytes buffer.\n",
 				          ARRAY_SIZE(request));
@@ -673,7 +673,7 @@ static int tcp_connect(struct tunnel *tunnel)
 				};
 				const char *eol = NULL;
 
-				for (int i = 0; (i < ARRAY_SIZE(HTTP_EOL)) &&
+				for (size_t i = 0; (i < ARRAY_SIZE(HTTP_EOL)) &&
 				     (eol == NULL); i++)
 					eol = strstr(response, HTTP_EOL[i]);
 				response = eol;

--- a/src/userinput.c
+++ b/src/userinput.c
@@ -301,7 +301,7 @@ void read_password(const char *pinentry, const char *hint,
 {
 	int masked = 0;
 	struct termios oldt, newt;
-	int i;
+	size_t i;
 
 	if (pinentry && *pinentry) {
 		pinentry_read_password(pinentry, hint, prompt, pass, len);


### PR DESCRIPTION
This patch adds fixes for `-Wsign-compare` & `-Wunused-parameter`

```bash
$ make 
  CC       src/openfortivpn-hdlc.o
src/hdlc.c:147:16: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
        for (i = 0; i < pktsize; i++) {
                    ~ ^ ~~~~~~~
src/hdlc.c:150:15: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'long' [-Wsign-compare]
                if (frmsize < written + 2)
                    ~~~~~~~ ^ ~~~~~~~~~~~
src/hdlc.c:160:14: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned long') and 'long' [-Wsign-compare]
        if (frmsize < written + 3)
            ~~~~~~~ ^ ~~~~~~~~~~~
src/hdlc.c:203:21: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
        for (i = *start; i < bufsize - 2; i++) {
                         ~ ^ ~~~~~~~~~~~
src/hdlc.c:213:11: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
        while (s < bufsize - 2 && buffer[s] == 0x7e) // consecutive Flag Sequences
               ~ ^ ~~~~~~~~~~~
src/hdlc.c:217:16: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
        for (i = s; i < bufsize; i++) {
                    ~ ^ ~~~~~~~
src/hdlc.c:262:20: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
        for (i = start; i < frmsize; i++) {
                        ~ ^ ~~~~~~~
src/hdlc.c:276:15: warning: comparison of integers of different signs: 'ssize_t' (aka 'long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
                if (written >= pktsize)
                    ~~~~~~~ ^  ~~~~~~~
8 warnings generated.
  CC       src/openfortivpn-http.o
src/http.c:488:16: warning: comparison of integers of different signs: 'long' and 'unsigned long' [-Wsign-compare]
        if (e - s + 1 > sizeof(path))
            ~~~~~~~~~ ^ ~~~~~~~~~~~~
src/http.c:502:18: warning: comparison of integers of different signs: 'long' and 'unsigned long' [-Wsign-compare]
                        if (e - p + 1 < sizeof(prompt)) {
                            ~~~~~~~~~ ^ ~~~~~~~~~~~~~~
src/http.c:548:18: warning: comparison of integers of different signs: 'long' and 'unsigned long' [-Wsign-compare]
                        if (e - n + 1 > sizeof(tmp))
                            ~~~~~~~~~ ^ ~~~~~~~~~~~
src/http.c:552:9: warning: comparison of integers of different signs: 'unsigned long' and 'long' [-Wsign-compare]
                        if (!SPACE_AVAILABLE(3 * (e - n) + 1))
                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/http.c:476:56: note: expanded from macro 'SPACE_AVAILABLE'
#define SPACE_AVAILABLE(sz) (sizeof(data) - (d - data) >= (sz))
                             ~~~~~~~~~~~~~~~~~~~~~~~~~ ^   ~~
src/http.c:568:18: warning: comparison of integers of different signs: 'long' and 'unsigned long' [-Wsign-compare]
                        if (e - v + 1 > sizeof(tmp))
                            ~~~~~~~~~ ^ ~~~~~~~~~~~
src/http.c:572:9: warning: comparison of integers of different signs: 'unsigned long' and 'long' [-Wsign-compare]
                        if (!SPACE_AVAILABLE(3 * (e - v) + 1))
                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/http.c:476:56: note: expanded from macro 'SPACE_AVAILABLE'
#define SPACE_AVAILABLE(sz) (sizeof(data) - (d - data) >= (sz))
                             ~~~~~~~~~~~~~~~~~~~~~~~~~ ^   ~~
6 warnings generated.
  CC       src/openfortivpn-io.o
src/io.c:74:59: warning: unused parameter 'file' [-Wunused-parameter]
static void lock_callback(int mode, int type, const char *file, int line)
                                                          ^
src/io.c:74:69: warning: unused parameter 'line' [-Wunused-parameter]
static void lock_callback(int mode, int type, const char *file, int line)
                                                                    ^
2 warnings generated.
  CC       src/openfortivpn-ipv4.o
src/ipv4.c:1057:16: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
        for (i = 0; i < strlen(str); i++)
                    ~ ^ ~~~~~~~~~~~
1 warning generated.
  CC       src/openfortivpn-tunnel.o
src/tunnel.c:400:19: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
                if (exit_status >= ARRAY_SIZE(pppd_message) || exit_status < 0) {
                    ~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~
src/tunnel.c:619:21: warning: comparison of integers of different signs: 'ssize_t' (aka 'long') and 'unsigned long' [-Wsign-compare]
                if (bytes_written != strlen(request)) {
                    ~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~
src/tunnel.c:631:10: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
                        if (j >= ARRAY_SIZE(request) - 1) {
                            ~ ^  ~~~~~~~~~~~~~~~~~~~~~~~
src/tunnel.c:676:24: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
                                for (int i = 0; (i < ARRAY_SIZE(HTTP_EOL)) &&
                                                 ~ ^ ~~~~~~~~~~~~~~~~~~~~
4 warnings generated.
  CC       src/openfortivpn-userinput.o
src/userinput.c:322:16: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
        for (i = 0; i < len; i++) {
                    ~ ^ ~~~
1 warning generated.
  CCLD     openfortivpn
```