### PR TITLE
Allow to delegate the authentication to external programs

### DIFF
--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -8,6 +8,8 @@ openfortivpn \- Client for PPP+SSL VPN tunnel services
 [\fI<host>\fR[:\fI<port>\fR]]
 [\fB\-u\fR \fI<user>\fR]
 [\fB\-p\fR \fI<pass>\fR]
+[\fB\-\-cookie=\fI<cookie>\fR]
+[\fB\-\-cookie\-on\-stdin\fR]
 [\fB\-\-pinentry=\fI<name>\fR]
 [\fB\-\-otp=\fI<otp>\fR]
 [\fB\-\-otp\-prompt=\fI<prompt>\fR]
@@ -71,6 +73,12 @@ VPN account username.
 \fB\-p \fI<pass>\fR, \fB\-\-password=\fI<pass>\fR
 VPN account password in plain text.
 For a secure alternative, use pinentry or let openfortivpn prompt for the password.
+.TP
+\fB\-\-cookie=\fI<cookie>\fR
+A valid cookie (SVPNCOOKIE) to use in place of username and password.
+.TP
+\fB\-\-cookie\-on\-stdin\fR
+Read the cookie (SVPNCOOKIE) from standard input.
 .TP
 \fB\-\-pinentry=\fI<name>\fR
 The pinentry program to use. Allows supplying the password in a secure manner.

--- a/src/config.c
+++ b/src/config.c
@@ -44,6 +44,7 @@ const struct vpn_config invalid_cfg = {
 	.username = {'\0'},
 	.password = {'\0'},
 	.password_set = 0,
+	.cookie = NULL,
 	.otp = {'\0'},
 	.otp_prompt = NULL,
 	.otp_delay = -1,
@@ -268,6 +269,10 @@ int load_config(struct vpn_config *cfg, const char *filename)
 				continue;
 			}
 			cfg->otp_delay = otp_delay;
+		} else if (strcmp(key, "cookie") == 0) {
+			log_warn("Ignoring option \"%s\".\n", key);
+		} else if (strcmp(key, "cookie-on-stdin") == 0) {
+			log_warn("Ignoring option \"%s\".\n", key);
 		} else if (strcmp(key, "no-ftm-push") == 0) {
 			int no_ftm_push = strtob(val);
 
@@ -462,6 +467,7 @@ void destroy_vpn_config(struct vpn_config *cfg)
 {
 	free(cfg->otp_prompt);
 	free(cfg->pinentry);
+	free(cfg->cookie);
 #if HAVE_USR_SBIN_PPPD
 	free(cfg->pppd_log);
 	free(cfg->pppd_plugin);
@@ -505,6 +511,10 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 		dst->otp_delay = src->otp_delay;
 	if (src->no_ftm_push != invalid_cfg.no_ftm_push)
 		dst->no_ftm_push = src->no_ftm_push;
+	if (src->cookie != invalid_cfg.cookie) {
+		free(dst->cookie);
+		dst->cookie = src->cookie;
+	}
 	if (src->pinentry) {
 		free(dst->pinentry);
 		dst->pinentry = src->pinentry;

--- a/src/config.h
+++ b/src/config.h
@@ -90,6 +90,7 @@ struct vpn_config {
 	char		password[PASSWORD_SIZE + 1];
 	int		password_set;
 	char		otp[OTP_SIZE + 1];
+	char		*cookie;
 	char		*otp_prompt;
 	unsigned int	otp_delay;
 	int		no_ftm_push;

--- a/src/http.c
+++ b/src/http.c
@@ -410,46 +410,46 @@ end:
 
 static int get_auth_cookie(struct tunnel *tunnel, char *buf, uint32_t buffer_size)
 {
-	int ret = 0;
 	const char *line;
 
-	ret = ERR_HTTP_NO_COOKIE;
-
 	line = find_header(buf, "Set-Cookie: ", buffer_size);
-	if (line) {
-		if (strncmp(line, "SVPNCOOKIE=", 11) == 0) {
-			if (line[11] == ';' || line[11] == '\0') {
-				log_debug("Empty cookie.\n");
-			} else {
-				char *end1;
-				char *end2;
-				char end1_save = '\0';
-				char end2_save = '\0';
+	return auth_set_cookie(tunnel, line);
+}
 
-				end1 = strstr(line, "\r");
-				if (end1 != NULL) {
-					end1_save = *end1;
-					end1[0] = '\0';
-				}
-				end2 = strstr(line, ";");
-				if (end2 != NULL) {
-					end2_save = *end2;
-					end2[0] = '\0';
-				}
-				log_debug("Cookie: %s\n", line);
-				strncpy(tunnel->cookie, line, COOKIE_SIZE);
-				tunnel->cookie[COOKIE_SIZE] = '\0';
-				if (strlen(line) > COOKIE_SIZE) {
-					log_error("Cookie larger than expected: %zu > %d\n",
-					          strlen(line), COOKIE_SIZE);
+int auth_set_cookie(struct tunnel *tunnel, const char *line)
+{
+	int ret = ERR_HTTP_NO_COOKIE;
+
+	if (line) {
+		const char *cookie_start;
+
+		cookie_start = strstr(line, "SVPNCOOKIE=");
+		if (cookie_start != NULL) {
+			const char *cookie_end;
+			int cookie_len;
+
+			cookie_end = strpbrk(cookie_start, "\r\n;");
+			if (cookie_end)
+				cookie_len = cookie_end - cookie_start;
+			else
+				cookie_len = strlen(cookie_start);
+
+			if (cookie_len > COOKIE_SIZE) {
+				log_error("Cookie larger than expected: %zu > %d\n",
+				          cookie_len, COOKIE_SIZE);
+			} else {
+				strncpy(tunnel->cookie, cookie_start, COOKIE_SIZE);
+				tunnel->cookie[cookie_len] = '\0';
+
+				if (tunnel->cookie[11] == '\0') {
+					log_debug("Empty cookie.\n");
 				} else {
+					log_debug("Cookie: %s\n", tunnel->cookie);
 					ret = 1; // success
 				}
-				if (end1 != NULL)
-					end1[0] = end1_save;
-				if (end2 != NULL)
-					end2[0] = end2_save;
 			}
+		} else {
+			log_debug("No cookie found\n");
 		}
 	}
 	return ret;

--- a/src/http.h
+++ b/src/http.h
@@ -58,5 +58,6 @@ int auth_log_in(struct tunnel *tunnel);
 int auth_log_out(struct tunnel *tunnel);
 int auth_request_vpn_allocation(struct tunnel *tunnel);
 int auth_get_config(struct tunnel *tunnel);
+int auth_set_cookie(struct tunnel *tunnel, const char *line);
 
 #endif

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1286,7 +1286,10 @@ int run_tunnel(struct vpn_config *config)
 
 	// Step 2: connect to the HTTP interface and authenticate to get a
 	// cookie
-	ret = auth_log_in(&tunnel);
+	if (config->cookie)
+		ret = auth_set_cookie(&tunnel, config->cookie);
+	else
+		ret = auth_log_in(&tunnel);
 	if (ret != 1) {
 		log_error("Could not authenticate to gateway. Please check the password, client certificate, etc.\n");
 		log_debug("%s (%d)\n", err_http_str(ret), ret);

--- a/src/userinput.c
+++ b/src/userinput.c
@@ -340,3 +340,26 @@ void read_password(const char *pinentry, const char *hint,
 
 	printf("\n");
 }
+
+char *read_from_stdin(size_t count)
+{
+	char *buf;
+	char *output;
+	int bytes_read;
+
+	buf = malloc(count + 1);
+	if (buf == NULL)
+		return NULL;
+
+	bytes_read = read(STDIN_FILENO, buf, count);
+	if (bytes_read == -1) {
+		free(buf);
+		return NULL;
+	}
+
+	buf[bytes_read] = '\0';
+	output = realloc(buf, bytes_read + 1);
+
+	// Just keep using the larger buffer if realloc() fails.
+	return output ? output : buf;
+}

--- a/src/userinput.h
+++ b/src/userinput.h
@@ -23,4 +23,6 @@
 void read_password(const char *pinentry, const char *hint,
                    const char *prompt, char *pass, size_t len);
 
+char *read_from_stdin(size_t count);
+
 #endif


### PR DESCRIPTION
Some users are required to login with SAML and perform multi-factor authentications. In some cases performing the authentication without a browser is close to impossible, so it is best to delegate the operation to external programs.
This also allows to move the complexity of dealing with different SAML providers out of `openfortivpn`.

These changes allow users to authenticate in two different ways:
 - Passing a valid `SVPNCOOKIE` through a new command line argument (`--cookie`).
   Users are in this case expected to know how to retrieve the cookie.
   This option is not strictly related to SAML, even though that is likely the main reason for using it.
 - ~Specifying a command that will be executed to retrieve the `SVPNCOOKIE` (`--saml-handler`).
   The command will receive the URL for the SAML authentication as argument.~