### PR TITLE
CONFIG FILES → CONFIGURATION

### DIFF
--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -277,7 +277,7 @@ VPN_ROUTE_GATEWAY_... the gateway for the current route entry
 If not compiled for pppd the pppd options and features that rely on them are not
 available. On FreeBSD \fB\-\-ppp\-system\fR is available instead.
 
-.SH CONFIG FILE
+.SH CONFIGURATION
 Options can be taken from a configuration file. Options passed in the command
 line will override those from the config file, though. The default config file
 is @SYSCONFDIR@/openfortivpn/config, but this can be set using the \fB\-c\fR option.


### PR DESCRIPTION
According to man-pages(7), conventional man page section names include CONFIGURATION but not CONFIG FILES. On the other hand CONFIGURATION is `Normally only in Section 4` _Special files (devices)_. Still, I prefer standard names.