### PR TITLE
Query for the PEM pass phrase only once

### DIFF
--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -145,6 +145,9 @@ or a partial PKCS11-URI (p11tool --list-token-urls)
 Use specified PEM-encoded key if the server requires authentication with
 a certificate.
 .TP
+\fB\-\-pem-passphrase=\fI<pass>\fR
+Pass phrase for the PEM-encoded key.
+.TP
 \fB\-\-use\-syslog\fR
 Log to syslog instead of terminal.
 .TP
@@ -308,6 +311,8 @@ user\-cert = @SYSCONFDIR@/openfortivpn/user\-cert.pem
 # user\-cert = pkcs1: # use smartcard as client certificate
 .br
 user\-key = @SYSCONFDIR@/openfortivpn/user\-key.pem
+.br
+pem\-passphrase = baz
 .br
 # the sha256 digest of the trusted host certs obtained by
 .br

--- a/src/config.c
+++ b/src/config.c
@@ -75,6 +75,8 @@ const struct vpn_config invalid_cfg = {
 	.ca_file = NULL,
 	.user_cert = NULL,
 	.user_key = NULL,
+	.pem_passphrase = {'\0'},
+	.pem_passphrase_set = 0,
 	.insecure_ssl = -1,
 	.cipher_list = NULL,
 	.min_tls = -1,
@@ -410,6 +412,10 @@ int load_config(struct vpn_config *cfg, const char *filename)
 		} else if (strcmp(key, "user-key") == 0) {
 			free(cfg->user_key);
 			cfg->user_key = strdup(val);
+		} else if (strcmp(key, "pem-passphrase") == 0) {
+			strncpy(cfg->pem_passphrase, val, PEM_PASSPHRASE_SIZE);
+			cfg->pem_passphrase[PEM_PASSPHRASE_SIZE] = '\0';
+			cfg->pem_passphrase_set = 1;
 		} else if (strcmp(key, "insecure-ssl") == 0) {
 			int insecure_ssl = strtob(val);
 
@@ -578,6 +584,10 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 	if (src->user_key) {
 		free(dst->user_key);
 		dst->user_key = src->user_key;
+	}
+	if (src->pem_passphrase_set) {
+		strcpy(dst->pem_passphrase, src->pem_passphrase);
+		dst->pem_passphrase_set = src->pem_passphrase_set;
 	}
 	if (src->insecure_ssl != invalid_cfg.insecure_ssl)
 		dst->insecure_ssl = src->insecure_ssl;

--- a/src/config.h
+++ b/src/config.h
@@ -63,6 +63,7 @@ struct x509_digest {
 #define PASSWORD_SIZE	256
 #define OTP_SIZE	64
 #define REALM_SIZE	63
+#define PEM_PASSPHRASE_SIZE	31
 
 /*
  * RFC 6265 does not limit the size of cookies:
@@ -120,6 +121,8 @@ struct vpn_config {
 	char			*ca_file;
 	char			*user_cert;
 	char			*user_key;
+	char			pem_passphrase[PEM_PASSPHRASE_SIZE + 1];
+	int			pem_passphrase_set;
 	int			insecure_ssl;
 	int			min_tls;
 	int			seclevel_1;


### PR DESCRIPTION
OpenSSL queries for the PEM pass phrase whenever we call ssl_connect().
Instead, openfortivpn will query for the PEM password only once, if needed, from within an OpenSSL callback.