### PR TITLE
check the address of ifa_addr, not of an ifa_addr member

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -521,8 +521,7 @@ int ppp_interface_is_up(struct tunnel *tunnel)
 		        strstr(ifa->ifa_name, "tun") != NULL &&
 #endif
 		        ifa->ifa_flags & IFF_UP) {
-			if (&(ifa->ifa_addr->sa_family) != NULL
-			    && ifa->ifa_addr->sa_family == AF_INET) {
+			if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_INET) {
 				struct in_addr if_ip_addr =
 				        cast_addr(ifa->ifa_addr)->sin_addr;
 


### PR DESCRIPTION
`ifa_addr` points to a `struct sockaddr`:
```c
struct ifaddrs {
	[...]
	struct sockaddr *ifa_addr;    /* Address of interface */
	[...]
};
```

Then in turn `struct sockaddr` looks like this:
```c
struct sockaddr {
	unsigned short sa_family;
	char           sa_data[14];
};
```
Clearly, `ifa_addr` and `&(ifa->sa_family)` are the same. Use the simplest and most straightforward form.

Fixes #928.