### PR TITLE
SSL → TLS

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -37,7 +37,7 @@ jobs:
             --form email=DimitriPapadopoulos@users.noreply.github.com \
             --form file=@openfortivpn.xz \
             --form version=coverity_scan \
-            --form description="Client for PPP+SSL VPN tunnel services" \
+            --form description="Client for PPP+TLS VPN tunnel services" \
             https://scan.coverity.com/builds?project=adrienverge%2Fopenfortivpn
         env:
           TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ On the master branch there may be changes that are not (yet) described here.
 * [-] improve tunnel speed on macOS
 * [-] modify memory allocation in the tunnel configuration structure
 * [+] openfortivpn returns the PPP exit status
-* [+] print SSL socket options in log
+* [+] print TLS socket options in log
 
 ### 1.15.0
 
@@ -362,7 +362,7 @@ On the master branch there may be changes that are not (yet) described here.
 * [+] Export the configuration of routes and gateway to environment
 * [~] Several improvements around establishing the tunnel connection and http traffic
 * [+] Allow using a custom CA
-* [-] Turn on SSL verification, check the hostname at least for the CN
+* [-] Turn on TLS verification, check the hostname at least for the CN
 * [+] Add --plugin option
 * [-] Fix a format string warning in do_log_packet
 * [~] Improved debugging output

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 openfortivpn
 ============
 
-openfortivpn is a client for PPP+SSL VPN tunnel services.
+openfortivpn is a client for PPP+TLS VPN tunnel services.
 It spawns a pppd process and operates the communication between the gateway and
 this process.
 

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -1,7 +1,7 @@
 .TH OPENFORTIVPN 1 "May 4, 2020" ""
 
 .SH NAME
-openfortivpn \- Client for PPP+SSL VPN tunnel services
+openfortivpn \- Client for PPP+TLS VPN tunnel services
 
 .SH SYNOPSIS
 .B openfortivpn
@@ -167,13 +167,13 @@ Pass phrase for the PEM-encoded key.
 Log to syslog instead of terminal.
 .TP
 \fB\-\-trusted\-cert=\fI<digest>\fR
-Trust a given gateway. If classical SSL certificate validation fails, the
+Trust a given gateway. If classical TLS certificate validation fails, the
 gateway certificate will be matched against this value. \fI<digest>\fR is the
 X509 certificate's sha256 sum. The certificate has to be encoded in DER form.
 This option can be used multiple times to trust several certificates.
 .TP
 \fB\-\-insecure\-ssl\fR
-Do not disable insecure SSL protocols/ciphers.
+Do not disable insecure TLS protocols/ciphers.
 If your server requires a specific cipher, consider using \fB\-\-cipher\-list\fR
 instead.
 .TP

--- a/src/http.c
+++ b/src/http.c
@@ -112,9 +112,9 @@ int http_send(struct tunnel *tunnel, const char *request, ...)
 		n = safe_ssl_write(tunnel->ssl_handle, (uint8_t *) buffer,
 		                   length);
 	if (n < 0) {
-		log_debug("Error writing to SSL connection (%s).\n",
+		log_debug("Error writing to TLS connection (%s).\n",
 		          err_ssl_str(n));
-		return ERR_HTTP_SSL;
+		return ERR_HTTP_TLS;
 	}
 
 	return 1;
@@ -169,13 +169,13 @@ int http_receive(struct tunnel *tunnel,
 
 		while ((n = safe_ssl_read(tunnel->ssl_handle,
 		                          (uint8_t *) buffer + bytes_read,
-		                          capacity - bytes_read)) == ERR_SSL_AGAIN)
+		                          capacity - bytes_read)) == ERR_TLS_AGAIN)
 			;
 		if (n < 0) {
-			log_debug("Error reading from SSL connection (%s).\n",
+			log_debug("Error reading from TLS connection (%s).\n",
 			          err_ssl_str(n));
 			free(buffer);
-			return ERR_HTTP_SSL;
+			return ERR_HTTP_TLS;
 		}
 		bytes_read += n;
 
@@ -315,7 +315,7 @@ static int http_request(struct tunnel *tunnel, const char *method,
 
 	ret = do_http_request(tunnel, method, uri, data,
 	                      response, response_size);
-	if (ret == ERR_HTTP_SSL) {
+	if (ret == ERR_HTTP_TLS) {
 		ssl_connect(tunnel);
 		ret = do_http_request(tunnel, method, uri, data,
 		                      response, response_size);

--- a/src/http.h
+++ b/src/http.h
@@ -25,7 +25,8 @@
 #define ERR_HTTP_INVALID	-1
 #define ERR_HTTP_TOO_LONG	-2
 #define ERR_HTTP_NO_MEM		-3
-#define ERR_HTTP_SSL		-4
+#define ERR_HTTP_SSL		-4  // deprecated
+#define ERR_HTTP_TLS		-4
 #define ERR_HTTP_BAD_RES_CODE	-5
 #define ERR_HTTP_PERMISSION	-6
 #define ERR_HTTP_NO_COOKIE	-7
@@ -40,8 +41,8 @@ static inline const char *err_http_str(int code)
 		return "Request too long";
 	else if (code == ERR_HTTP_NO_MEM)
 		return "Not enough memory";
-	else if (code == ERR_HTTP_SSL)
-		return "SSL error";
+	else if (code == ERR_HTTP_TLS)
+		return "TLS error";
 	else if (code == ERR_HTTP_BAD_RES_CODE)
 		return "Bad HTTP response code";
 	else if (code == ERR_HTTP_PERMISSION)

--- a/src/io.c
+++ b/src/io.c
@@ -427,7 +427,7 @@ static void debug_bad_packet(struct tunnel *tunnel, uint8_t *header)
 }
 
 /*
- * Thread to read bytes from the SSL socket, convert them to ppp packets and add
+ * Thread to read bytes from the TLS socket, convert them to ppp packets and add
  * them to the 'ssl_to_pty' pool.
  */
 static void *ssl_read(void *arg)
@@ -446,14 +446,14 @@ static void *ssl_read(void *arg)
 
 		ret = safe_ssl_read_all(tunnel->ssl_handle, header, 6);
 		if (ret < 0) {
-			log_debug("Error reading from SSL connection (%s).\n",
+			log_debug("Error reading from TLS connection (%s).\n",
 			          err_ssl_str(ret));
 			break;
 		}
 
 		if (memcmp(header, http_header, 6) == 0) {
 			/*
-			 * When the SSL-VPN portal has not been set up to allow
+			 * When the TLS-VPN portal has not been set up to allow
 			 * tunnel mode for VPN clients, while it allows web mode
 			 * for web browsers, it returns an HTTP error instead of
 			 * a PPP packet:
@@ -483,7 +483,7 @@ static void *ssl_read(void *arg)
 		ret = safe_ssl_read_all(tunnel->ssl_handle, pkt_data(packet),
 		                        size);
 		if (ret < 0) {
-			log_debug("Error reading from SSL connection (%s).\n",
+			log_debug("Error reading from TLS connection (%s).\n",
 			          err_ssl_str(ret));
 			free(packet);
 			break;
@@ -525,7 +525,7 @@ static void *ssl_read(void *arg)
 }
 
 /*
- * Thread to pop packets from the 'pty_to_ssl' pool, and write them to the SSL
+ * Thread to pop packets from the 'pty_to_ssl' pool, and write them to the TLS
  * socket.
  */
 static void *ssl_write(void *arg)
@@ -553,7 +553,7 @@ static void *ssl_write(void *arg)
 			                     packet->content, 6 + packet->len);
 		} while (ret == 0);
 		if (ret < 0) {
-			log_debug("Error writing to SSL connection (%s).\n",
+			log_debug("Error writing to TLS connection (%s).\n",
 			          err_ssl_str(ret));
 			free(packet);
 			break;
@@ -567,7 +567,7 @@ static void *ssl_write(void *arg)
 }
 
 /*
- * Thread to pop packets from the 'pty_to_ssl' pool, and write them to the SSL
+ * Thread to pop packets from the 'pty_to_ssl' pool, and write them to the TLS
  * socket.
  */
 static void *if_config(void *arg)

--- a/src/io.h
+++ b/src/io.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 
 /*
- * For performance reasons, we store the 6-byte header used by the SSL
+ * For performance reasons, we store the 6-byte header used by the TLS
  * communication right in front of the real PPP packet data. This way,
  * SSL_write can be called directly on packet->content, instead of memcpy'ing
  * the header + data to a temporary buffer.

--- a/src/main.c
+++ b/src/main.c
@@ -92,7 +92,7 @@ PPPD_USAGE \
 "\n"
 
 #define summary \
-"Client for PPP+SSL VPN tunnel services.\n" \
+"Client for PPP+TLS VPN tunnel services.\n" \
 "openfortivpn connects to a VPN by setting up a tunnel to the gateway at\n" \
 "<host>:<port>. It spawns a pppd process and operates the communication between\n" \
 "the gateway and this process.\n" \
@@ -143,7 +143,7 @@ PPPD_USAGE \
 "                                authentication with a certificate.\n" \
 "  --pem-passphrase=<pass>       Pass phrase for the PEM-encoded key.\n" \
 "  --use-syslog                  Log to syslog instead of terminal.\n" \
-"  --trusted-cert=<digest>       Trust a given gateway. If classical SSL\n" \
+"  --trusted-cert=<digest>       Trust a given gateway. If classical TLS\n" \
 "                                certificate validation fails, the gateway\n" \
 "                                certificate will be matched against this value.\n" \
 "                                <digest> is the X509 certificate's sha256 sum.\n" \
@@ -151,7 +151,7 @@ PPPD_USAGE \
 "                                several certificates.\n"
 
 #define help_options_part2 \
-"  --insecure-ssl                Do not disable insecure SSL protocols/ciphers.\n" \
+"  --insecure-ssl                Do not disable insecure TLS protocols/ciphers.\n" \
 "                                Also enable TLS v1.0 if applicable.\n" \
 "                                If your server requires a specific cipher or protocol,\n" \
 "                                consider using --cipher-list and/or --min-tls instead.\n" \

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -385,7 +385,7 @@ static int pppd_run(struct tunnel *tunnel)
 #endif
 
 		if (close(tunnel->ssl_socket))
-			log_warn("Could not close ssl socket (%s).\n", strerror(errno));
+			log_warn("Could not close TLS socket (%s).\n", strerror(errno));
 		tunnel->ssl_socket = -1;
 		execv(pppd_args.data[0], (char *const *)pppd_args.data);
 		free(pppd_args.data);
@@ -997,7 +997,7 @@ free_cert:
 }
 
 /*
- * Destroy and free the SSL connection to the gateway.
+ * Destroy and free the TLS connection to the gateway.
  */
 static void ssl_disconnect(struct tunnel *tunnel)
 {
@@ -1012,7 +1012,7 @@ static void ssl_disconnect(struct tunnel *tunnel)
 	tunnel->ssl_context = NULL;
 
 	if (close(tunnel->ssl_socket))
-		log_warn("Could not close ssl socket (%s).\n", strerror(errno));
+		log_warn("Could not close TLS socket (%s).\n", strerror(errno));
 	tunnel->ssl_socket = -1;
 }
 
@@ -1052,7 +1052,7 @@ static int pem_passphrase_cb(char *buf, int size, int rwflag, void *u)
 }
 
 /*
- * Connects to the gateway and initiate an SSL session.
+ * Connects to the gateway and initiate a TLS session.
  */
 int ssl_connect(struct tunnel *tunnel)
 {
@@ -1295,7 +1295,7 @@ err_ssl_context:
 	tunnel->ssl_context = NULL;
 err_ssl_socket:
 	if (close(tunnel->ssl_socket))
-		log_warn("Could not close ssl socket (%s).\n", strerror(errno));
+		log_warn("Could not close TLS socket (%s).\n", strerror(errno));
 	tunnel->ssl_socket = -1;
 err_tcp_connect:
 	return 1;
@@ -1323,8 +1323,8 @@ int run_tunnel(struct vpn_config *config)
 	if (ret)
 		goto err_tunnel;
 
-	// Step 1: open a SSL connection to the gateway
-	log_debug("Establishing ssl connection\n");
+	// Step 1: open a TLS connection to the gateway
+	log_debug("Establishing TLS connection\n");
 	ret = ssl_connect(&tunnel);
 	if (ret)
 		goto err_tunnel;


### PR DESCRIPTION
* I have changed most user-visible strings, documentation, and code comments.
* I have also changed macro constants, keeping old definitions and marking them as deprecated.
* I have not changed function and variable names, because that would break compatibility.

The most debatable change would be:
```
openfortivpn - Client for PPP+TLS VPN tunnel services
```
instead of:
```
openfortivpn - Client for PPP+SSL VPN tunnel services
```
Indeed, "VPN SSL" remains much more used than "VPN TLS". I have therefore kept that as is.

@adrienverge Comments?