### PR TITLE
Hopefully help reach higher speeds on macOS

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -232,7 +232,7 @@ static int pppd_run(struct tunnel *tunnel)
 		} else {
 			static const char *const v[] = {
 				ppp_path,
-				"115200", // speed
+				"230400", // speed
 				":192.0.2.1", // <local_IP_address>:<remote_IP_address>
 				"noipdefault",
 				"noaccomp",


### PR DESCRIPTION
While on Linux the _speed_ option does not seem to be taken into account, on macOS it appears to be throttling the VPN connection.

According to the [`pppd` man page](https://ppp.samba.org/pppd.html), Linux and other system "only support the commonly-used baud rates". However, `pppd` does not require specific baud rates in this use case.

Fixes #428?