### PR TITLE
fix issues with masking password in debug output

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -90,16 +90,14 @@ int http_send(struct tunnel *tunnel, const char *request, ...)
 		char password[3 * PASSWORD_SIZE + 1];
 
 		url_encode(password, tunnel->config->password);
-		pwstart = strstr(logbuffer, password);
 
-		while (pwstart != NULL) {
+		while ((pwstart = strstr(logbuffer, password))) {
 			int pos, pwlen, i;
 
 			pos = pwstart - logbuffer;
 			pwlen = strlen(password);
 			for (i = pos; i < pos + pwlen; i++)
 				logbuffer[i] = '*';
-			pwstart = strstr(logbuffer, password);
 		}
 	}
 

--- a/src/http.c
+++ b/src/http.c
@@ -92,13 +92,14 @@ int http_send(struct tunnel *tunnel, const char *request, ...)
 		url_encode(password, tunnel->config->password);
 		pwstart = strstr(logbuffer, password);
 
-		if (pwstart != NULL) {
+		while (pwstart != NULL) {
 			int pos, pwlen, i;
 
 			pos = pwstart - logbuffer;
-			pwlen = strlen(tunnel->config->password);
+			pwlen = strlen(password);
 			for (i = pos; i < pos + pwlen; i++)
 				logbuffer[i] = '*';
+			pwstart = strstr(logbuffer, password);
 		}
 	}
 


### PR DESCRIPTION
As discussed in private, this commmit fixes issues with masking the password in the debug output. 

Thanks to Moses Palmér from New Rain Software for his report:

When debug logging HTTP requests, openfortivpn makes an attempt to mask the password. This is performed by searching for the URL-encoded password in the log message, and if found, masking its characters.


I see two problems with the implementation.


Firstly, the code assumes that only one instance of the password string is present in the log buffer; if a user has selected a password that may be a substring of a header, the actual password from the query string will be logged.


Secondly, even if the correct instance of the password string is found, it may not be completely masked. The code performing the masking uses the length of the actual password and not the length of the URL encoded password to determine the number of characters to mask (https://github.com/adrienverge/openfortivpn/blob/6181a4a69b8cc954758623ce89bd22e5dcc0e44e/src/http.c#L99). For a password with many characters needing URL escaping, this will reveal a lot of the string.

We agreed that this is an issue with security context, but it is not that critical so that it couldn't be discussed and fixed in a public pull request.
