### PR TITLE
Fix Coverity defect

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -426,7 +426,7 @@ int auth_set_cookie(struct tunnel *tunnel, const char *line)
 		cookie_start = strstr(line, "SVPNCOOKIE=");
 		if (cookie_start != NULL) {
 			const char *cookie_end;
-			int cookie_len;
+			size_t cookie_len;
 
 			cookie_end = strpbrk(cookie_start, "\r\n;");
 			if (cookie_end)


### PR DESCRIPTION
CID 379132: API usage errors (PRINTF_ARGS)
Argument "cookie_len" to format specifier "%zu" was expected to have type "size_t"("unsigned long") but has type "int".