### PR TITLE
Merge 'tun' config value if set in source configuration

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -523,6 +523,9 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 		free(dst->pinentry);
 		dst->pinentry = src->pinentry;
 	}
+	if (src->tun != invalid_cfg.tun) {
+		dst->tun = src->tun;
+	}
 	if (src->realm[0])
 		strcpy(dst->realm, src->realm);
 	if (src->iface_name[0])


### PR DESCRIPTION
This commit modifies the `merge_config` function to include the 'tun' value from the source configuration if it is set. Previously, this value was not being merged, leading to inconsistencies in the final configuration.

The change checks if 'tun' in the source configuration is different from its default value before merging it into the destination configuration.

This ensures that the 'tun' setting is correctly propagated when configurations are merged, allowing for more flexible and accurate VPN setups.