### PR TITLE
Declare C string constants using array syntax

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1055,7 +1055,7 @@ int ssl_connect(struct tunnel *tunnel)
 				cipher_list = "HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4";
 			tunnel->config->cipher_list = strdup(cipher_list);
 		} else if (tunnel->config->seclevel_1) {
-			const char *cipher_list = "DEFAULT@SECLEVEL=1";
+			static const char cipher_list[] = "DEFAULT@SECLEVEL=1";
 
 			tunnel->config->cipher_list = strdup(cipher_list);
 		}


### PR DESCRIPTION
Avoid pointer syntax when possible.

They are different, the array syntax generates smaller, faster code.

See for example [Declaring C String Constants The Right Way](https://eklitzke.org/declaring-c-string-constants-the-right-way):

> ### Pointer Semantics vs. Array Semantics
> 
> I mentioned this in passing already, but the key thing about a pointer is that it has its own memory address. A pointer is not the thing it points to, it's a separate thing entirely. This is _not_ true of an array: an array _is_ the data.
> 
> If you take the address of a pointer, you get the memory location of the pointer itself. If you want to know the memory address the pointer points to, you take the value of the pointer.
> 
> Arrays are not pointers. They are just data. There's no difference between the address of an array, and the value of an array.
> 
> When the linker finally generates the code for the declaration of ptr, it puts the string "Lorem ipsum" somewhere in memory, and then creates a 64-bit value pointing to that string. But the linker doesn't have to do this for arr: it actually uses the address of the string data itself wherever `arr` is used.