### PR TITLE
Pass ipcp-accept-remote to pppd

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -236,6 +236,7 @@ static int pppd_run(struct tunnel *tunnel)
 				":169.254.2.1", // <local_IP_address>:<remote_IP_address>
 				"noipdefault",
 				"ipcp-accept-local",
+				"ipcp-accept-remote",
 				"noaccomp",
 				"noauth",
 				"default-asyncmap",


### PR DESCRIPTION
Since https://github.com/ppp-project/ppp/commit/9fe8923419a954fedf8b6d1a6cc07b45f165c1ab, pppd refuses to accept a different remote IP if we explictly pass one on the command line. This results in an error like:

pppd: Peer refused to agree to his IP address

Passing ipcp-accept-remote disables this behavior.

Bug: https://bugs.gentoo.org/907404