### PR TITLE
Ignore pushes to master branch

### DIFF
--- a/.github/workflows/openfortivpn.yml
+++ b/.github/workflows/openfortivpn.yml
@@ -3,6 +3,8 @@ name: Tests
 
 on:
   push:
+    branches-ignore: [master]
+    # Remove the line above to run when pushing to master
 
   pull_request:
     branches: [master]


### PR DESCRIPTION
Otherwise, we end up running tests twice with each pull request, first when submitting the pull request, then when pushing the pull request into master.