### PR TITLE
Change type of systemd.service

### DIFF
--- a/lib/systemd/system/openfortivpn@.service.in
+++ b/lib/systemd/system/openfortivpn@.service.in
@@ -4,7 +4,7 @@ After=network-online.target
 Documentation=man:openfortivpn(1)
 
 [Service]
-Type=simple
+Type=notify
 PrivateTmp=true
 ExecStart=@BINDIR@/openfortivpn -c @SYSCONFDIR@/openfortivpn/%I.conf
 OOMScoreAdjust=-100


### PR DESCRIPTION
Change to `notify`:
> Behavior of `notify` is similar to `exec`; however, it is expected that the service sends a notification message via [sd_notify(3)](https://www.freedesktop.org/software/systemd/man/sd_notify.html#) or an equivalent call when it has finished starting up. systemd will proceed with starting follow-up units after this notification message has been sent.

If `notify` doesn't work, we could fall back to `exec`:
> The `exec` type is similar to `simple`, but the service manager will consider the unit started immediately after the main service binary has been executed.