### PR TITLE
Improve Bash test scripts

### DIFF
--- a/tests/lint/astyle.sh
+++ b/tests/lint/astyle.sh
@@ -4,7 +4,7 @@
 # Check that astyle is installed
 if ! command -v astyle &>/dev/null; then
   echo "error: astyle is not installed" >&2
-  exit -1
+  exit 255
 fi
 
 rc=0

--- a/tests/lint/checkpatch.sh
+++ b/tests/lint/checkpatch.sh
@@ -2,8 +2,8 @@
 # Copyright (C) 2020 Dimitri Papadopoulos
 
 # Path to checkpatch.pl
-script_dir=`dirname "${BASH_SOURCE[0]}"`
-checkpatch_path=`realpath "${script_dir}/../ci/checkpatch/checkpatch.pl"`
+script_dir=$(dirname "${BASH_SOURCE[0]}")
+checkpatch_path=$(realpath "${script_dir}/../ci/checkpatch/checkpatch.pl")
 
 rc=0
 


### PR DESCRIPTION
* Use $() instead of ``
* From the [Bash Reference Manual](https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html):
  > Exit statuses fall between 0 and 255, though, as explained below, the shell may use values above 125 specially.