### PR TITLE
Discard invalid empty HDLC frame at end of buffer

### DIFF
--- a/src/hdlc.c
+++ b/src/hdlc.c
@@ -200,7 +200,7 @@ ssize_t hdlc_find_frame(const uint8_t *buffer, size_t bufsize, off_t *start)
 	int i, s = -1, e = -1;
 
 	// Look for frame start
-	for (i = *start; i < bufsize - 2; i++) {
+	for (i = *start; i < bufsize; i++) {
 		if (buffer[i] == 0x7e) { // Flag Sequence
 			s = i + 1;
 			break;
@@ -210,7 +210,7 @@ ssize_t hdlc_find_frame(const uint8_t *buffer, size_t bufsize, off_t *start)
 		return ERR_HDLC_NO_FRAME_FOUND;
 
 	// Discard empty frames
-	while (s < bufsize - 2 && buffer[s] == 0x7e) // consecutive Flag Sequences
+	while (s < bufsize && buffer[s] == 0x7e) // consecutive Flag Sequences
 		s++;
 
 	// Look for frame end


### PR DESCRIPTION
When start is exactly 2 bytes before the end of the buffer, the optimisation where we skip the last 2 bytes kicks in, and we return an invalid result (offset 0 represents an empty HDLC frame) instead of `ERR_HDLC_NO_FRAME_FOUND`.

Fixes #788.

Thank you @mr0mr0 for this fix!