### PR TITLE
SSO/SAML/2FA and external browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,21 @@ As described in [#54](https://github.com/adrienverge/openfortivpn/issues/54),
 a malicious user could use `--pppd-plugin` and `--pppd-log` options to divert
 the program's behaviour.
 
+SSO/SAML/2FA
+------------
+
+In some cases, the server may require the VPN client to load and interact
+with a web page containing JavaScript. Depending on the complexity of the
+web page, interpreting the web page might be beyond the reach of a command
+line program such as openfortivpn.
+
+In such cases, you may use an external program spawning a full-fledged
+web browser such as
+[openfortivpn-webview](https://github.com/gm-vm/openfortivpn-webview)
+to authenticate and retrieve a session cookie. This cookie can be fed
+to openfortivpn using option `--cookie-on-stdin`. Obviously, such a
+solution requires a graphic session.
+
 Contributing
 ------------
 


### PR DESCRIPTION
A few notes on how to proceed in case SSO/SAML/2FA require user interaction in web pages containing JavaScript. The best course of action is to use external software that spawns a real web browser to retrieve the session cookie. Of course that requires a graphic session, unlike openfortivpn.

Related to #974, #1042, #1080.