### PR TITLE
Allow reading config files from process substitutions

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -454,13 +454,20 @@ int load_config(struct vpn_config *cfg, const char *filename)
 		}
 	}
 
-	ret = 0;
+	if (errno != 0) // From getline
+		ret = ERR_CFG_SEE_ERRNO;
+	else
+		ret = 0;
 
 err_close:
-	if (fclose(file))
+	if (fclose(file)) {
 		log_warn("Could not close %s (%s).\n", filename, strerror(errno));
-	if (line)
-		free(line);
+		if (ret == ERR_CFG_SEE_ERRNO) {
+			// fclose just ruined the errno, so don't rely on it anymore.
+			ret = ERR_CFG_UNKNOWN;
+		}
+	}
+	free(line);
 	return ret;
 }
 


### PR DESCRIPTION
Use getline instead of strtok_r for reading config files, since getline reads the file incrementally and doesn't require the 
file to be read on beforehand. Files coming from process substitutions doesn't have a size since they are just stdout feeds 
from another process (or processes).

Example use case:
```
$ openfortivpn -c <(cat /path/to/a-config-file | grep -v remove_me)
```