### PR TITLE
Avoid spurious warning on macOS

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -635,15 +635,19 @@ static int tcp_connect(struct tunnel *tunnel)
 #ifdef SO_SNDBUF
 	ret = tcp_getsockopt(handle, SO_SNDBUF);
 	if (ret < 0)
+#ifndef __APPLE__
 		log_warn("getsockopt: %s: %s\n", "SO_SNDBUF", strerror(errno));
 	else
+#endif
 		log_debug("SO_SNDBUF: %d\n", ret);
 #endif
 #ifdef SO_RCVBUF
 	ret = tcp_getsockopt(handle, SO_RCVBUF);
 	if (ret < 0)
+#ifndef __APPLE__
 		log_warn("getsockopt: %s: %s\n", "SO_RCVBUF", strerror(errno));
 	else
+#endif
 		log_debug("SO_RCVBUF: %d\n", ret);
 #endif
 


### PR DESCRIPTION
On macOS, SO_SNDBUF and SO_RCVBUF are defined in <sys/socket.h> but
getsockopt() fails for these values with:
	Protocol not available

I guess this is expected on macOS, although the GETSOCKOPT(2) man page
does not document that. In any case the behaviour is common enough to
avoid the warning in the log.

Fixes #822.