### PR TITLE
Add a space at the end of the OTP prompt

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -515,7 +515,7 @@ static int try_otp_auth(struct tunnel *tunnel, const char *buffer,
 		}
 	}
 	if (p == NULL)
-		p = "Please enter one-time password:";
+		p = "Please enter one-time password: ";
 	/* Search for all inputs */
 	while ((s = strcasestr(s, "<INPUT"))) {
 		s += 6;


### PR DESCRIPTION
Other prompts do have that final space:
```
	"VPN account password: "
	"Two-factor authentication token: "
```
@mrbaseman I cannot test myself, but this makes sense, doesn't it?