### PR TITLE
Upgrade to the latest OpenSSL 1.0.2 release

### DIFF
--- a/tests/ci/install_openssl.sh
+++ b/tests/ci/install_openssl.sh
@@ -6,7 +6,7 @@ PREFIX="$1"
 
 [ -x "${PREFIX}/bin/openssl" ] && exit 0
 
-VERSION=1.0.2o
+VERSION=1.0.2u
 SRC="https://www.openssl.org/source/old/1.0.2/openssl-${VERSION}.tar.gz"
 
 wget -O openssl.tar.gz "$SRC"


### PR DESCRIPTION
OpenSSL 1.0.2u is the latest publicly available release.

OpenSSL 1.0.2y is currently the latest security fix for version 1.0.2, available under extended support contracts. We do not have access to it, so we stay with 1.0.2u.