### PR TITLE
Break on reading 0 from ppp pty

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -212,7 +212,7 @@ static void *pppd_read(void *arg)
 			break;
 		} else if (n == 0) {
 			log_warn("read returned %ld\n", n);
-			continue;
+			break;
 		} else if (first_time) {
 			// pppd did talk, now we can write to it if we want
 			SEM_POST(&sem_pppd_ready);


### PR DESCRIPTION
On some (all?) non-Linux systems, when select() returns pty master file descriptor as ready to read, subsequent read() returns 0 if the slave side fd has been closed, to indicate EOF. When this happens, break is the correct course of action to avoid a potentially hazardous loop.

Fixes github issues #794, #137