### PR TITLE
Ubuntu 22.04: update to autoconf 2.71

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,6 @@ AM_INIT_AUTOMAKE([foreign subdir-objects])
 
 # Checks for programs.
 AC_PROG_CC
-AC_PROG_CC_STDC
 AC_PROG_MKDIR_P
 AC_PROG_SED
 AC_PROG_INSTALL

--- a/configure.ac
+++ b/configure.ac
@@ -448,4 +448,5 @@ AS_IF([test "x$enable_obsolete" = "xyes"], [AC_DEFINE([SUPPORT_OBSOLETE_CODE])])
 
 
 AC_CONFIG_COMMANDS([timestamp], [touch src/.dirstamp])
-AC_OUTPUT(Makefile)
+AC_CONFIG_FILES([Makefile])
+AC_OUTPUT


### PR DESCRIPTION
Fixes #982.

See [4.7 Creating Configuration Files](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf.html#Configuration-Files).