### PR TITLE
Silence CodeQL alert

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -852,7 +852,6 @@ err_socket:
 static int ssl_verify_cert(struct tunnel *tunnel)
 {
 	int ret = -1;
-	int cert_valid = 0;
 	unsigned char digest[SHA256LEN];
 	unsigned int len;
 	struct x509_digest *elem;
@@ -871,17 +870,13 @@ static int ssl_verify_cert(struct tunnel *tunnel)
 		return 1;
 	}
 
-	subj = X509_get_subject_name(cert);
-
-	// compare against gateway_host and correctly check return value
-	// to fix prior incorrect use of X509_check_host
-	if (X509_check_host(cert, tunnel->config->gateway_host,
-	                    0, 0, NULL) == 1)
-		cert_valid = 1;
-
-	// Try to validate certificate using local PKI
-	if (cert_valid
-	    && SSL_get_verify_result(tunnel->ssl_handle) == X509_V_OK) {
+	// Validate certificate:
+	// 1. Validate using local PKI
+	// 2. Compare against gateway_host and correctly check return value
+	//    to fix prior incorrect use of X509_check_host
+	if (SSL_get_verify_result(tunnel->ssl_handle) == X509_V_OK
+	    && X509_check_host(cert, tunnel->config->gateway_host,
+	                       0, 0, NULL) == 1) {
 		log_debug("Gateway certificate validation succeeded.\n");
 		ret = 0;
 		goto free_cert;
@@ -908,6 +903,8 @@ static int ssl_verify_cert(struct tunnel *tunnel)
 		ret = 0;
 		goto free_cert;
 	}
+
+	subj = X509_get_subject_name(cert);
 
 	log_error("Gateway certificate validation failed, and the certificate digest is not in the local whitelist. If you trust it, rerun with:\n");
 	log_error("    --trusted-cert %s\n", digest_str);


### PR DESCRIPTION
https://github.com/adrienverge/openfortivpn/security/code-scanning/26
> This call to SSL_get_peer_certificate is not followed by a call to SSL_get_verify_result.