### PR TITLE
Do we really require GNU C library compatibility?

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -103,8 +103,6 @@ AC_TYPE_UINT8_T
 AC_CHECK_TYPES([struct termios], [], [], [#include <termios.h>])
 
 # Checks for library functions.
-AC_FUNC_MALLOC
-AC_FUNC_REALLOC
 AC_CHECK_FUNCS([ \
 access \
 close \


### PR DESCRIPTION
I don't think we need AC_FUNC_MALLOC and AC_FUNC_REALLOC.

From the [documentation](https://www.gnu.org/software/autoconf/manual/autoconf-2.70/html_node/Particular-Functions.html):
> If the `malloc` function is compatible with the GNU C library `malloc` (i.e., ‘`malloc (0)`’ returns a valid pointer), define `HAVE_MALLOC` to 1. Otherwise define `HAVE_MALLOC` to 0, ask for an `AC_LIBOBJ` replacement for ‘`malloc`’, and define `malloc` to `rpl_malloc` so that the native `malloc` is not used in the main project.

We do not rely on this specificity as far as I can see.