### PR TITLE
Partially revert 3b54df0, make its code optional

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -67,6 +67,7 @@ const struct vpn_config invalid_cfg = {
 	.pppd_ipparam = NULL,
 	.pppd_ifname = NULL,
 	.pppd_call = NULL,
+	.pppd_accept_remote = -1,
 #endif
 #if HAVE_USR_SBIN_PPP
 	.ppp_system = NULL,
@@ -563,6 +564,8 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 		free(dst->pppd_call);
 		dst->pppd_call = src->pppd_call;
 	}
+	if (src->pppd_accept_remote != invalid_cfg.pppd_accept_remote)
+		dst->pppd_accept_remote = src->pppd_accept_remote;
 #endif
 #if HAVE_USR_SBIN_PPP
 	if (src->ppp_system) {

--- a/src/config.h
+++ b/src/config.h
@@ -115,6 +115,7 @@ struct vpn_config {
 	char			*pppd_ipparam;
 	char			*pppd_ifname;
 	char			*pppd_call;
+	int                     pppd_accept_remote;
 #endif
 #if HAVE_USR_SBIN_PPP
 	char			*ppp_system;

--- a/src/main.c
+++ b/src/main.c
@@ -36,7 +36,8 @@
 #define PPPD_USAGE \
 "                    [--pppd-use-peerdns=<0|1>] [--pppd-log=<file>]\n" \
 "                    [--pppd-ifname=<string>] [--pppd-ipparam=<string>]\n" \
-"                    [--pppd-call=<name>] [--pppd-plugin=<file>]\n"
+"                    [--pppd-call=<name>] [--pppd-plugin=<file>]\n" \
+"                    [--pppd-accept-remote]\n"
 
 #define PPPD_HELP \
 "  --pppd-use-peerdns=[01]       Whether to ask peer ppp server for DNS server\n" \
@@ -52,7 +53,9 @@
 "                                and ip-down scripts. See man (8) pppd.\n" \
 "  --pppd-call=<name>            Move most pppd options from pppd cmdline to\n" \
 "                                /etc/ppp/peers/<name> and invoke pppd with\n" \
-"                                'call <name>'.\n"
+"                                'call <name>'.\n" \
+"  --pppd-accept-remote          Invoke pppd with option 'ipcp-accept-remote'." \
+"                                It might help avoid errors with PPP 2.5.0.\n"
 #elif HAVE_USR_SBIN_PPP
 #define PPPD_USAGE \
 "                    [--ppp-system=<system>]\n"
@@ -243,6 +246,7 @@ int main(int argc, char **argv)
 		.pppd_ipparam = NULL,
 		.pppd_ifname = NULL,
 		.pppd_call = NULL,
+		.pppd_accept_remote = 0,
 #endif
 #if HAVE_USR_SBIN_PPP
 		.ppp_system = NULL,
@@ -305,6 +309,7 @@ int main(int argc, char **argv)
 		{"pppd-ipparam",         required_argument, NULL, 0},
 		{"pppd-ifname",          required_argument, NULL, 0},
 		{"pppd-call",            required_argument, NULL, 0},
+		{"pppd-accept-remote",   no_argument, &cli_cfg.pppd_accept_remote, 1},
 		{"plugin",               required_argument, NULL, 0}, // deprecated
 #endif
 #if HAVE_USR_SBIN_PPP

--- a/src/main.c
+++ b/src/main.c
@@ -390,7 +390,7 @@ int main(int argc, char **argv)
 				cli_cfg.pppd_call = strdup(optarg);
 				break;
 			}
-			// --plugin is deprecated, --pppd-plugin should be used
+			// --plugin is deprecated, use --pppd-plugin
 			if (cli_cfg.pppd_plugin == NULL &&
 			    strcmp(long_options[option_index].name,
 			           "plugin") == 0) {


### PR DESCRIPTION
With 3b54df0, macOS users massively report this issue:
```
WARN:   Could not get current default route (Parsing /proc/net/route failed).
WARN:   Protecting tunnel route has failed. But this can be working except for some cases.
```
See https://github.com/adrienverge/openfortivpn/issues/1118.

With 3b54df0, NetworkManager users on Linux report routing problems.
See https://github.com/adrienverge/openfortivpn/issues/1120.

Without 3b54df0, users on Linux with PPP 2.5.0 report this issue:
```
Peer refused to agree to his IP address.
```
See https://github.com/adrienverge/openfortivpn/issues/1114.

Therefore, make the code optional, to cover all cases. Of course, this is a short term solution. We need to understand what happens and provide a real fix that doesn't involve options.

Fixes #1118 and #1120.