### PR TITLE
Revert from dynamic to automatic allocation of password

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -292,8 +292,8 @@ int load_config(struct vpn_config *cfg, const char *filename)
 			free(cfg->pinentry);
 			cfg->pinentry = strdup(val);
 		} else if (strcmp(key, "realm") == 0) {
-			strncpy(cfg->realm, val, FIELD_SIZE - 1);
-			cfg->realm[FIELD_SIZE] = '\0';
+			strncpy(cfg->realm, val, REALM_SIZE);
+			cfg->realm[REALM_SIZE] = '\0';
 		} else if (strcmp(key, "set-dns") == 0) {
 			int set_dns = strtob(val);
 

--- a/src/config.c
+++ b/src/config.c
@@ -268,7 +268,7 @@ int load_config(struct vpn_config *cfg, const char *filename)
 			cfg->password[PASSWORD_SIZE] = '\0';
 			cfg->password_set = 1;
 		} else if (strcmp(key, "otp") == 0) {
-			strncpy(cfg->otp, val, FIELD_SIZE - 1);
+			strncpy(cfg->otp, val, FIELD_SIZE);
 			cfg->otp[FIELD_SIZE] = '\0';
 		} else if (strcmp(key, "otp-prompt") == 0) {
 			free(cfg->otp_prompt);

--- a/src/config.c
+++ b/src/config.c
@@ -260,8 +260,8 @@ int load_config(struct vpn_config *cfg, const char *filename)
 			}
 			cfg->gateway_port = port;
 		} else if (strcmp(key, "username") == 0) {
-			strncpy(cfg->username, val, FIELD_SIZE - 1);
-			cfg->username[FIELD_SIZE] = '\0';
+			strncpy(cfg->username, val, USERNAME_SIZE);
+			cfg->username[USERNAME_SIZE] = '\0';
 		} else if (strcmp(key, "password") == 0) {
 			cfg->password = strdup(val);
 		} else if (strcmp(key, "otp") == 0) {

--- a/src/config.c
+++ b/src/config.c
@@ -249,8 +249,8 @@ int load_config(struct vpn_config *cfg, const char *filename)
 		}
 
 		if (strcmp(key, "host") == 0) {
-			strncpy(cfg->gateway_host, val, FIELD_SIZE);
-			cfg->gateway_host[FIELD_SIZE] = '\0';
+			strncpy(cfg->gateway_host, val, GATEWAY_HOST_SIZE);
+			cfg->gateway_host[GATEWAY_HOST_SIZE] = '\0';
 		} else if (strcmp(key, "port") == 0) {
 			unsigned long port = strtoul(val, NULL, 0);
 

--- a/src/config.c
+++ b/src/config.c
@@ -268,8 +268,8 @@ int load_config(struct vpn_config *cfg, const char *filename)
 			cfg->password[PASSWORD_SIZE] = '\0';
 			cfg->password_set = 1;
 		} else if (strcmp(key, "otp") == 0) {
-			strncpy(cfg->otp, val, FIELD_SIZE);
-			cfg->otp[FIELD_SIZE] = '\0';
+			strncpy(cfg->otp, val, OTP_SIZE);
+			cfg->otp[OTP_SIZE] = '\0';
 		} else if (strcmp(key, "otp-prompt") == 0) {
 			free(cfg->otp_prompt);
 			cfg->otp_prompt = strdup(val);

--- a/src/config.h
+++ b/src/config.h
@@ -58,6 +58,7 @@ struct x509_digest {
 };
 
 #define FIELD_SIZE	64
+#define GATEWAY_HOST_SIZE	253
 #define USERNAME_SIZE	64
 #define PASSWORD_SIZE	256
 #define REALM_SIZE	63
@@ -80,7 +81,7 @@ struct x509_digest {
 #define MAX_DOMAIN_LENGTH 256
 
 struct vpn_config {
-	char		gateway_host[FIELD_SIZE + 1];
+	char		gateway_host[GATEWAY_HOST_SIZE + 1];
 	struct in_addr	gateway_ip;
 	uint16_t	gateway_port;
 	char		username[USERNAME_SIZE + 1];

--- a/src/config.h
+++ b/src/config.h
@@ -90,8 +90,8 @@ struct vpn_config {
 	int		password_set;
 	char		otp[OTP_SIZE + 1];
 	char		*otp_prompt;
-	unsigned int  otp_delay;
-	int         no_ftm_push;
+	unsigned int	otp_delay;
+	int		no_ftm_push;
 	char		*pinentry;
 	char		iface_name[IF_NAMESIZE];
 	char		realm[REALM_SIZE + 1];
@@ -125,10 +125,10 @@ struct vpn_config {
 	int			seclevel_1;
 	char			*cipher_list;
 	struct x509_digest	*cert_whitelist;
-	int                     use_engine;
-	char                    *user_agent;
-	char                    *hostcheck;
-	char                    *check_virtual_desktop;
+	int			use_engine;
+	char			*user_agent;
+	char			*hostcheck;
+	char			*check_virtual_desktop;
 };
 
 int add_trusted_cert(struct vpn_config *cfg, const char *digest);

--- a/src/config.h
+++ b/src/config.h
@@ -58,6 +58,7 @@ struct x509_digest {
 };
 
 #define FIELD_SIZE	64
+#define REALM_SIZE	63
 
 /*
  * RFC 6265 does not limit the size of cookies:
@@ -88,7 +89,7 @@ struct vpn_config {
 	int         no_ftm_push;
 	char		*pinentry;
 	char		iface_name[FIELD_SIZE + 1];
-	char		realm[FIELD_SIZE + 1];
+	char		realm[REALM_SIZE + 1];
 
 	int	set_routes;
 	int	set_dns;

--- a/src/config.h
+++ b/src/config.h
@@ -58,10 +58,10 @@ struct x509_digest {
 	char data[SHA256STRLEN];
 };
 
-#define FIELD_SIZE	64
 #define GATEWAY_HOST_SIZE	253
 #define USERNAME_SIZE	64
 #define PASSWORD_SIZE	256
+#define OTP_SIZE	64
 #define REALM_SIZE	63
 
 /*
@@ -88,7 +88,7 @@ struct vpn_config {
 	char		username[USERNAME_SIZE + 1];
 	char		password[PASSWORD_SIZE + 1];
 	int		password_set;
-	char		otp[FIELD_SIZE + 1];
+	char		otp[OTP_SIZE + 1];
 	char		*otp_prompt;
 	unsigned int  otp_delay;
 	int         no_ftm_push;

--- a/src/config.h
+++ b/src/config.h
@@ -19,6 +19,7 @@
 #define OPENFORTIVPN_CONFIG_H
 
 #include <netinet/in.h>
+#include <net/if.h>
 
 #include <errno.h>
 #include <stdint.h>
@@ -92,7 +93,7 @@ struct vpn_config {
 	unsigned int  otp_delay;
 	int         no_ftm_push;
 	char		*pinentry;
-	char		iface_name[FIELD_SIZE + 1];
+	char		iface_name[IF_NAMESIZE];
 	char		realm[REALM_SIZE + 1];
 
 	int	set_routes;

--- a/src/config.h
+++ b/src/config.h
@@ -59,6 +59,7 @@ struct x509_digest {
 
 #define FIELD_SIZE	64
 #define USERNAME_SIZE	64
+#define PASSWORD_SIZE	256
 #define REALM_SIZE	63
 
 /*
@@ -83,7 +84,8 @@ struct vpn_config {
 	struct in_addr	gateway_ip;
 	uint16_t	gateway_port;
 	char		username[USERNAME_SIZE + 1];
-	char		*password;
+	char		password[PASSWORD_SIZE + 1];
+	int		password_set;
 	char		otp[FIELD_SIZE + 1];
 	char		*otp_prompt;
 	unsigned int  otp_delay;

--- a/src/config.h
+++ b/src/config.h
@@ -58,6 +58,7 @@ struct x509_digest {
 };
 
 #define FIELD_SIZE	64
+#define USERNAME_SIZE	64
 #define REALM_SIZE	63
 
 /*
@@ -81,7 +82,7 @@ struct vpn_config {
 	char		gateway_host[FIELD_SIZE + 1];
 	struct in_addr	gateway_ip;
 	uint16_t	gateway_port;
-	char		username[FIELD_SIZE + 1];
+	char		username[USERNAME_SIZE + 1];
 	char		*password;
 	char		otp[FIELD_SIZE + 1];
 	char		*otp_prompt;

--- a/src/http.c
+++ b/src/http.c
@@ -629,7 +629,7 @@ int auth_log_in(struct tunnel *tunnel)
 	int ret;
 	char username[3 * FIELD_SIZE + 1];
 	char password[3 * FIELD_SIZE + 1];
-	char realm[3 * FIELD_SIZE + 1];
+	char realm[3 * REALM_SIZE + 1];
 	char reqid[32] = { '\0' };
 	char polid[32] = { '\0' };
 	char group[128] = { '\0' };

--- a/src/http.c
+++ b/src/http.c
@@ -584,7 +584,7 @@ static int try_otp_auth(struct tunnel *tunnel, const char *buffer,
 			v = NULL;
 			if (cfg->otp[0] == '\0') {
 				read_password(cfg->pinentry, "otp",
-				              p, cfg->otp, FIELD_SIZE);
+				              p, cfg->otp, OTP_SIZE);
 				if (cfg->otp[0] == '\0') {
 					log_error("No OTP specified\n");
 					return 0;
@@ -730,7 +730,7 @@ int auth_log_in(struct tunnel *tunnel)
 				// Prompt for 2FA token
 				read_password(cfg->pinentry, "2fa",
 				              "Two-factor authentication token: ",
-				              cfg->otp, FIELD_SIZE);
+				              cfg->otp, OTP_SIZE);
 
 				if (cfg->otp[0] == '\0') {
 					log_error("No token specified\n");

--- a/src/http.c
+++ b/src/http.c
@@ -87,7 +87,7 @@ int http_send(struct tunnel *tunnel, const char *request, ...)
 	strcpy(logbuffer, buffer);
 	if (loglevel <= OFV_LOG_DEBUG_DETAILS && tunnel->config->password[0] != '\0') {
 		char *pwstart;
-		char password[3 * FIELD_SIZE + 1];
+		char password[3 * PASSWORD_SIZE + 1];
 
 		url_encode(password, tunnel->config->password);
 		pwstart = strstr(logbuffer, password);
@@ -628,7 +628,7 @@ int auth_log_in(struct tunnel *tunnel)
 {
 	int ret;
 	char username[3 * USERNAME_SIZE + 1];
-	char password[3 * FIELD_SIZE + 1];
+	char password[3 * PASSWORD_SIZE + 1];
 	char realm[3 * REALM_SIZE + 1];
 	char reqid[32] = { '\0' };
 	char polid[32] = { '\0' };

--- a/src/http.c
+++ b/src/http.c
@@ -636,7 +636,8 @@ int auth_log_in(struct tunnel *tunnel)
 	char portal[64] = { '\0' };
 	char magic[32] = {'\0' };
 	char peer[32]  = { '\0' };
-	char data[1152], token[128], tokenresponse[256], tokenparams[320];
+	char data[9 + 3 * USERNAME_SIZE + 12 + 3 * PASSWORD_SIZE + 7 + 3 * REALM_SIZE + 7 + 1];
+	char token[128], tokenresponse[256], tokenparams[320];
 	char action_url[1024] = { '\0' };
 	char *res = NULL;
 	uint32_t response_size;

--- a/src/http.c
+++ b/src/http.c
@@ -627,7 +627,7 @@ static int try_otp_auth(struct tunnel *tunnel, const char *buffer,
 int auth_log_in(struct tunnel *tunnel)
 {
 	int ret;
-	char username[3 * FIELD_SIZE + 1];
+	char username[3 * USERNAME_SIZE + 1];
 	char password[3 * FIELD_SIZE + 1];
 	char realm[3 * REALM_SIZE + 1];
 	char reqid[32] = { '\0' };

--- a/src/main.c
+++ b/src/main.c
@@ -524,8 +524,8 @@ int main(int argc, char **argv)
 				*optarg++ = '*';  // nuke it
 			break;
 		case 'o':
-			strncpy(cli_cfg.otp, optarg, FIELD_SIZE);
-			cli_cfg.otp[FIELD_SIZE] = '\0';
+			strncpy(cli_cfg.otp, optarg, OTP_SIZE);
+			cli_cfg.otp[OTP_SIZE] = '\0';
 			break;
 		default:
 			goto user_error;

--- a/src/main.c
+++ b/src/main.c
@@ -433,8 +433,8 @@ int main(int argc, char **argv)
 			}
 			if (strcmp(long_options[option_index].name,
 			           "ifname") == 0) {
-				strncpy(cli_cfg.iface_name, optarg, FIELD_SIZE);
-				cli_cfg.iface_name[FIELD_SIZE] = '\0';
+				strncpy(cli_cfg.iface_name, optarg, IF_NAMESIZE - 1);
+				cli_cfg.iface_name[IF_NAMESIZE - 1] = '\0';
 				break;
 			}
 			if (strcmp(long_options[option_index].name,

--- a/src/main.c
+++ b/src/main.c
@@ -401,8 +401,8 @@ int main(int argc, char **argv)
 			}
 			if (strcmp(long_options[option_index].name,
 			           "realm") == 0) {
-				strncpy(cli_cfg.realm, optarg, FIELD_SIZE);
-				cli_cfg.realm[FIELD_SIZE] = '\0';
+				strncpy(cli_cfg.realm, optarg, REALM_SIZE);
+				cli_cfg.realm[REALM_SIZE] = '\0';
 				break;
 			}
 			if (strcmp(long_options[option_index].name,

--- a/src/main.c
+++ b/src/main.c
@@ -582,8 +582,8 @@ int main(int argc, char **argv)
 				goto user_error;
 			}
 		}
-		strncpy(cfg.gateway_host, host, FIELD_SIZE);
-		cfg.gateway_host[FIELD_SIZE] = '\0';
+		strncpy(cfg.gateway_host, host, GATEWAY_HOST_SIZE);
+		cfg.gateway_host[GATEWAY_HOST_SIZE] = '\0';
 	}
 
 	// Check host and port

--- a/src/main.c
+++ b/src/main.c
@@ -515,8 +515,8 @@ int main(int argc, char **argv)
 			config_file = optarg;
 			break;
 		case 'u':
-			strncpy(cli_cfg.username, optarg, FIELD_SIZE);
-			cli_cfg.username[FIELD_SIZE] = '\0';
+			strncpy(cli_cfg.username, optarg, USERNAME_SIZE);
+			cli_cfg.username[USERNAME_SIZE] = '\0';
 			break;
 		case 'p':
 			cli_cfg.password = strdup(optarg);

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -45,7 +45,6 @@
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <ifaddrs.h>
-#include <net/if.h>
 #include <netdb.h>
 #if HAVE_PTY_H
 #include <pty.h>

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -585,7 +585,7 @@ static int tcp_connect(struct tunnel *tunnel)
 	int ret, handle;
 	struct sockaddr_in server;
 	char *env_proxy;
-	const int iface_len = strnlen(tunnel->config->iface_name, IFNAMSIZ);
+	const int iface_len = strnlen(tunnel->config->iface_name, IF_NAMESIZE);
 
 	handle = socket(AF_INET, SOCK_STREAM, 0);
 
@@ -647,7 +647,7 @@ static int tcp_connect(struct tunnel *tunnel)
 		log_debug("SO_RCVBUF: %d\n", ret);
 #endif
 
-	if (iface_len == IFNAMSIZ) {
+	if (iface_len == IF_NAMESIZE) {
 		log_error("socket: Too long iface name\n");
 		goto err_post_socket;
 	}
@@ -659,8 +659,8 @@ static int tcp_connect(struct tunnel *tunnel)
 		struct ifreq ifr;
 
 		memset(&ifr, 0, sizeof(ifr));
-		if (strlcpy(ifr.ifr_name, tunnel->config->iface_name, IFNAMSIZ)
-		    >= IFNAMSIZ) {
+		if (strlcpy(ifr.ifr_name, tunnel->config->iface_name, IF_NAMESIZE)
+		    >= IF_NAMESIZE) {
 			log_error("interface name too long\n");
 			goto err_post_socket;
 		}


### PR DESCRIPTION
Revert #361. Replace `FIELD_SIZE` by more specific variables. Use a maximum length of 256 characters for `password`.

Fixes #826.
