### PR TITLE
Add hooks for when link goes up and down

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -442,6 +442,12 @@ int load_config(struct vpn_config *cfg, const char *filename)
 		} else if (strcmp(key, "check-virtual-desktop") == 0) {
 			free(cfg->check_virtual_desktop);
 			cfg->check_virtual_desktop = strdup(val);
+		} else if (strcmp(key, "up-hook") == 0) {
+			free(cfg->up_hook);
+			cfg->up_hook = strdup(val);
+		} else if (strcmp(key, "down-hook") == 0) {
+			free(cfg->down_hook);
+			cfg->down_hook = strdup(val);
 		} else {
 			log_warn("Bad key in configuration file: \"%s\".\n", key);
 			goto err_free;
@@ -600,4 +606,12 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 		dst->hostcheck = src->hostcheck;
 	if (src->check_virtual_desktop != invalid_cfg.check_virtual_desktop)
 		dst->check_virtual_desktop = src->check_virtual_desktop;
+	if (src->up_hook) {
+		free(dst->up_hook);
+		dst->up_hook = src->up_hook;
+	}
+	if (src->down_hook) {
+		free(dst->down_hook);
+		dst->down_hook = src->down_hook;
+	}
 }

--- a/src/config.h
+++ b/src/config.h
@@ -132,6 +132,8 @@ struct vpn_config {
 	char			*user_agent;
 	char			*hostcheck;
 	char			*check_virtual_desktop;
+	char	*up_hook;
+	char	*down_hook;
 };
 
 int add_trusted_cert(struct vpn_config *cfg, const char *digest);

--- a/src/main.c
+++ b/src/main.c
@@ -83,7 +83,8 @@ PPPD_USAGE \
 "                    " RESOLVCONF_USAGE "[--ca-file=<file>]\n" \
 "                    [--user-cert=<file>] [--user-key=<file>]\n" \
 "                    [--use-syslog] [--trusted-cert=<digest>]\n" \
-"                    [--persistent=<interval>] [-c <file>] [-v|-q]\n" \
+"                    [--persistent=<interval>] [--up-hook=<file>]\n"\
+"                    [--down-hook=<file>] [-c <file>] [-v|-q]\n" \
 "       openfortivpn --help\n" \
 "       openfortivpn --version\n" \
 "\n"
@@ -143,7 +144,11 @@ PPPD_USAGE \
 "                                certificate will be matched against this value.\n" \
 "                                <digest> is the X509 certificate's sha256 sum.\n" \
 "                                This option can be used multiple times to trust\n" \
-"                                several certificates.\n"
+"                                several certificates.\n" \
+"  --up-hook=<file>              Run this script when the link goes up, and wait for\n" \
+"                                completion.\n" \
+"  --down-hook=<file>            Run this script when the link goes down, and wait\n" \
+"                                for completion.\n"
 
 #define help_options_part2 \
 "  --insecure-ssl                Do not disable insecure SSL protocols/ciphers.\n" \
@@ -238,6 +243,8 @@ int main(int argc, char **argv)
 		.cert_whitelist = NULL,
 		.use_engine = 0,
 		.user_agent = NULL,
+		.up_hook = NULL,
+		.down_hook = NULL,
 	};
 	struct vpn_config cli_cfg = invalid_cfg;
 
@@ -270,6 +277,8 @@ int main(int argc, char **argv)
 		{"cipher-list",          required_argument, NULL, 0},
 		{"min-tls",              required_argument, NULL, 0},
 		{"seclevel-1",           no_argument, &cli_cfg.seclevel_1, 1},
+		{"up-hook",              required_argument, NULL, 0},
+		{"down-hook",            required_argument, NULL, 0},
 #if HAVE_USR_SBIN_PPPD
 		{"pppd-use-peerdns",     required_argument, NULL, 0},
 		{"pppd-no-peerdns",      no_argument, &cli_cfg.pppd_use_peerdns, 0},
@@ -507,6 +516,16 @@ int main(int argc, char **argv)
 					break;
 				}
 				cli_cfg.set_dns = set_dns;
+				break;
+			}
+			if (strcmp(long_options[option_index].name,
+			           "up-hook") == 0) {
+				cli_cfg.up_hook = strdup(optarg);
+				break;
+			}
+			if (strcmp(long_options[option_index].name,
+			           "down-hook") == 0) {
+				cli_cfg.down_hook = strdup(optarg);
 				break;
 			}
 			goto user_error;

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -108,6 +108,11 @@ static int ofv_append_varr(struct ofv_varr *p, const char *x)
 	return 0;
 }
 
+static void run_hook(const char* hook) {
+	log_info("Running hook %s.\n", hook);
+	system(hook);
+}
+
 static int on_ppp_if_up(struct tunnel *tunnel)
 {
 	log_info("Interface %s is UP.\n", tunnel->ppp_iface);
@@ -133,6 +138,9 @@ static int on_ppp_if_up(struct tunnel *tunnel)
 #if HAVE_SYSTEMD
 	sd_notify(0, "READY=1");
 #endif
+	if (tunnel->config->up_hook) {
+		run_hook(tunnel->config->up_hook);
+	}
 
 	return 0;
 }
@@ -153,6 +161,10 @@ static int on_ppp_if_down(struct tunnel *tunnel)
 	if (tunnel->config->set_dns) {
 		log_info("Removing VPN nameservers...\n");
 		ipv4_del_nameservers_from_resolv_conf(tunnel);
+	}
+
+	if (tunnel->config->down_hook) {
+		run_hook(tunnel->config->down_hook);
 	}
 
 	return 0;


### PR DESCRIPTION
When the link has been established optionally run a supplied 'up-hook'
and when it goes down run 'down-hook'.

Allows simple interaction with other subsystems, in my case
reconfiguring proxies.