### PR TITLE
[Draft Proof of concept] Saml login (for Okta) via a docker running a scripted headless browser

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -623,6 +623,18 @@ static int try_otp_auth(struct tunnel *tunnel, const char *buffer,
 #undef SPACE_AVAILABLE
 }
 
+int auth_log_in_stdin(struct tunnel *tunnel)
+{
+	FILE *pipe;
+	pipe = popen(tunnel->config->password, "r");
+	if (NULL == pipe) {
+		return 0;
+	}
+	fgets(tunnel->cookie, sizeof(tunnel->cookie), pipe);
+	tunnel->cookie[COOKIE_SIZE+1] = '\0';
+	pclose(pipe);
+	return 1;
+}
 
 /*
  * Authenticates to gateway by sending username and password.
@@ -802,12 +814,10 @@ int auth_log_out(struct tunnel *tunnel)
 
 int auth_request_vpn_allocation(struct tunnel *tunnel)
 {
-	int ret = http_request(tunnel, "GET", "/remote/index", "", NULL, NULL);
+	char *res = NULL;
+	int ret = http_request(tunnel, "GET", "/sslvpn/portal.html", "", &res, NULL);
 
-	if (ret != 1)
-		return ret;
-
-	return http_request(tunnel, "GET", "/remote/fortisslvpn", "", NULL, NULL);
+	return ret;
 }
 
 

--- a/src/http.c
+++ b/src/http.c
@@ -623,7 +623,7 @@ static int try_otp_auth(struct tunnel *tunnel, const char *buffer,
 #undef SPACE_AVAILABLE
 }
 
-int auth_log_in_stdin(struct tunnel *tunnel)
+int auth_log_in_popen(struct tunnel *tunnel)
 {
 	FILE *pipe;
 	pipe = popen(tunnel->config->password, "r");

--- a/src/http.c
+++ b/src/http.c
@@ -631,7 +631,7 @@ int auth_log_in_stdin(struct tunnel *tunnel)
 		return 0;
 	}
 	fgets(tunnel->cookie, sizeof(tunnel->cookie), pipe);
-	tunnel->cookie[COOKIE_SIZE+1] = '\0';
+	tunnel->cookie[strcspn(tunnel->cookie, "\r\n")] = 0;
 	pclose(pipe);
 	return 1;
 }

--- a/src/http.h
+++ b/src/http.h
@@ -55,7 +55,7 @@ int http_send(struct tunnel *tunnel, const char *request, ...);
 int http_receive(struct tunnel *tunnel, char **response, uint32_t *response_size);
 
 int auth_log_in(struct tunnel *tunnel);
-int auth_log_in_stdin(struct tunnel *tunnel);
+int auth_log_in_popen(struct tunnel *tunnel);
 int auth_log_out(struct tunnel *tunnel);
 int auth_request_vpn_allocation(struct tunnel *tunnel);
 int auth_get_config(struct tunnel *tunnel);

--- a/src/http.h
+++ b/src/http.h
@@ -55,6 +55,7 @@ int http_send(struct tunnel *tunnel, const char *request, ...);
 int http_receive(struct tunnel *tunnel, char **response, uint32_t *response_size);
 
 int auth_log_in(struct tunnel *tunnel);
+int auth_log_in_stdin(struct tunnel *tunnel);
 int auth_log_out(struct tunnel *tunnel);
 int auth_request_vpn_allocation(struct tunnel *tunnel);
 int auth_get_config(struct tunnel *tunnel);

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1286,7 +1286,7 @@ int run_tunnel(struct vpn_config *config)
 
 	// Step 2: connect to the HTTP interface and authenticate to get a
 	// cookie
-	ret = auth_log_in_stdin(&tunnel);
+	ret = auth_log_in_popen(&tunnel);
 	if (ret != 1) {
 		log_error("Could not authenticate to gateway. Please check the password, client certificate, etc.\n");
 		log_debug("%s (%d)\n", err_http_str(ret), ret);

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1286,7 +1286,7 @@ int run_tunnel(struct vpn_config *config)
 
 	// Step 2: connect to the HTTP interface and authenticate to get a
 	// cookie
-	ret = auth_log_in(&tunnel);
+	ret = auth_log_in_stdin(&tunnel);
 	if (ret != 1) {
 		log_error("Could not authenticate to gateway. Please check the password, client certificate, etc.\n");
 		log_debug("%s (%d)\n", err_http_str(ret), ret);


### PR DESCRIPTION
I'm looking forward a solution to **automate SAML login https://github.com/adrienverge/openfortivpn/issues/867** .

I can't bear FortiClient and OKTA login form (without password manager), messing with my resolver settings, at least once a day.

My idea is to use [pupetter](https://github.com/puppeteer/puppeteer) ( or any headless browser ) to retrieve the "vpn auth cookie"

For convenience, I use the password value as command line to run. The output of the command is the cookie value.

My proof of concept works :
- The vpn cookie value is retrieved
- The vpn settings are retrieved (the xml containing routes and other stuff ... )
- The tunnel works

~At the "tunnel step", I face a "bad request error". I have no clue why nor what to change : I would need some help to go further.~ ok nevermind i fixed my own mess with https://github.com/adrienverge/openfortivpn/pull/955/commits/5c490b9d1a8c509ed770e9c698376b3ebef948e9

**Do you think there would be a way to support saml login this kind of way ?**