### PR TITLE
Address integer overflow reported by a code analyser

### DIFF
--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -27,13 +27,13 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 
+#include <assert.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <assert.h>
 
 #define IPV4_GET_ROUTE_BUFFER_CHUNK_SIZE 65536
 #define SHOW_ROUTE_BUFFER_SIZE 128
@@ -165,6 +165,7 @@ static int ipv4_get_route(struct rtentry *route)
 	/* this is not present on Mac OS X and FreeBSD */
 	int fd;
 	uint32_t total_bytes_read = 0;
+	ssize_t bytes_read;
 
 	// Cannot stat, mmap not lseek this special /proc file
 	fd = open("/proc/net/route", O_RDONLY);
@@ -173,10 +174,10 @@ static int ipv4_get_route(struct rtentry *route)
 		goto end;
 	}
 
-	int bytes_read;
-
 	while ((bytes_read = read(fd, buffer + total_bytes_read,
 	                          buffer_size - total_bytes_read - 1)) > 0) {
+		assert(bytes_read < UINT32_MAX &&
+		       total_bytes_read < UINT32_MAX - bytes_read);
 		total_bytes_read += bytes_read;
 
 		if ((buffer_size - total_bytes_read) < 1) {
@@ -232,6 +233,7 @@ cleanup:
 	while (fgets(line, buffer_size - total_bytes_read - 1, fp) != NULL) {
 		uint32_t bytes_read = strlen(line);
 
+		assert(total_bytes_read < UINT32_MAX - bytes_read);
 		total_bytes_read += bytes_read;
 
 		if (bytes_read > 0 && line[bytes_read - 1] != '\n') {

--- a/src/userinput.c
+++ b/src/userinput.c
@@ -24,6 +24,7 @@
 #include <sys/wait.h>
 #include <termios.h>
 
+#include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <stdarg.h>
@@ -98,12 +99,14 @@ static char *uri_unescape(const char *string)
 
 static int pinentry_read(int from, char **retstr)
 {
-	int bufsiz = 0;
+	size_t bufsiz = 0;
 	char *buf = NULL, *saveptr = NULL;
-	int len = 0;
-	int ret;
+	size_t len = 0;
 
 	do {
+		ssize_t ret;
+
+		assert(bufsiz >= len);
 		if (bufsiz - len < 64) {
 			bufsiz += 64;
 			char *tmp = realloc(buf, bufsiz);
@@ -132,6 +135,7 @@ static int pinentry_read(int from, char **retstr)
 				*retstr = strdup("Short read");
 			return -1;
 		}
+		assert(len < SIZE_MAX - ret);
 		len += ret;
 	} while (buf[len - 1] != '\n');
 	// overwrite the newline with a null character
@@ -149,6 +153,8 @@ static int pinentry_read(int from, char **retstr)
 	}
 
 	if (strncmp(buf, "ERR ", 4) == 0 || strncmp(buf, "S ERROR", 7) == 0) {
+		long ret;
+
 		ret = strtol(&buf[4], NULL, 10);
 		if (!ret)
 			ret = -1;
@@ -157,7 +163,7 @@ static int pinentry_read(int from, char **retstr)
 			*retstr = *retstr ? uri_unescape(*retstr + 1) : NULL;
 		}
 		free(buf);
-		return ret;
+		return (int)ret;
 	}
 
 	free(buf);


### PR DESCRIPTION
The output of` /usr/sbin/netstat` would have to be larger than 2 GB for this to be a menace. Because this seems quite improbable, address with an `assert()` for now.