### PR TITLE
Print HTTP requests

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -285,6 +285,7 @@ static int do_http_request(struct tunnel *tunnel,
 	                        "Content-Length: %d\r\n"
 	                        "\r\n%s");
 
+	log_info("%s %s\n", method, uri);
 	ret = http_send(tunnel, template, method, uri,
 	                tunnel->config->gateway_host, tunnel->config->gateway_port,
 	                tunnel->config->user_agent, tunnel->cookie,


### PR DESCRIPTION
Use `log_info()` for consistency with _openconnect_.