### PR TITLE
Do not print HTTP requests after all

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -285,7 +285,6 @@ static int do_http_request(struct tunnel *tunnel,
 	                        "Content-Length: %d\r\n"
 	                        "\r\n%s");
 
-	log_info("%s %s\n", method, uri);
 	ret = http_send(tunnel, template, method, uri,
 	                tunnel->config->gateway_host, tunnel->config->gateway_port,
 	                tunnel->config->user_agent, tunnel->cookie,


### PR DESCRIPTION
Report to next minor version - not in a patch release.

Revert ef8ee6e421b1d6c2b0a1f6ae00a7e45074371bfc.