### PR TITLE
syslog.target is obsolete

### DIFF
--- a/lib/systemd/system/openfortivpn@.service.in
+++ b/lib/systemd/system/openfortivpn@.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=OpenFortiVPN for %I
-After=syslog.target network-online.target
+After=network-online.target
 Wants=network-online.target
 Documentation=man:openfortivpn(1)
 Documentation=https://github.com/adrienverge/openfortivpn#readme


### PR DESCRIPTION
Removed from systemd in 2013.

Addresses https://github.com/adrienverge/openfortivpn/commit/5c71e1f05a661317ad36249771aa3659ee30f04e#commitcomment-111887525.