### PR TITLE
Remove unused functions from AC_CHECK_FUNCS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -120,7 +120,6 @@ fileno \
 fopen \
 forkpty \
 fprintf \
-fputc \
 fputs \
 fread \
 free \
@@ -142,7 +141,6 @@ ioctl \
 isatty \
 isdigit \
 isspace \
-malloc \
 memcmp \
 memcpy \
 memmem \
@@ -151,8 +149,6 @@ memset \
 ntohs \
 open \
 openlog \
-optarg \
-optind \
 pclose \
 popen \
 printf \
@@ -169,10 +165,8 @@ pthread_mutex_lock \
 pthread_mutex_unlock \
 pthread_self \
 pthread_sigmask \
-putchar \
 puts \
 read \
-realloc \
 rewind \
 select \
 sem_destroy \


### PR DESCRIPTION
* While the _malloc_() and _realloc_() functions are being called, the _AC_FUNC_MALLOC_ and _AC_FUNC_REALLOC_ macros have already been checking if these functions are available **and** compatible with the GNU C library functions.
* Also, _optarg_ and _optind_ are not functions - they are documented to be external variables.