### PR TITLE
Typos caught by codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ On the master branch there may be changes that are not (yet) described here.
 * [+] add git commit id in debug output
 * [-] do not use interface ip for routing on linux
 * [-] avoid extra hop on interface for default route
-* [+] clean up, updates and improvments in the build system
+* [+] clean up, updates and improvements in the build system
 * [+] increase the inbound HTTP buffer capacity when needed
 * [+] print domain search list to output
 * [+] add systemd service file
@@ -191,7 +191,7 @@ On the master branch there may be changes that are not (yet) described here.
 * [+] Print clear text error messages of pppd upon failure
 * [~] Existing configuration file is not overwritten anymore at installation time
 * [~] Increase the accepted cookie size and align the error behavior according to RFCs
-* [-] More gracefully handle unexcpected content of resolv.conf
+* [-] More gracefully handle unexpected content of resolv.conf
 * [~] Dynamically allocate memory for split routes and thus support larger numbers of routes
 
 ### 1.5.0
@@ -286,8 +286,8 @@ On the master branch there may be changes that are not (yet) described here.
 * [+] Add support for client keys and certificates
 * [~] Extend the split VPN support with older FortiOS servers
 * [+] Add a config parser to handle received non-xml content
-* [~] Allow ommitting the gateway for split routes
-* [~] Allow ommitting DNS servers
+* [~] Allow omitting the gateway for split routes
+* [~] Allow omitting DNS servers
 * [-] Fix a memory leak in auth_get_config
 * [+] Support split routes
 * [+] Export the configuration of routes and gateway to environment

--- a/configure.ac
+++ b/configure.ac
@@ -372,7 +372,7 @@ AC_ARG_ENABLE([resolvconf],
 	AS_HELP_STRING([--enable-resolvconf],
 		       [Enable usage of resolvconf at runtime by default. \
 			Use --disable-resolvconf for the opposite, note that \
-			resolvconf support will still be compliled in, but \
+			resolvconf support will still be compilled in, but \
 			disabled if not explicitly enabled at runtime.]))
 
 # Determine how resolvconf works at build-time if it is installed:

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -143,7 +143,7 @@ static int ipv4_get_route(struct rtentry *route)
 	 * - the routing table is to some extent trusted input,
 	 * - it's not that large,
 	 * - and the loop in strtok_r increments the pointer in each
-	 *   interation until it reaches the area where we have ensured
+	 *   iteration until it reaches the area where we have ensured
 	 *   that there is a delimiting '\0' character by proper
 	 *   initialization. We ensure this also when growing the buffer.
 	 */


### PR DESCRIPTION
We should probably integrate [codespell](https://github.com/codespell-project/codespell) into CI:
[Integrating codespell into your CI](https://belmoussaoui.com/article/14-integrate-codespell-ci)