### PR TITLE
#754 io.c: pppd_write() - continue on EAGAIN

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -337,9 +337,13 @@ static void *pppd_write(void *arg)
 			n = write(tunnel->pppd_pty, &hdlc_buffer[written],
 			          len - written);
 			// retry on repeatable failure
-			if ((n == -1) && (errno != EAGAIN)) {
-				log_error("write: %s\n", strerror(errno));
-				goto err_free_buf;
+			if (n == -1) {
+				if (errno == EAGAIN) {
+					continue;
+				} else {
+					log_error("write: %s\n", strerror(errno));
+					goto err_free_buf;
+				}
 			}
 			written += n;
 		}


### PR DESCRIPTION
"written += n" in the case that n==-1 and errno == EAGAIN causes "written" to go backwards. continue, instead, to avoid updating it in the retryable write case.