### PR TITLE
Use bash and python3 from env

### DIFF
--- a/etc/ppp/ip-down.local.example
+++ b/etc/ppp/ip-down.local.example
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 case "$PPP_IPPARAM" in
     openfortivpn*)

--- a/etc/ppp/ip-up.local.example
+++ b/etc/ppp/ip-up.local.example
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 case "$PPP_IPPARAM" in
     openfortivpn*)

--- a/tests/lint/astyle.sh
+++ b/tests/lint/astyle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2015 Adrien Vergé
 
 # Check that astyle is installed

--- a/tests/lint/checkpatch.sh
+++ b/tests/lint/checkpatch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2020 Dimitri Papadopoulos
 
 # Path to checkpatch.pl

--- a/tests/lint/eol-at-eof.sh
+++ b/tests/lint/eol-at-eof.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2015 Adrien Vergé
 
 rc=0

--- a/tests/lint/line_length.py
+++ b/tests/lint/line_length.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Copyright (c) 2015 Adrien Vergé
 
 """Enforce maximum line length in openfortivpn C source code.

--- a/tests/lint/run.sh
+++ b/tests/lint/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2015 Adrien Vergé
 
 rc=0


### PR DESCRIPTION
Hi
According to [Stackoverflow](https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang#10383546) and [Stackoverflow](https://stackoverflow.com/questions/7670303/purpose-of-usr-bin-python3-shebang) it looks like the portability of the scripts could be improved by having this new style for the shebangs.