### PR TITLE
Fix Coverity defect

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1268,7 +1268,6 @@ int run_tunnel(struct vpn_config *config)
 	                tunnel.cookie);
 	if (ret != 1) {
 		log_error("Could not start tunnel (%s).\n", err_http_str(ret));
-		ret = 1;
 		goto err_start_tunnel;
 	}
 


### PR DESCRIPTION
CID 365297: Unused value (UNUSED_VALUE)
assigned_value: Assigning value 1 to ret here, but that
stored value is overwritten before it can be used.

Fixes issue introduced by #798.