### PR TITLE
Minor changes for memset() and free()

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -104,6 +104,7 @@ static void destroy_ssl_locks(void)
 	for (i = 0; i < CRYPTO_num_locks(); i++)
 		pthread_mutex_destroy(&lockarray[i]);
 	OPENSSL_free(lockarray);
+	lockarray = NULL;
 }
 #else
 static void init_ssl_locks(void)

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -116,18 +116,13 @@ static inline void route_destroy(struct rtentry *route)
 static int ipv4_get_route(struct rtentry *route)
 {
 	size_t buffer_size = IPV4_GET_ROUTE_BUFFER_CHUNK_SIZE;
-	char *buffer = malloc(buffer_size);
+	char *buffer;
 	char *realloc_buffer;
 	int err = 0;
 	char *start, *line;
 	char *saveptr1 = NULL, *saveptr2 = NULL;
 	uint32_t rtdest, rtmask, rtgtw;
 	int rtfound = 0;
-
-	if (!buffer) {
-		err = ERR_IPV4_SEE_ERRNO;
-		goto end;
-	}
 
 	/*
 	 * initialize the buffer with zeroes, aiming to address the
@@ -148,7 +143,12 @@ static int ipv4_get_route(struct rtentry *route)
 	 *   that there is a delimiting '\0' character by proper
 	 *   initialization. We ensure this also when growing the buffer.
 	 */
-	memset(buffer, '\0', IPV4_GET_ROUTE_BUFFER_CHUNK_SIZE);
+	buffer = calloc(1, buffer_size);
+	if (!buffer) {
+		err = ERR_IPV4_SEE_ERRNO;
+		goto end;
+	}
+
 	log_debug("ip route show %s\n", ipv4_show_route(route));
 
 	// store what we are looking for

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -808,7 +808,7 @@ static int tcp_connect(struct tunnel *tunnel)
 	log_debug("server_addr: %s\n", inet_ntoa(server.sin_addr));
 	log_debug("server_port: %u\n", ntohs(server.sin_port));
 	server.sin_family = AF_INET;
-	memset(&(server.sin_zero), '\0', 8);
+	memset(&(server.sin_zero), 0, sizeof(server.sin_zero));
 	log_debug("gateway_ip: %s\n", inet_ntoa(tunnel->config->gateway_ip));
 	log_debug("gateway_port: %u\n", tunnel->config->gateway_port);
 
@@ -840,7 +840,7 @@ static int tcp_connect(struct tunnel *tunnel)
 		// be careful not to fetch too many bytes at once
 		const char *response = NULL;
 
-		memset(&(request), '\0', sizeof(request));
+		memset(&(request), 0, sizeof(request));
 		for (int j = 0; response == NULL; j++) {
 			if (j >= ARRAY_SIZE(request) - 1) {
 				log_error("Proxy response is unexpectedly large and cannot fit in the %lu-bytes buffer.\n",


### PR DESCRIPTION
* Call calloc() instead of malloc()/memset().
* Set pointer to NULL after free(), when not a local variable.