### PR TITLE
IPPROTO_IP → 0

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -607,7 +607,7 @@ static int ipv4_set_route(struct rtentry *route)
 	/* we can copy rtentry struct directly between openfortivpn and kernel */
 	log_debug("ip route add %s\n", ipv4_show_route(route));
 
-	int sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+	int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 
 	if (sockfd < 0)
 		return ERR_IPV4_SEE_ERRNO;
@@ -676,7 +676,7 @@ static int ipv4_del_route(struct rtentry *route)
 	tmp.rt_window = 0;
 	tmp.rt_irtt = 0;
 
-	sockfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+	sockfd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (sockfd < 0)
 		return ERR_IPV4_SEE_ERRNO;
 	if (ioctl(sockfd, SIOCDELRT, &tmp) == -1) {


### PR DESCRIPTION
From the POSIX documentation for the `protocol` argument of `socket`:

https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html

> Specifies a particular protocol to be used with the socket. Specifying a _protocol_ of 0 causes _socket_() to use an unspecified default protocol appropriate for the requested socket type.

While the actual value of `IPPROTO_IP` is 0, the POSIX documentation for the `netinet/in.h` header suggests `IPPROTO_IP` should be used only for the `level` argument of `getsockopt` and `setsockopt`:

https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html

> The _<netinet/in.h>_ header shall define the following macros for use as values of the _level_ argument of [_getsockopt_()](https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html) and [_setsockopt_()](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html):
>
> IPPROTO_IP
> Internet protocol.
