### PR TITLE
Revert #846 / e9dfa8e

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -35,7 +35,7 @@
 #endif
 
 #include <openssl/err.h>
-#ifdef OPENSSL_ENGINE
+#ifndef OPENSSL_NO_ENGINE
 #include <openssl/engine.h>
 #endif
 #include <openssl/ui.h>
@@ -1115,7 +1115,7 @@ int ssl_connect(struct tunnel *tunnel)
 #endif
 
 	/* Use engine for PIV if user-cert config starts with pkcs11 URI: */
-#ifdef OPENSSL_ENGINE
+#ifndef OPENSSL_NO_ENGINE
 	if (tunnel->config->use_engine > 0) {
 		ENGINE *e;
 
@@ -1204,9 +1204,9 @@ int ssl_connect(struct tunnel *tunnel)
 				goto err_ssl_context;
 			}
 		}
-#ifdef OPENSSL_ENGINE
+#ifndef OPENSSL_NO_ENGINE
 	}
-#endif /* PKCS11-engine */
+#endif
 
 	tunnel->ssl_handle = SSL_new(tunnel->ssl_context);
 	if (tunnel->ssl_handle == NULL) {


### PR DESCRIPTION
Actually, I have not entirely reverted #846 / e9dfa8e. I have just modified the default setting: OpenSSL engines are now enabled by default, but are disabled when `OPENSSL_NO_ENGINE` is set.

Indeed, `OPENSSL_NO_ENGINE` is never defined, while `OPENSSL_NO_ENGINE` may be defined by _OpenSSL_ in `<openssl/opensslconf.h>`.

Fixes #931 and #793.