### PR TITLE
Skip new codespell false positives

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,4 +18,4 @@ jobs:
       - uses: codespell-project/actions-codespell@master
         with:
           skip: .git,checkpatch.pl,spelling.txt,LICENSE.OpenSSL
-          ignore_words_list: synopsys,parms
+          ignore_words_list: anull,caf,synopsys,parms


### PR DESCRIPTION
Caused by updated codespell dictionaries.

See also https://github.com/codespell-project/codespell/issues/2786.