### PR TITLE
Assign an IPv4 address from the link-local subnet

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -232,7 +232,7 @@ static int pppd_run(struct tunnel *tunnel)
 			static const char *const v[] = {
 				ppp_path,
 				"230400", // speed
-				":192.0.2.1", // <local_IP_address>:<remote_IP_address>
+				":169.254.2.1", // <local_IP_address>:<remote_IP_address>
 				"noipdefault",
 				"noaccomp",
 				"noauth",


### PR DESCRIPTION
While the 192.0.2.0/24 TEST-NET-1 block would avoid collisions,
the 169.254.0.0/16 subnet described in RFC3927 has precisely been
specified precisely for such cases.

We should probably select "an address using a pseudo-random number
generator with a uniform distribution in the range from 169.254.1.0
to 169.254.254.255 inclusive", as described in RFC3927. However,
that would of course require more code and I'm lazy, but more
importantly it had been reported that FortiClient uses 169.254.2.1.
I'd rather use the same address as FortiClient.

Fixes #832.