### PR TITLE
properly update resolvconf if use option "use-resolvconf=0"

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -1063,19 +1063,20 @@ static inline char *replace_char(char *str, char find, char replace)
 //string trim function it removes trim chars from first & end of string
 static inline char *str_trim(const char *input, char *output, char *trim_chars)
 {
-    int i, j, len = strlen(input), start_index = -1, end_index = -1, trim_char_len, flag;
-    char temp;
+	int i, j, len = strlen(input);
+	int start_index = -1, end_index = -1, trim_char_len, flag;
+	char temp;
 
-    if (trim_chars == NULL) {
+	if (trim_chars == NULL) {
 		//if trim chars is NULL then set default
 assign_trim_chars:
-        trim_chars = " \n\r";
-        trim_char_len = 3;
-    } else {
-        trim_char_len = strlen(trim_chars);
+		trim_chars = " \n\r";
+		trim_char_len = 3;
+	} else {
+		trim_char_len = strlen(trim_chars);
 		if (trim_char_len <= 0)
 			goto assign_trim_chars;
-    }
+	}
 	// remove trim chars from first untill reach character other than trim char
 	for (i = 0; i < len; i++) {
 		temp = input[i];
@@ -1089,32 +1090,32 @@ assign_trim_chars:
 			start_index = i;
 			break;
 		}
-    }
+	}
 	//if start_index is -1 then
 	//all chars are trim chars so set 0th char to \0 and return
-    if (start_index == -1) {
-        output[0] = '\0';
-        return output;
-    }
+	if (start_index == -1) {
+		output[0] = '\0';
+		return output;
+	}
 	// remove trim chars from last to first
 	//untill reach character other than trim char
-    for (i = len-1; i > -1; i--) {
-        temp = input[i];
-        flag = 0;
+	for (i = len-1; i > -1; i--) {
+		temp = input[i];
+		flag = 0;
 		for (j = 0; j < trim_char_len; j++)
 			if (temp == trim_chars[j])
 				flag = 1;
 		if (flag == 0) {
 			end_index = i;
 			break;
-        }
-    }
+		}
+	}
 	//end index other than trim char so add +1 for loop
-    ++end_index;
-    for (i = start_index, j = 0; i < end_index; i++, j++)
-        output[j] = input[i];
+	++end_index;
+	for (i = start_index, j = 0; i < end_index; i++, j++)
+		output[j] = input[i];
 	//add final as \0
-    output[j] = '\0';
+	output[j] = '\0';
 	return output;
 }
 

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -1068,27 +1068,27 @@ static inline char *str_trim(const char *input, char *output, char *trim_chars)
 
     if (trim_chars == NULL) {
 		//if trim chars is NULL then set default
-        assign_trim_chars:
+assign_trim_chars:
         trim_chars = " \n\r";
         trim_char_len = 3;
     } else {
         trim_char_len = strlen(trim_chars);
-        if (trim_char_len <= 0)
-            goto assign_trim_chars;
+		if (trim_char_len <= 0)
+			goto assign_trim_chars;
     }
 	// remove trim chars from first untill reach character other than trim char
-    for (i = 0; i < len; i++) {
-        temp = input[i];
-        if (temp == '\0')
-            break;
-        flag = 0;
-        for (int j = 0; j < trim_char_len; j++)
-            if (temp == trim_chars[j])
-                flag=1;
-        if (flag == 0) {
-            start_index = i;
-            break;
-        }   
+	for (i = 0; i < len; i++) {
+		temp = input[i];
+		if (temp == '\0')
+			break;
+		flag = 0;
+		for (int j = 0; j < trim_char_len; j++)
+			if (temp == trim_chars[j])
+				flag = 1;
+		if (flag == 0) {
+			start_index = i;
+			break;
+		}
     }
 	//if start_index is -1 then all chars are trim chars so set 0th char to \0 and return
     if (start_index == -1) {
@@ -1099,13 +1099,13 @@ static inline char *str_trim(const char *input, char *output, char *trim_chars)
     for (i = len-1; i > -1; i--) {
         temp = input[i];
         flag = 0;
-        for (j = 0; j < trim_char_len; j++)
-            if (temp == trim_chars[j])
-                flag=1;
-        if (flag == 0) {
-            end_index = i;
-            break;
-        }   
+		for (j = 0; j < trim_char_len; j++)
+			if (temp == trim_chars[j])
+				flag = 1;
+		if (flag == 0) {
+			end_index = i;
+			break;
+        }
     }
 	//end index other than trim char so add +1 for loop
     ++end_index;
@@ -1239,7 +1239,7 @@ int ipv4_add_nameservers_to_resolv_conf(struct tunnel *tunnel)
 
 	if (use_resolvconf == 0) {
 		char *saveptr = NULL;
-		
+
 		strcpy(buffer, resolv_conf_data);
 		for (const char *line = strtok_r(buffer, "\n", &saveptr);
 		     line != NULL;

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -1061,76 +1061,59 @@ static inline char *replace_char(char *str, char find, char replace)
 }
 
 //string trim function it removes trim chars from first & end of string
-static inline void str_trim(const char* input, char* output,char* trim_chars){
-    int i, j, len = strlen(input), start_index=-1, end_index=-1, trim_char_len, flag;
+static inline char *str_trim(const char *input, char *output, char *trim_chars)
+{
+    int i, j, len = strlen(input), start_index = -1, end_index = -1, trim_char_len, flag;
     char temp;
-    if(trim_chars==NULL){
-	//if trim chars is NULL then set default
+
+    if (trim_chars == NULL) {
+		//if trim chars is NULL then set default
         assign_trim_chars:
         trim_chars = " \n\r";
         trim_char_len = 3;
-    }else{
+    } else {
         trim_char_len = strlen(trim_chars);
-        if(trim_char_len<=0){
+        if (trim_char_len <= 0)
             goto assign_trim_chars;
-        }
     }
 	// remove trim chars from first untill reach character other than trim char
-    for ( i = 0; i < len; i++)
-    {
+    for (i = 0; i < len; i++) {
         temp = input[i];
-        if(temp=='\0'){
+        if (temp == '\0')
             break;
-        }
         flag = 0;
         for (int j = 0; j < trim_char_len; j++)
-        {
             if (temp == trim_chars[j])
-            {
                 flag=1;
-            }
-            
-        }
-        if(flag==0){
+        if (flag == 0) {
             start_index = i;
             break;
-        }
-        
+        }   
     }
 	//if start_index is -1 then all chars are trim chars so set 0th char to \0 and return
-    if(start_index==-1){
-        output[0]='\0';
-        return;
+    if (start_index == -1) {
+        output[0] = '\0';
+        return output;
     }
 	// remove trim chars from last to first untill reach character other than trim char
-    for ( i = len-1; i > -1; i--)
-    {
+    for (i = len-1; i > -1; i--) {
         temp = input[i];
         flag = 0;
         for (j = 0; j < trim_char_len; j++)
-        {
             if (temp == trim_chars[j])
-            {
                 flag=1;
-            }
-            
-        }
-        if(flag==0){
+        if (flag == 0) {
             end_index = i;
             break;
-        }
-        
+        }   
     }
 	//end index other than trim char so add +1 for loop
     ++end_index;
-    
-    for (i = start_index,j=0; i < end_index; i++,j++)
-    {
+    for (i = start_index, j = 0; i < end_index; i++, j++)
         output[j] = input[i];
-    }
 	//add final as \0
-    output[j]='\0';
-	return;
+    output[j] = '\0';
+	return output;
 }
 
 int ipv4_add_nameservers_to_resolv_conf(struct tunnel *tunnel)
@@ -1256,6 +1239,7 @@ int ipv4_add_nameservers_to_resolv_conf(struct tunnel *tunnel)
 
 	if (use_resolvconf == 0) {
 		char *saveptr = NULL;
+		
 		strcpy(buffer, resolv_conf_data);
 		for (const char *line = strtok_r(buffer, "\n", &saveptr);
 		     line != NULL;

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -1090,12 +1090,14 @@ assign_trim_chars:
 			break;
 		}
     }
-	//if start_index is -1 then all chars are trim chars so set 0th char to \0 and return
+	//if start_index is -1 then
+	//all chars are trim chars so set 0th char to \0 and return
     if (start_index == -1) {
         output[0] = '\0';
         return output;
     }
-	// remove trim chars from last to first untill reach character other than trim char
+	// remove trim chars from last to first
+	//untill reach character other than trim char
     for (i = len-1; i > -1; i--) {
         temp = input[i];
         flag = 0;
@@ -1128,7 +1130,8 @@ int ipv4_add_nameservers_to_resolv_conf(struct tunnel *tunnel)
 	char dns_suffix[DNS_SUFFIX_SIZE];
 #undef DNS_SUFFIX_SIZE
 	char *buffer = NULL;
-	//resolv_conf_data used to hold resolvconf data because strtok_r changed input buffer
+	//resolv_conf_data used to hold resolvconf data
+	//because strtok_r changed input buffer
 	char *resolv_conf_data = NULL;
 	int use_resolvconf = 0;
 


### PR DESCRIPTION
1) replace_char(dns_suffix, ';', ' '); missed in while delete name-server so added it
2) dns_suffix ends with ; have ends with " " so trimmed the dns_suffix
3) strtok_r method changed the input buffer so resolv_conf updation not working properly if name-server already present