### PR TITLE
Rework 6a2873b

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -465,7 +465,7 @@ static void *ssl_read(void *arg)
 		total = (header[0] << 8) | header[1];
 		magic = (header[2] << 8) | header[3];
 		size = (header[4] << 8) | header[5];
-		if (magic != 0x5050 || total != 6 + size || size == 0) {
+		if (magic != 0x5050 || total < 6 || total != 6 + size || size == 0) {
 			log_error("Received bad header from gateway:\n");
 			debug_bad_packet(tunnel, header);
 			break;


### PR DESCRIPTION
The type of `total` is `uint16_t`, so it's 65535 at most.

The type of size is `uint16_t` too, but in addition we have:
```
	total == 6 + size
```
So `size` is 65529 at most and cannot be `0xffff`. So far, LGTM seems to be right when suggesting removing the comparison.

So, why does Coverity Scan still complain? The following failure might be possible:
* `total` < 6
* `size` > 65529 and operation `6 + size` overflows

While comparing `size` with `0xffff` does seem useless, we do add a check to make sure that `total >= 6`, which may happen if an attacker sends a crafted packet.