### PR TITLE
Fix segfault from my last SNI changes

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -52,7 +52,7 @@ const struct vpn_config invalid_cfg = {
 	.pinentry = NULL,
 	.realm = {'\0'},
 	.iface_name = {'\0'},
-	.sni = NULL,
+	.sni = {'\0'},
 	.set_routes = -1,
 	.set_dns = -1,
 	.pppd_use_peerdns = -1,
@@ -300,8 +300,8 @@ int load_config(struct vpn_config *cfg, const char *filename)
 			}
 			cfg->set_dns = set_dns;
 		} else if (strcmp(key, "sni") == 0) {
-			free(cfg->sni);
-			cfg->sni = strdup(val);
+			strncpy(cfg->sni, val, GATEWAY_HOST_SIZE);
+			cfg->sni[GATEWAY_HOST_SIZE] = '\0';
 		} else if (strcmp(key, "set-routes") == 0) {
 			int set_routes = strtob(val);
 

--- a/src/config.h
+++ b/src/config.h
@@ -98,7 +98,7 @@ struct vpn_config {
 	char			iface_name[IF_NAMESIZE];
 	char			realm[REALM_SIZE + 1];
 
-	char			*sni;
+	char			sni[GATEWAY_HOST_SIZE + 1];
 	int			set_routes;
 	int			set_dns;
 	int			pppd_use_peerdns;

--- a/src/main.c
+++ b/src/main.c
@@ -232,7 +232,7 @@ int main(int argc, char **argv)
 		.pinentry = NULL,
 		.realm = {'\0'},
 		.iface_name = {'\0'},
-		.sni = NULL,
+		.sni = {'\0'},
 		.set_routes = 1,
 		.set_dns = 1,
 		.use_syslog = 0,
@@ -522,7 +522,8 @@ int main(int argc, char **argv)
 			}
 			if (strcmp(long_options[option_index].name,
 			           "sni") == 0) {
-				cli_cfg.sni = strdup(optarg);
+				strncpy(cli_cfg.sni, optarg, GATEWAY_HOST_SIZE);
+				cli_cfg.sni[GATEWAY_HOST_SIZE] = '\0';
 				break;
 			}
 			if (strcmp(long_options[option_index].name,

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1270,14 +1270,14 @@ int ssl_connect(struct tunnel *tunnel)
 
 
 	// Set SNI for the session
-	const char *sni = tunnel->config->sni ? tunnel->config->sni :
+	const char *sni = tunnel->config->sni[0] ? tunnel->config->sni :
 	                  tunnel->config->gateway_host;
 	if (SSL_set_tlsext_host_name(tunnel->ssl_handle, sni) != 1)
 		log_warn("SSL_set_tlsext_host_name('%s'): %s\n",
 		         sni,
 		         ERR_error_string(ERR_peek_last_error(), NULL));
 	else
-		log_debug("Set SNU TLS handshake: %s\n", sni);
+		log_debug("Set SNI for TLS handshake: %s\n", sni);
 
 	// Initiate SSL handshake
 	if (SSL_connect(tunnel->ssl_handle) != 1) {


### PR DESCRIPTION
Deal with `sni` the same way as `gateway_host`
- Use the same maximum length `GATEWAY_HOST_SIZE`.
- Handle `sni` as a fixed-length array instead of a pointer to dynamically allocated memory. Fix the current segfault in the process, which can be explained by improper handling of the allocated memory in `merge_config()`, where we would try to merge fixed-size arrays instead of pointers to allocated memory. Now we try to merge fixed-size arrays everywhere.