### PR TITLE
Disable support for FortiOS 4 by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -439,8 +439,8 @@ int main(int argc, char **argv){
 
 # prepare to get rid of obsolete code (FortiOS 4)
 AC_ARG_ENABLE([obsolete],
-	[AS_HELP_STRING([--disable-obsolete], [disable support for FortiOS 4])],,
-	[enable_obsolete=yes])
+	[AS_HELP_STRING([--enable-obsolete], [enable support for FortiOS 4])],,
+	[enable_obsolete=no])
 AS_CASE(["$enable_obsolete"],
 	[yes], [],
 	[no], [],


### PR DESCRIPTION
Do not read the HTML-formatted configuration from FortiOS 4.
Just read the XML-formatted configuration.

#680 was the 1st step.
This is the 2nd step.
The 3rd step will be to completely get rid of the obsolete code and the `--enable-obsolete` option.