### PR TITLE
Clean up 1a6d2e9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -228,11 +228,11 @@ AC_ARG_WITH([pppd],
 		with_ppp="no"
 	])
 )
-# this is specifically for pppd < 2.5.0
+# support pppd < 2.5.0 by default instead of pppd >= 2.5.0
 AC_ARG_ENABLE([legacy_pppd],
 	AS_HELP_STRING([--enable-legacy-pppd],
-	               [work around pppd < 2.5.0 issues]))
-# and this is for the ppp user space client on FreeBSD
+	               [support pppd < 2.5.0 by default instead of pppd >= 2.5.0]))
+# this is for the ppp user space client on FreeBSD
 AC_ARG_WITH([ppp],
 	AS_HELP_STRING([--with-ppp],
 		       [set the path to the ppp userspace client on FreeBSD]),

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -39,6 +39,7 @@ openfortivpn \- Client for PPP+SSL VPN tunnel services
 [\fB\-\-pppd\-ipparam=\fI<string>\fR]
 [\fB\-\-pppd\-ifname=\fI<string>\fR]
 [\fB\-\-pppd\-call=\fI<name>\fR]
+[\fB\-\-pppd\-accept\-remote=\fI<bool>\fR]
 [\fB\-\-ppp\-system=\fI<string>\fR]
 [\fB\-\-use\-resolvconf=\fI<bool>\fR]
 [\fB\-\-persistent=\fI<interval>\fR]
@@ -226,6 +227,10 @@ Drop usual arguments from pppd command line and add `call <name>' instead.
 This can be useful on Debian and Ubuntu, where unprivileged users in
 group `dip' can invoke `pppd call <name>' to make pppd read and apply
 options from /etc/ppp/peers/<name> (including privileged ones).
+.TP
+\fB\-\-pppd\-accept\-remote=\fI<bool>\fR
+Whether to invoke pppd with `ipcp-accept-remote'. Enabling this option breaks
+pppd < 2.5.0 but is required by newer pppd versions.
 .TP
 \fB\-\-ppp\-system=\fI<string>\fR
 Only available if compiled for ppp user space client (e.g. on FreeBSD).

--- a/src/config.c
+++ b/src/config.c
@@ -350,6 +350,15 @@ int load_config(struct vpn_config *cfg, const char *filename)
 		} else if (strcmp(key, "pppd-call") == 0) {
 			free(cfg->pppd_call);
 			cfg->pppd_call = strdup(val);
+		} else if (strcmp(key, "pppd-accept-remote") == 0) {
+			int pppd_accept_remote = strtob(val);
+
+			if (pppd_accept_remote < 0) {
+				log_warn("Bad pppd-accept-remote in configuration file: \"%s\".\n",
+				         val);
+				continue;
+			}
+			cfg->pppd_accept_remote = pppd_accept_remote;
 #else
 		} else if (strcmp(key, "pppd") == 0) {
 			log_warn("Ignoring pppd option \"%s\" in the config file.\n",


### PR DESCRIPTION
Runtime option `pppd-accept-remote` will remain available at all time, but will now accept a boolean argument:
* `--pppd-accept-remote=1`: invoke pppd with the `ipcp-accept-remote` option, which is required by pppd ≥ 2.5.0.
* `--pppd-accept-remote=0`: invoke pppd without the `ipcp-accept-remote` option, which is required by pppd < 2.5.0.
* `--pppd-accept-remote` is kept as a deprecated, undocumented synonym of `--pppd-accept-remote=1`.

Build-time option `--enable-legacy-pppd` will change the default from `--pppd-accept-remote=1` to `--pppd-accept-remote=0`. This might be preferable on older platforms shipping pppd < 2.5.0, such as macOS.