### PR TITLE
Add "ipcp-accept-remote" pppd option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -228,6 +228,10 @@ AC_ARG_WITH([pppd],
 		with_ppp="no"
 	])
 )
+# this is specifically for pppd < 2.5.0
+AC_ARG_ENABLE([legacy_pppd],
+	AS_HELP_STRING([--enable-legacy-pppd],
+	               [work around pppd < 2.5.0 issues]))
 # and this is for the ppp user space client on FreeBSD
 AC_ARG_WITH([ppp],
 	AS_HELP_STRING([--with-ppp],
@@ -323,6 +327,13 @@ AS_IF([test "x$with_pppd" = "xyes"], [
 ],[
 	AC_DEFINE(HAVE_USR_SBIN_PPPD, 0)
 	AC_MSG_NOTICE([HAVE_USR_SBIN_PPPD... 0])
+])
+AS_IF([test "x$enable_legacy_pppd" = "xyes"], [
+	AC_DEFINE(LEGACY_PPPD, 1)
+	AC_MSG_NOTICE([LEGACY_PPPD... 1])
+],[
+	AC_DEFINE(LEGACY_PPPD, 0)
+	AC_MSG_NOTICE([LEGACY_PPPD... 0])
 ])
 AS_IF([test "x$enable_proc" = "xyes"], [
 	AC_DEFINE(HAVE_PROC_NET_ROUTE, 1)

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -270,13 +270,33 @@ static int pppd_run(struct tunnel *tunnel)
 				 * of our local IP address, even if the local IP address
 				 * was specified in an option.
 				 *
-				 * This option attempts to fix this:
+				 * pppd < 2.5.0 requires this option to avoid this error:
 				 *     Peer refused to agree to our IP address
+				 * This doesn't make sense to me. I feel it should be the
+				 * default because:
+				 * 1. we do not specify a local IP address,
+				 * 2. we use option noipdefault to specifically ask the
+				 *    peer to supply the local IP address.
 				 *
-				 * Yet, this doesn't make sense: we do not specify
-				 * a local IP address, and we use noipdefault.
+				 * pppd ≥ 2.5.0 might not require it, but I don't dare
+				 * removing it.
 				 */
 				"ipcp-accept-local",
+#ifndef LEGACY_PPPD
+				/*
+				 * With this option, pppd accepts the peer's idea of its
+				 * (remote) IP address, even if the remote IP address was
+				 * specified in an option.
+				 *
+				 * pppd ≥ 2.5.0 requires this option to avoid this error:
+				 *     Peer refused to agree to his IP address
+				 * This makes perfect sense.
+				 *
+				 * Unfortunately, pppd < 2.5.0 does not like this option.
+				 * Again, this doesn't make sense to me.
+				 */
+				"ipcp-accept-remote",
+#endif
 				"noaccomp",
 				"noauth",
 				"default-asyncmap",


### PR DESCRIPTION
PPP ≥ 2.5.0 requires this option to avoid this error:
```
	Peer refused to agree to his IP address
```
It makes sense to let the remote decide for the remote IP address.

Unfortunately, PPP < 2.5.0 does not like this option. Of course, it doesn't make any sense.

Fixes #1076.