### PR TITLE
Use different hints for OTP and 2FA

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -726,8 +726,8 @@ int auth_log_in(struct tunnel *tunnel)
 			snprintf(tokenparams, sizeof(tokenparams), "ftmpush=1");
 		} else {
 			if (cfg->otp[0] == '\0') {
-				// Prompt for OTP token
-				read_password(cfg->pinentry, "otp",
+				// Prompt for 2FA token
+				read_password(cfg->pinentry, "2fa",
 				              "Two-factor authentication token: ",
 				              cfg->otp, FIELD_SIZE);
 


### PR DESCRIPTION
OTP is used when the user has a fortitoken in advance and can set it in the config file or via the command line, so that it is available before login. 2FA are requested after login, sent by email or SMS. 
It makes sense to name the hint differently, and helps distinguish both cases case forthe benefit of NetworkManager-fortisslvpn and derivatives