### PR TITLE
Ensure only the pin code is sent

### DIFF
--- a/src/userinput.c
+++ b/src/userinput.c
@@ -97,7 +97,7 @@ static char *uri_unescape(const char *string)
 static int pinentry_read(int from, char **retstr)
 {
 	int bufsiz = 0;
-	char *buf = NULL;
+	char *buf = NULL, *saveptr = NULL;;
 	int len = 0;
 	int ret;
 
@@ -135,7 +135,7 @@ static int pinentry_read(int from, char **retstr)
 	    || strncmp(buf, "D ", 2) == 0) {
 		if (retstr) {
 			*retstr = strchr(buf, ' ');
-			*retstr = *retstr ? strtok_r(*retstr, "\n", NULL) : NULL;
+			*retstr = *retstr ? strtok_r(*retstr, "\n", &saveptr) : NULL;
 			*retstr = *retstr ? uri_unescape(*retstr + 1) : NULL;
 		}
 		free(buf);

--- a/src/userinput.c
+++ b/src/userinput.c
@@ -97,7 +97,7 @@ static char *uri_unescape(const char *string)
 static int pinentry_read(int from, char **retstr)
 {
 	int bufsiz = 0;
-	char *buf = NULL, *saveptr = NULL;
+	char *buf = NULL;
 	int len = 0;
 	int ret;
 
@@ -135,7 +135,7 @@ static int pinentry_read(int from, char **retstr)
 	    || strncmp(buf, "D ", 2) == 0) {
 		if (retstr) {
 			*retstr = strchr(buf, ' ');
-			**retstr = *retstr ? strtok_r(*retstr, "\n", &saveptr) : NULL;
+			*retstr = *retstr ? strtok_r(*retstr, "\n", NULL) : NULL;
 			*retstr = *retstr ? uri_unescape(*retstr + 1) : NULL;
 		}
 		free(buf);

--- a/src/userinput.c
+++ b/src/userinput.c
@@ -135,6 +135,7 @@ static int pinentry_read(int from, char **retstr)
 	    || strncmp(buf, "D ", 2) == 0) {
 		if (retstr) {
 			*retstr = strchr(buf, ' ');
+			*retstr = strtok(*retstr, "\n");
 			*retstr = *retstr ? uri_unescape(*retstr + 1) : NULL;
 		}
 		free(buf);

--- a/src/userinput.c
+++ b/src/userinput.c
@@ -97,7 +97,7 @@ static char *uri_unescape(const char *string)
 static int pinentry_read(int from, char **retstr)
 {
 	int bufsiz = 0;
-	char *buf = NULL;
+	char *buf = NULL, *saveptr = NULL;
 	int len = 0;
 	int ret;
 
@@ -135,7 +135,7 @@ static int pinentry_read(int from, char **retstr)
 	    || strncmp(buf, "D ", 2) == 0) {
 		if (retstr) {
 			*retstr = strchr(buf, ' ');
-			*retstr = strtok(*retstr, "\n");
+			**retstr = *retstr ? strtok_r(*retstr, "\n", &saveptr) : NULL;
 			*retstr = *retstr ? uri_unescape(*retstr + 1) : NULL;
 		}
 		free(buf);

--- a/src/userinput.c
+++ b/src/userinput.c
@@ -97,7 +97,7 @@ static char *uri_unescape(const char *string)
 static int pinentry_read(int from, char **retstr)
 {
 	int bufsiz = 0;
-	char *buf = NULL, *saveptr = NULL;;
+	char *buf = NULL, *saveptr = NULL;
 	int len = 0;
 	int ret;
 


### PR DESCRIPTION
The pinentry program answers with "D PIN\nOK\n". Sometimes the "\nOK\n" gets sent to the gateway, causing errors. The change ensures only the PIN is sent, by taking the string up to, and discarding, the first "\n". See https://github.com/adrienverge/openfortivpn/issues/744