### PR TITLE
Variant for the © symbol: (C) → (c)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/config.h
+++ b/src/config.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hdlc.c
+++ b/src/hdlc.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/hdlc.h
+++ b/src/hdlc.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/http.c
+++ b/src/http.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/http.h
+++ b/src/http.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/io.c
+++ b/src/io.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/io.h
+++ b/src/io.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/log.c
+++ b/src/log.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/log.h
+++ b/src/log.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/tunnel.h
+++ b/src/tunnel.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Adrien Vergé
+ *  Copyright (c) 2015 Adrien Vergé
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/userinput.c
+++ b/src/userinput.c
@@ -1,6 +1,6 @@
 /*
- *  Copyright (C) 2015 Davíð Steinn Geirsson
- *  Copyright (C) 2019 Lubomir Rintel <lkundrak@v3.sk>
+ *  Copyright (c) 2015 Davíð Steinn Geirsson
+ *  Copyright (c) 2019 Lubomir Rintel <lkundrak@v3.sk>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/userinput.h
+++ b/src/userinput.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Davíð Steinn Geirsson
+ *  Copyright (c) 2015 Davíð Steinn Geirsson
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/xml.c
+++ b/src/xml.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Lubomir Rintel
+ *  Copyright (c) 2015 Lubomir Rintel
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/xml.h
+++ b/src/xml.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2015 Lubomir Rintel
+ *  Copyright (c) 2015 Lubomir Rintel
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/tests/lint/astyle.sh
+++ b/tests/lint/astyle.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2015 Adrien Vergé
+# Copyright (c) 2015 Adrien Vergé
 
 # Check that astyle is installed
 if ! command -v astyle &>/dev/null; then

--- a/tests/lint/checkpatch.sh
+++ b/tests/lint/checkpatch.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2020 Dimitri Papadopoulos
+# Copyright (c) 2020 Dimitri Papadopoulos
 
 # Path to checkpatch.pl
 script_dir=$(dirname "${BASH_SOURCE[0]}")

--- a/tests/lint/eol-at-eof.sh
+++ b/tests/lint/eol-at-eof.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2015 Adrien Vergé
+# Copyright (c) 2015 Adrien Vergé
 
 rc=0
 

--- a/tests/lint/line_length.py
+++ b/tests/lint/line_length.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python3
-# Copyright (C) 2015 Adrien Vergé
+# Copyright (c) 2015 Adrien Vergé
 
 """Enforce maximum line length in openfortivpn C source code.
 

--- a/tests/lint/run.sh
+++ b/tests/lint/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2015 Adrien Vergé
+# Copyright (c) 2015 Adrien Vergé
 
 rc=0
 


### PR DESCRIPTION
Stubbornly stick to the examples provided in:

§ 4.2.2 of the [_Compendium of Copyright Office Practices, first ed._](https://copyright.gov/history/comp/compendium-one.pdf)

![compendium-one](https://user-images.githubusercontent.com/3234522/232288051-9f20c763-1801-4aad-8919-09afb6cd8943.png)

§ 1005.01(c) of the [_Compendium of Copyright Office Practices, second ed._](https://copyright.gov/history/comp/compendium-two.pdf)

![compendium-two](https://user-images.githubusercontent.com/3234522/232287852-cdcabe2a-e20a-4e42-a7b7-db1ebf5b9d9c.png)

§ [2204.4(A)](https://copyright.gov/comp3/chap2200/ch2200-notice.pdf#%5B%7B%22num%22%3A40%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C76%2C151%2C0%5D) of the [_Compendium of Copyright Office Practices, third ed._](https://copyright.gov/comp3/)
> #### 2204.4(A) Variants for the © Symbol
> 
> A variant of the symbol © is acceptable only if it resembles the © closely enough to
> indicate clearly that the variant is intended to be the copyright symbol. Acceptable
> variants include:
> * The letter c with a parenthesis over the top.
> * The letter c with a parenthesis under the bottom.
> * (c
> * c)
> * (c)
> * The letter c with an unenclosed circle around it.