### PR TITLE
add Dockerfile and notes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine
+
+WORKDIR /opt
+
+RUN apk update
+
+RUN apk add --update-cache \
+    git autoconf automake pkgconfig gcc g++ libressl-dev make ppp-pppoe
+
+COPY . ./
+
+RUN ./autogen.sh && \
+    ./configure --prefix=/usr/local --sysconfdir=/etc --disable-dependency-tracking && \
+    make && \
+    make install
+
+ENTRYPOINT ["/usr/local/bin/openfortivpn"]
+
+CMD ["-c", "/etc/openfortivpn/config"]

--- a/README.md
+++ b/README.md
@@ -174,6 +174,25 @@ For other distros, you'll need to build and install from source:
 
     Finally, install runtime dependency `ppp` or `pppd`.
 
+Docker
+----------------
+
+Build
+
+```bash
+docker build . -t openforticlient
+```
+Run
+```bash
+docker run --privileged --cap-add=NET_ADMIN --net host -d -v config:/etc/openfortivpn/config openforticlient
+```
+
+or with parameters
+
+```bash
+docker run --privileged --cap-add=NET_ADMIN --net host -d -v config:/etc/openfortivpn/config openforticlient -c /etc/openfortivpn/config --set-dns=0 --pppd-use-peerdns=1
+```
+
 Running as root?
 ----------------
 


### PR DESCRIPTION
Hello,

I generally use openfortivpn with docker. There are some fortivpnclient docker images but not `openfortivpn`. So I would like to add Dockerfle to use it everywhere.


in Docker needed two param ` --privileged --cap-add=NET_ADMIN` and `--net host`

There two options to run it

`docker run --privileged --cap-add=NET_ADMIN --net host -d -v config:/etc/openfortivpn/config openforticlient`

or could be run with other params like `--set-dns=0 --pppd-use-peerdns=1`

`docker run --privileged --cap-add=NET_ADMIN --net host -d -v config:/etc/openfortivpn/config openforticlient -c /etc/openfortivpn/config --set-dns=0 --pppd-use-peerdns=1`


Thank you.