### PR TITLE
Security hardening for GitHub Actions

### DIFF
--- a/.github/workflows/openfortivpn.yml
+++ b/.github/workflows/openfortivpn.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   astyle:
     name: Style


### PR DESCRIPTION
https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

The idea is that the software supply chain relies on 3rd party actions that could be compromised. Mitigate this risk by giving these actions minimal rights to the repository. Here read-only access is good enough.