### PR TITLE
Fix new checkpatch.pl issue

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -205,7 +205,7 @@ cleanup:
 	}
 
 #else
-	FILE * fp;
+	FILE *fp;
 	uint32_t total_bytes_read = 0;
 
 	char *saveptr3 = NULL;


### PR DESCRIPTION
```
src/ipv4.c:208: ERROR: "foo * bar" should be "foo *bar"
total: 1 errors, 0 warnings, 1414 lines checked
error: src/ipv4.c does not comply with Linux kernel coding style
```

Strangely enough, this reverts 0157f73 which was suggested by `checkpatch.pl` itself at the time!