### PR TITLE
Fix "Peer refused to agree to our IP address"

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -238,6 +238,7 @@ static int pppd_run(struct tunnel *tunnel)
 				"230400", // speed
 				":169.254.2.1", // <local_IP_address>:<remote_IP_address>
 				"noipdefault",
+				"ipcp-accept-local",
 				"noaccomp",
 				"noauth",
 				"default-asyncmap",


### PR DESCRIPTION
I do not understand `ipcp-accept-local` would be required or have any effect here:
> With this option, pppd will accept the peer's idea of our local IP address, even if the local IP address was specified in an option.

Indeed, we do not specify the local IP address:
> `":169.254.2.1", // <local_IP_address>:<remote_IP_address>`

Instead, we explicitly ask the peer to provide the local IP address, using option `noipdefault`:
> With this option, the peer will have to supply the local IP address during IPCP negotiation (unless it specified explicitly on the command line or in an options file).

It seems to be working in practice. So let's test it.

Fixes #920.