### PR TITLE
Document secure password storage with pinentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Examples
   openfortivpn vpn-gateway:8443 --username=foo --realm=bar
   ```
 
+* Store password securely with a pinentry program:
+  ```
+  openfortivpn vpn-gateway:8443 --username=foo --pinentry=pinentry-mac
+  ```
+
 * Don't set IP routes and don't add VPN nameservers to `/etc/resolv.conf`:
   ```
   openfortivpn vpn-gateway:8443 -u foo --no-routes --no-dns --pppd-no-peerdns
@@ -41,9 +46,6 @@ Examples
   host = vpn-gateway
   port = 8443
   username = foo
-  password = bar
-  # The pinentry program to use. Allows supplying the password in a secure manner. See the man page for details.
-  # pinentry = pinentry-mac
   set-dns = 0
   pppd-use-peerdns = 0
   # X509 certificate sha256 sum, trust only this one!

--- a/README.md
+++ b/README.md
@@ -7,8 +7,13 @@ this process.
 
 It is compatible with Fortinet VPNs.
 
-
+Usage
 --------
+
+```
+man openfortivpn
+```
+
 Examples
 --------
 
@@ -24,7 +29,7 @@ Examples
 
 * Don't set IP routes and don't add VPN nameservers to `/etc/resolv.conf`:
   ```
-  openfortivpn vpn-gateway:8443 -u foo -p bar --no-routes --no-dns --pppd-no-peerdns
+  openfortivpn vpn-gateway:8443 -u foo --no-routes --no-dns --pppd-no-peerdns
   ```
 * Using a config file:
   ```
@@ -37,15 +42,19 @@ Examples
   port = 8443
   username = foo
   password = bar
-  set-routes = 0
+  # The pinentry program to use. Allows supplying the password in a secure manner. See the man page for details.
+  # pinentry = pinentry-mac
   set-dns = 0
   pppd-use-peerdns = 0
   # X509 certificate sha256 sum, trust only this one!
   trusted-cert = e46d4aff08ba6914e64daa85bc6112a422fa7ce16631bff0b592a28556f993db
   ```
 
+* For the full list of config options, see the `CONFIG FILE` section of
+  ```
+  man openfortivpn
+  ```
 
----------
 Smartcard
 ---------
 
@@ -73,9 +82,6 @@ Multiple readers are currently not supported.
 Smartcard support has been tested with Yubikey under Linux, but other PIV enabled
 smartcards may work too. On Mac OS X Mojave it is known that the pkcs engine-by-id is not found.
 
-
-
-----------
 Installing
 ----------
 
@@ -160,7 +166,6 @@ For other distros, you'll need to build and install from source:
 
     Finally, install runtime dependency `ppp` or `pppd`.
 
-----------------
 Running as root?
 ----------------
 
@@ -189,8 +194,6 @@ As described in [#54](https://github.com/adrienverge/openfortivpn/issues/54),
 a malicious user could use `--pppd-plugin` and `--pppd-log` options to divert
 the program's behaviour.
 
-
-------------
 Contributing
 ------------
 

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -8,6 +8,7 @@ openfortivpn \- Client for PPP+SSL VPN tunnel services
 [\fI<host>\fR[:\fI<port>\fR]]
 [\fB\-u\fR \fI<user>\fR]
 [\fB\-p\fR \fI<pass>\fR]
+[\fB\-\-pinentry=\fI<name>\fR]
 [\fB\-\-otp=\fI<otp>\fR]
 [\fB\-\-otp\-prompt=\fI<prompt>\fR]
 [\fB\-\-otp\-delay=\fI<delay>\fR]
@@ -68,7 +69,11 @@ Specify a custom config file (default: @SYSCONFDIR@/openfortivpn/config).
 VPN account username.
 .TP
 \fB\-p \fI<pass>\fR, \fB\-\-password=\fI<pass>\fR
-VPN account password.
+VPN account password in plain text. For a secure alternative, use pinentry.
+.TP
+\fB\-\-pinentry=\fI<name>\fR
+The pinentry program to use. Allows supplying the password in a secure manner.
+For example: pinentry-gnome3 on Linux, or pinentry-mac on macOS.
 .TP
 \fB\-o \fI<otp>\fR, \fB\-\-otp=\fI<otp>\fR
 One-Time-Password.
@@ -288,7 +293,13 @@ port = 443
 .br
 username = foo
 .br
-password = bar
+# Password in plain text. For a secure alternative, use pinentry.
+.br
+# password = bar
+.br
+# The pinentry program to use. Allows supplying the password in a secure manner.
+.br
+# pinentry = pinentry-mac
 .br
 # realm = some-realm
 .br
@@ -303,8 +314,6 @@ password = bar
 # This would disable FTM push notification support, and use OTP instead
 .br
 # no\-ftm\-push = 1
-.br
-# pinentry = pinentry program
 .br
 user\-cert = @SYSCONFDIR@/openfortivpn/user\-cert.pem
 .br

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -69,7 +69,8 @@ Specify a custom config file (default: @SYSCONFDIR@/openfortivpn/config).
 VPN account username.
 .TP
 \fB\-p \fI<pass>\fR, \fB\-\-password=\fI<pass>\fR
-VPN account password in plain text. For a secure alternative, use pinentry.
+VPN account password in plain text.
+For a secure alternative, use pinentry or let openfortivpn prompt for the password.
 .TP
 \fB\-\-pinentry=\fI<name>\fR
 The pinentry program to use. Allows supplying the password in a secure manner.
@@ -293,7 +294,9 @@ port = 443
 .br
 username = foo
 .br
-# Password in plain text. For a secure alternative, use pinentry.
+# Password in plain text.
+.br
+# For a secure alternative, use pinentry or let openfortivpn prompt for the password.
 .br
 # password = bar
 .br


### PR DESCRIPTION
Based on the discussion in https://github.com/adrienverge/openfortivpn/issues/710

- Add missing `--pinentry` option to man page
- Improve the man page on plain password vs. pinentry
- README to mention man page as the main source of documentation
- README to favor pinentry over plain text passwords
- Fix format of headers in README

----

The changed parts of man page after local `sudo make install`:

```
OPENFORTIVPN(1)



NAME
       openfortivpn - Client for PPP+SSL VPN tunnel services


SYNOPSIS
       openfortivpn  [<host>[:<port>]]  [-u  <user>]  [-p  <pass>]  [--pinentry=<name>]  [--otp=<otp>]  [--otp-prompt=<prompt>] [--otp-delay=<delay>] [--no-ftm-push] [--realm=<realm>] [--ifname=<interface>] [--set-routes=<bool>]
       [--no-routes] [--set-dns=<bool>] [--no-dns] [--half-internet-routes=<bool>] [--ca-file=<file>]  [--user-cert=<file>]  [--user-cert=pkcs11:]  [--user-key=<file>]  [--use-syslog]  [--trusted-cert=<digest>]  [--insecure-ssl]
       [--cipher-list=<ciphers>]    [--min-tls=<version>]   [--seclevel-1]   [--pppd-use-peerdns=<bool>]   [--pppd-no-peerdns]   [--pppd-log=<file>]   [--pppd-plugin=<file>]   [--pppd-ipparam=<string>]   [--pppd-ifname=<string>]
       [--pppd-call=<name>] [--ppp-system=<string>] [--use-resolvconf=<bool>] [--persistent=<interval>] [-c <file>] [-v|-q]
       openfortivpn --help
       openfortivpn --version

--

       -p <pass>, --password=<pass>
              VPN account password in plain text.  For a secure alternative, use pinentry or let openfortivpn prompt for the password.

       --pinentry=<name>
              The pinentry program to use. Allows supplying the password in a secure manner.  For example: pinentry-gnome3 on Linux, or pinentry-mac on macOS.

       -o <otp>, --otp=<otp>
              One-Time-Password.

--

CONFIG FILE

       A config file looks like:
              # this is a comment
              host = vpn-gateway
              port = 443
              username = foo
              # Password in plain text.
              # For a secure alternative, use pinentry or let openfortivpn prompt for the password.
              # password = bar
              # The pinentry program to use. Allows supplying the password in a secure manner.
              # pinentry = pinentry-mac
              # realm = some-realm
--
```