### PR TITLE
SSLv23_client_method() → TLS_client_method()

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1019,9 +1019,11 @@ int ssl_connect(struct tunnel *tunnel)
 	SSL_load_error_strings();
 	// Register the available ciphers and digests
 	SSL_library_init();
-#endif
 
 	tunnel->ssl_context = SSL_CTX_new(SSLv23_client_method());
+#else
+	tunnel->ssl_context = SSL_CTX_new(TLS_client_method());
+#endif
 	if (tunnel->ssl_context == NULL) {
 		log_error("SSL_CTX_new: %s\n",
 		          ERR_error_string(ERR_peek_last_error(), NULL));


### PR DESCRIPTION
From the man page:
	SSLv23_method(), SSLv23_server_method(), SSLv23_client_method()
	Use of these functions is deprecated. They have been replaced with
	the above TLS_method(), TLS_server_method() and TLS_client_method()
	respectively. New code should use those functions instead.