### PR TITLE
Listen for SAML login requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ config.guess
 openfortivpn@.service
 test.sh
 .vscode
+configure~

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ doc/*.1
 config.sub
 config.guess
 openfortivpn@.service
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ doc/*.1
 config.sub
 config.guess
 openfortivpn@.service
+test.sh
 .vscode

--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,8 @@
 
 bin_PROGRAMS = openfortivpn
 openfortivpn_SOURCES = src/config.c src/config.h src/hdlc.c src/hdlc.h \
-		       src/http.c src/http.h src/io.c src/io.h src/ipv4.c \
+		       src/http.c src/http.h src/io.c src/io.h \
+			   src/http_server.c src/ipv4.c \
 		       src/ipv4.h src/log.c src/log.h src/tunnel.c \
 		       src/tunnel.h src/main.c src/ssl.h src/xml.c \
 		       src/xml.h src/userinput.c src/userinput.h

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Examples
   openfortivpn vpn-gateway:8443 --username= --password= --user-cert=cert.pem --user-key=key.pem
   ```
 
+* Connect using SAML login:
+  ```shell
+  openfortivpn vpn-gateway:8443 --saml-login
+  ```
+
 * Don't set IP routes and don't add VPN nameservers to `/etc/resolv.conf`:
   ```shell
   openfortivpn vpn-gateway:8443 -u foo --no-routes --no-dns --pppd-no-peerdns
@@ -229,6 +234,14 @@ web browser such as
 to authenticate and retrieve a session cookie. This cookie can be fed
 to openfortivpn using option `--cookie-on-stdin`. Obviously, such a
 solution requires a graphic session.
+
+When started using `--saml-login` the program creates a web server that
+accepts SAML login requests. To login using SAML you just have to open
+`<your-vpn-domain>/remote/saml/start?redirect=1` and follow the login steps.
+At the end of the login process the page will be redirected to 
+`http://127.0.0.1:8020/?id=<session-id>`
+
+
 
 Contributing
 ------------

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -10,7 +10,7 @@ openfortivpn \- Client for PPP+TLS VPN tunnel services
 [\fB\-p\fR \fI<pass>\fR]
 [\fB\-\-cookie=\fI<cookie>\fR]
 [\fB\-\-cookie\-on\-stdin\fR]
-[\fB\-\-saml\-login=\fI<port>\fR]
+[\fB\-\-saml\-login[=\fI<port>\fR]]
 [\fB\-\-pinentry=\fI<name>\fR]
 [\fB\-\-otp=\fI<otp>\fR]
 [\fB\-\-otp\-prompt=\fI<prompt>\fR]

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -82,7 +82,7 @@ A valid cookie (SVPNCOOKIE) to use in place of username and password.
 \fB\-\-cookie\-on\-stdin\fR
 Read the cookie (SVPNCOOKIE) from standard input.
 .TP
-\fB\-\-saml\-login=[\fI<port>\fR]
+\fB\-\-saml\-login[=\fI<port>\fR]
 Create http server and accept requests for SAML login
 .TP
 \fB\-\-pinentry=\fI<name>\fR

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -10,6 +10,7 @@ openfortivpn \- Client for PPP+TLS VPN tunnel services
 [\fB\-p\fR \fI<pass>\fR]
 [\fB\-\-cookie=\fI<cookie>\fR]
 [\fB\-\-cookie\-on\-stdin\fR]
+[\fB\-\-saml\-login=\fI<port>\fR]
 [\fB\-\-pinentry=\fI<name>\fR]
 [\fB\-\-otp=\fI<otp>\fR]
 [\fB\-\-otp\-prompt=\fI<prompt>\fR]
@@ -80,6 +81,9 @@ A valid cookie (SVPNCOOKIE) to use in place of username and password.
 .TP
 \fB\-\-cookie\-on\-stdin\fR
 Read the cookie (SVPNCOOKIE) from standard input.
+.TP
+\fB\-\-saml\-login\fR
+Create http server and accept requests for SAML login
 .TP
 \fB\-\-pinentry=\fI<name>\fR
 The pinentry program to use. Allows supplying the password in a secure manner.

--- a/doc/openfortivpn.1.in
+++ b/doc/openfortivpn.1.in
@@ -82,7 +82,7 @@ A valid cookie (SVPNCOOKIE) to use in place of username and password.
 \fB\-\-cookie\-on\-stdin\fR
 Read the cookie (SVPNCOOKIE) from standard input.
 .TP
-\fB\-\-saml\-login\fR
+\fB\-\-saml\-login=[\fI<port>\fR]
 Create http server and accept requests for SAML login
 .TP
 \fB\-\-pinentry=\fI<name>\fR

--- a/etc/openfortivpn/config.template
+++ b/etc/openfortivpn/config.template
@@ -1,13 +1,22 @@
 ### configuration file for openfortivpn, see man openfortivpn(1) ###
 
 
-saml-login
 
 
-host = vpn.example.org
-port = 443
-username = vpnuser
-password = VPNpassw0rd
+# host = vpn.example.org
+# port = 443
+# username = vpnuser
+# password = VPNpassw0rd
 
-route = 10.0.0.1/16
-route = 172.17.5.43
+# trusted-cert = site-certificate
+
+# saml-login = 8020
+# route = 10.0.0.1/16
+# route = 172.17.5.43
+
+### dns servers, only last two lines will be used
+# dns = 4.4.4.4
+# dns = 8.8.8.8
+
+### dns suffix, only last line will be used 
+# domain = example.com

--- a/etc/openfortivpn/config.template
+++ b/etc/openfortivpn/config.template
@@ -1,6 +1,13 @@
 ### configuration file for openfortivpn, see man openfortivpn(1) ###
 
+
+saml-login
+
+
 host = vpn.example.org
 port = 443
 username = vpnuser
 password = VPNpassw0rd
+
+route = 10.0.0.1/16
+route = 172.17.5.43

--- a/src/config.c
+++ b/src/config.c
@@ -534,6 +534,9 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 		free(dst->cookie);
 		dst->cookie = src->cookie;
 	}
+	if(src->saml_port != 0){
+		dst->saml_port = src->saml_port;
+	}
 	if (src->pinentry) {
 		free(dst->pinentry);
 		dst->pinentry = src->pinentry;

--- a/src/config.c
+++ b/src/config.c
@@ -59,6 +59,7 @@ const struct vpn_config invalid_cfg = {
 	.routes = NULL,
 	.set_dns = -1,
 	.dns = NULL,
+	.domain_suffix = {'\0'},
 	.pppd_use_peerdns = -1,
 #if HAVE_RESOLVCONF
 	.use_resolvconf = -1,
@@ -425,6 +426,10 @@ int load_config(struct vpn_config *cfg, const char *filename)
 			if (strncmp(cfg->user_cert, "pkcs11:", 7) == 0)
 				cfg->use_engine = 1;
 		} else if (strcmp(key, "dns") == 0) {
+			free(cfg->domain_suffix);
+			cfg->domain_suffix = val;
+			continue;
+		} else if (strcmp(key, "dns") == 0) {
 			Node *newNode = (Node *)malloc(sizeof(Node));
 			newNode->value = val;
 			newNode->next = cfg->dns;
@@ -435,11 +440,10 @@ int load_config(struct vpn_config *cfg, const char *filename)
 			newNode->value = cidr_to_ip_mask(val);
 			newNode->next = cfg->routes;
 			cfg->routes = newNode;
-			log_warn("add route: %s\n", val);
 			continue;
 		} else if (strcmp(key, "saml-login") == 0) {
 			free(cfg->saml_port);
-			cfg->saml_port = strdup(val);
+			cfg->saml_port = atol(val);
 			continue;
 		} else if (strcmp(key, "user-key") == 0) {
 			free(cfg->user_key);

--- a/src/config.h
+++ b/src/config.h
@@ -92,6 +92,7 @@ struct vpn_config {
 	char			otp[OTP_SIZE + 1];
 	char			*cookie;
 	int			    saml_port;
+	char			*saml_session_id;
 	char			*otp_prompt;
 	unsigned int		otp_delay;
 	int			no_ftm_push;

--- a/src/config.h
+++ b/src/config.h
@@ -82,6 +82,12 @@ struct x509_digest {
  */
 #define MAX_DOMAIN_LENGTH 256
 
+typedef struct Node {
+	char *value;
+	struct Node *next;
+} Node;
+
+
 struct vpn_config {
 	char			gateway_host[GATEWAY_HOST_SIZE + 1];
 	struct in_addr		gateway_ip;
@@ -101,8 +107,10 @@ struct vpn_config {
 	char			realm[REALM_SIZE + 1];
 
 	char			sni[GATEWAY_HOST_SIZE + 1];
-	int			set_routes;
 	int			set_dns;
+	Node 		*dns; /* dns servers comming from the config file */
+	int			set_routes;
+	Node		*routes; /* routes comming from the config file */
 	int			pppd_use_peerdns;
 	int			use_syslog;
 #if HAVE_RESOLVCONF
@@ -138,6 +146,8 @@ struct vpn_config {
 	char			*hostcheck;
 	char			*check_virtual_desktop;
 };
+
+
 
 int add_trusted_cert(struct vpn_config *cfg, const char *digest);
 int strtob(const char *str);

--- a/src/config.h
+++ b/src/config.h
@@ -111,6 +111,7 @@ struct vpn_config {
 	Node 		*dns; /* dns servers comming from the config file */
 	int			set_routes;
 	Node		*routes; /* routes comming from the config file */
+	char		*domain_suffix;
 	int			pppd_use_peerdns;
 	int			use_syslog;
 #if HAVE_RESOLVCONF

--- a/src/config.h
+++ b/src/config.h
@@ -92,7 +92,7 @@ struct vpn_config {
 	char			otp[OTP_SIZE + 1];
 	char			*cookie;
 	int			    saml_port;
-	char			*saml_session_id;
+	char			saml_session_id[1024];
 	char			*otp_prompt;
 	unsigned int		otp_delay;
 	int			no_ftm_push;

--- a/src/config.h
+++ b/src/config.h
@@ -88,9 +88,10 @@ struct vpn_config {
 	uint16_t		gateway_port;
 	char			username[USERNAME_SIZE + 1];
 	char			password[PASSWORD_SIZE + 1];
-	int			password_set;
+	int			    password_set;
 	char			otp[OTP_SIZE + 1];
 	char			*cookie;
+	int			    saml_port;
 	char			*otp_prompt;
 	unsigned int		otp_delay;
 	int			no_ftm_push;

--- a/src/http.c
+++ b/src/http.c
@@ -627,6 +627,25 @@ static int try_otp_auth(struct tunnel *tunnel, const char *buffer,
  * @return  1   in case of success
  *          < 0 in case of error
  */
+int saml_login(struct vpn_config *config)
+{
+	log_debug("SAML login\n");
+	// char uri[1024];
+	// snprintf(uri, sizeof(uri), "/remote/saml/auth_id?id=%s", tunnel->saml_session_id);
+	// int ret = http_request(tunnel, "GET", uri ,uri, NULL, NULL);
+	log_debug("SAML login\n");
+	// int ret = http_request(tunnel, "GET", uri ,NULL, NULL, NULL);
+	// if (ret != 1)
+		// return ret;
+}
+
+
+/*
+ * Authenticates to gateway by sending username and password.
+ *
+ * @return  1   in case of success
+ *          < 0 in case of error
+ */
 int auth_log_in(struct tunnel *tunnel)
 {
 	int ret;

--- a/src/http.h
+++ b/src/http.h
@@ -56,7 +56,7 @@ static inline const char *err_http_str(int code)
 int http_send(struct tunnel *tunnel, const char *request, ...);
 int http_receive(struct tunnel *tunnel, char **response, uint32_t *response_size);
 
-// int saml_login(struct vpn_config *config);
+int saml_login(struct tunnel *tunnel);
 int auth_log_in(struct tunnel *tunnel);
 int auth_log_out(struct tunnel *tunnel);
 int auth_request_vpn_allocation(struct tunnel *tunnel);

--- a/src/http.h
+++ b/src/http.h
@@ -19,6 +19,7 @@
 #define OPENFORTIVPN_HTTP_H
 
 #include "tunnel.h"
+#include "config.h"
 
 #include <stdint.h>
 
@@ -55,6 +56,7 @@ static inline const char *err_http_str(int code)
 int http_send(struct tunnel *tunnel, const char *request, ...);
 int http_receive(struct tunnel *tunnel, char **response, uint32_t *response_size);
 
+// int saml_login(struct vpn_config *config);
 int auth_log_in(struct tunnel *tunnel);
 int auth_log_out(struct tunnel *tunnel);
 int auth_request_vpn_allocation(struct tunnel *tunnel);

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -32,8 +32,8 @@ int process_request(int new_socket, char *id) {
     ssize_t write_result = write(new_socket, response, buffer_size);
     (void)write_result;
 
-    dup2(new_socket, STDOUT_FILENO);
-    dup2(new_socket, STDERR_FILENO);
+    // dup2(new_socket, STDOUT_FILENO);
+    // dup2(new_socket, STDERR_FILENO);
 
 
 

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -7,6 +7,7 @@
 #include <pthread.h>
 #include "tunnel.h"
 #include <ctype.h>
+#include <signal.h>
 
 
 
@@ -116,7 +117,7 @@ void* start_http_server(void *void_config) {
         // Kill previous thread if it exists
         if (vpn_thread != 0) {
             log_error("Stop existing tunnel\n");
-            pthread_cancel(vpn_thread);
+            pthread_kill(vpn_thread,SIGTERM);
             pthread_join(vpn_thread, NULL);
         }
         

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -15,8 +15,8 @@ void* process_request(int new_socket) {
     return NULL;
 }
 
-void* start_http_server(int saml_port) {
-    log_info("Starting saml login server on port: %d\n", saml_port);
+void* start_http_server(long saml_port) {
+    
 
     int server_fd, new_socket;
     struct sockaddr_in address;
@@ -49,6 +49,7 @@ void* start_http_server(int saml_port) {
         log_error("Failed to listen on socket\n");
         return NULL;
     }
+    log_info("Listening for saml login on port: %d\n", saml_port);
     int running = 1;
     while(running) {
         if ((new_socket = accept(server_fd, (struct sockaddr *)&address, (socklen_t*)&addrlen)) < 0) {

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -1,0 +1,62 @@
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <unistd.h>
+#include "config.h"
+#include "log.h"
+#include "tunnel.h"
+
+
+
+void* process_request(int new_socket) {
+    log_info("Processing request\n");
+    
+
+    return NULL;
+}
+
+void* start_http_server(int saml_port) {
+    log_info("Starting saml login server on port: %d\n", saml_port);
+
+    int server_fd, new_socket;
+    struct sockaddr_in address;
+    int opt = 1;
+    int addrlen = sizeof(address);
+
+    // Creating socket file descriptor
+    if ((server_fd = socket(AF_INET, SOCK_STREAM, 0)) == 0) {
+        log_error("Failed to create socket\n");
+        return NULL;
+    }
+
+    // Forcefully attaching socket to the port
+    if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt))) {
+        log_error("Failed to set socket options\n");
+        return NULL;
+    }
+
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = INADDR_ANY;
+    address.sin_port = htons(saml_port);
+
+    // Forcefully attaching socket to the port
+    if (bind(server_fd, (struct sockaddr *)&address, sizeof(address)) < 0) {
+        log_error("Failed to bind socket to port %d \n",saml_port);
+        return NULL;
+    }
+
+    if (listen(server_fd, 3) < 0) {
+        log_error("Failed to listen on socket\n");
+        return NULL;
+    }
+    int running = 1;
+    while(running) {
+        if ((new_socket = accept(server_fd, (struct sockaddr *)&address, (socklen_t*)&addrlen)) < 0) {
+            log_error("Failed to accept connection\n");
+            continue;
+        }
+        process_request(new_socket);
+    }
+
+    return NULL;
+}

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -4,24 +4,67 @@
 #include <unistd.h>
 #include "config.h"
 #include "log.h"
+#include <pthread.h>
 #include "tunnel.h"
 
 
 
-void* process_request(int new_socket) {
+int process_request(int new_socket, char *id) {
     log_info("Processing request\n");
     
+    char *response = "HTTP/1.1 200 OK\r\nContent-Length: 13\r\nContent-Type: text/plain\r\n\r\nHello, world!";
+    ssize_t write_result = write(new_socket, response, strlen(response));
+    (void)write_result;
 
-    return NULL;
+    // Read the request
+    char request[1024];
+    ssize_t read_result = read(new_socket, request, sizeof(request));
+
+    // Check for '=id' in the response
+    if (read_result < 0 || strlen(request) < 10 || strncmp(request, "GET /?id=", 9) != 0) {
+        log_error("Bad request\n");
+        return -1;
+    }
+
+    // Extract the id
+    const int id_start = 9;
+    char *id_end = memchr(&request[id_start], ' ', 1000);
+
+    if (id_end == NULL) {
+        log_error("Bad request format\n");
+        return -1;
+    }
+
+    int id_length = id_end - &request[id_start];
+
+    if(id_length == 0 || id_length > 1000) {
+        log_error("Bad request id\n");
+        return -1;
+    }
+
+    strncpy(id, &request[id_start], id_length);
+
+    for (int i = 0; i < id_length; i++) {
+        if (isalnum(id[i]) || id[i] == '-') continue;
+        log_error("Invalid id format\n");
+        return -1;
+    }
+
+    log_info("Extracted id: %s\n", id);
+    close(new_socket);
+    return 0;
 }
 
-void* start_http_server(long saml_port) {
+/**
+ * run a http server to listen for saml login requests 
+*/
+void* start_http_server(struct vpn_config *config) {
     
-
     int server_fd, new_socket;
     struct sockaddr_in address;
     int opt = 1;
     int addrlen = sizeof(address);
+    long saml_port = config->saml_port;
 
     // Creating socket file descriptor
     if ((server_fd = socket(AF_INET, SOCK_STREAM, 0)) == 0) {
@@ -51,13 +94,46 @@ void* start_http_server(long saml_port) {
     }
     log_info("Listening for saml login on port: %d\n", saml_port);
     int running = 1;
+    char *id[1024];
+    config->saml_session_id = id;
+
+
+
+    pthread_t vpn_thread = NULL;
+
+
     while(running) {
         if ((new_socket = accept(server_fd, (struct sockaddr *)&address, (socklen_t*)&addrlen)) < 0) {
             log_error("Failed to accept connection\n");
             continue;
         }
-        process_request(new_socket);
+
+        int result = process_request(new_socket, config->saml_session_id);
+        if(result != 0) {
+            log_error("Failed to process request\n");
+            continue;
+        }
+
+
+        // Kill previous thread if it exists
+        if (vpn_thread != NULL) {
+            log_error("Stop existing tunnel\n");
+            pthread_cancel(vpn_thread);
+            pthread_join(vpn_thread, NULL);
+        }
+        
+        int thread_create_result = pthread_create(&vpn_thread, NULL, run_tunnel, &config);
+        // if (thread_create_result != 0) {
+        //     log_error("Failed to create VPN thread\n");
+        //     continue;
+        // }
+
+    
+        // pthread_detach(vpn_thread);
+
+        result = 0;
     }
 
     return NULL;
 }
+

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -1,3 +1,3 @@
 #include "config.h"
 
-void* start_http_server(struct vpn_config *config);
+void* start_http_server(void *void_config);

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -1,0 +1,3 @@
+
+
+void* start_http_server(void* arg);

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -1,3 +1,3 @@
+#include "config.h"
 
-
-void* start_http_server(long saml_port);
+void* start_http_server(struct vpn_config *config);

--- a/src/http_server.h
+++ b/src/http_server.h
@@ -1,3 +1,3 @@
 
 
-void* start_http_server(void* arg);
+void* start_http_server(long saml_port);

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -1399,44 +1399,6 @@ err_close:
 	return ret;
 }
 
-
-// char* cidr_to_ip_mask(char* cidr) {
-	
-// 	char* result = malloc(32);
-// 	memset(result, ' ', 31);
-// 	int dots = 0;
-// 	int cidrLen = strlen(cidr);
-// 	if(cidrLen > 32) cidrLen = 32;
-// 	for (int i = 0; i <= cidrLen; i++) {
-// 		result[i] = cidr[i];
-// 		if (cidr[i] != '.') continue;
-// 		dots++;
-// 	}
-// 	result[31] = '\0';
-// 	if(dots == 8) return result;
-	
-// 	struct in_addr mask_addr;
-// 	mask_addr.s_addr = 0xFFFFFFFF; // 255.255.255.255
-   
-// 	char* ip_str = strtok(cidr, "/");
-// 	char* mask_len_str = strtok(NULL, "/");
-// 	int mask_len = 0;
-// 	if (mask_len_str) {
-// 		mask_len = atoi(mask_len_str);
-// 	}
-// 	if(mask_len){
-// 		mask_addr.s_addr = htonl(~((1 << (32 - mask_len)) - 1));
-// 	}
-// 	char* mask_str = inet_ntoa(mask_addr);
-// 	snprintf(result, 32, "%-15s %s%d", ip_str, mask_str );
-// 	int mask_str_len = strlen(mask_str);
-// 	result[15] = '\0';
-// 	result[16 + mask_str_len] = '\0';
-// 	return result;
-    
-// }
-
-
 struct IP_Mask *cidr_to_ip_mask(char* cidr) {
     struct IP_Mask *result = malloc(sizeof(IP_Mask));
    

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -1398,3 +1398,70 @@ err_close:
 		         strerror(errno));
 	return ret;
 }
+
+
+// char* cidr_to_ip_mask(char* cidr) {
+	
+// 	char* result = malloc(32);
+// 	memset(result, ' ', 31);
+// 	int dots = 0;
+// 	int cidrLen = strlen(cidr);
+// 	if(cidrLen > 32) cidrLen = 32;
+// 	for (int i = 0; i <= cidrLen; i++) {
+// 		result[i] = cidr[i];
+// 		if (cidr[i] != '.') continue;
+// 		dots++;
+// 	}
+// 	result[31] = '\0';
+// 	if(dots == 8) return result;
+	
+// 	struct in_addr mask_addr;
+// 	mask_addr.s_addr = 0xFFFFFFFF; // 255.255.255.255
+   
+// 	char* ip_str = strtok(cidr, "/");
+// 	char* mask_len_str = strtok(NULL, "/");
+// 	int mask_len = 0;
+// 	if (mask_len_str) {
+// 		mask_len = atoi(mask_len_str);
+// 	}
+// 	if(mask_len){
+// 		mask_addr.s_addr = htonl(~((1 << (32 - mask_len)) - 1));
+// 	}
+// 	char* mask_str = inet_ntoa(mask_addr);
+// 	snprintf(result, 32, "%-15s %s%d", ip_str, mask_str );
+// 	int mask_str_len = strlen(mask_str);
+// 	result[15] = '\0';
+// 	result[16 + mask_str_len] = '\0';
+// 	return result;
+    
+// }
+
+
+struct IP_Mask *cidr_to_ip_mask(char* cidr) {
+    struct IP_Mask *result = malloc(sizeof(IP_Mask));
+   
+
+    result->ip = malloc(16);
+    result->mask = malloc(16);
+    
+    struct in_addr mask_addr;
+    mask_addr.s_addr = 0xFFFFFFFF; // 255.255.255.255
+   
+    char* ip_str = strtok(cidr, "/");
+    char* mask_len_str = strtok(NULL, "/");
+    int mask_len = 0;
+    if (mask_len_str) {
+        mask_len = atoi(mask_len_str);
+    }
+    if(mask_len){
+        mask_addr.s_addr = htonl(~((1 << (32 - mask_len)) - 1));
+    }
+    char* mask_str = inet_ntoa(mask_addr);
+    
+    strncpy(result->ip, ip_str, 16);
+    result->ip[15] = '\0';
+    strncpy(result->mask, mask_str, 15);
+    result->mask[15] = '\0';
+    
+    return result;
+}

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -73,6 +73,11 @@ struct ipv4_config {
 	struct rtentry	*split_rt; // split VPN routes
 };
 
+typedef struct IP_Mask{
+    char *ip;
+    char *mask;
+} IP_Mask;
+
 // Dummy function to make gcc 6 happy
 static inline struct sockaddr_in *cast_addr(struct sockaddr *addr)
 {
@@ -92,5 +97,6 @@ int ipv4_restore_routes(struct tunnel *tunnel);
 
 int ipv4_add_nameservers_to_resolv_conf(struct tunnel *tunnel);
 int ipv4_del_nameservers_from_resolv_conf(struct tunnel *tunnel);
+struct IP_Mask *cidr_to_ip_mask(char *cidr);
 
 #endif

--- a/src/log.h
+++ b/src/log.h
@@ -41,6 +41,7 @@ void increase_verbosity(void);
 void decrease_verbosity(void);
 
 void do_log(int verbosity, const char *format, ...);
+int is_valid_fd(int fd);
 
 #define log_level(verbosity, ...) \
 	do { \

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@
 #include "tunnel.h"
 #include "userinput.h"
 #include "log.h"
+#include "http_server.h"
 
 #include <openssl/ssl.h>
 
@@ -29,6 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 
 #if HAVE_USR_SBIN_PPPD && HAVE_USR_SBIN_PPP
 #error "Both HAVE_USR_SBIN_PPPD and HAVE_USR_SBIN_PPP have been defined."
@@ -77,7 +79,7 @@
 
 #define usage \
 "Usage: openfortivpn [<host>[:<port>]] [-u <user>] [-p <pass>]\n" \
-"                    [--cookie=<cookie>] [--cookie-on-stdin]\n" \
+"                    [--cookie=<cookie>] [--cookie-on-stdin] [--saml-login]\n" \
 "                    [--otp=<otp>] [--otp-delay=<delay>] [--otp-prompt=<prompt>]\n" \
 "                    [--pinentry=<program>] [--realm=<realm>]\n" \
 "                    [--ifname=<ifname>] [--set-routes=<0|1>]\n" \
@@ -117,6 +119,7 @@ PPPD_USAGE \
 "  -p <pass>, --password=<pass>  VPN account password.\n" \
 "  --cookie=<cookie>             A valid session cookie (SVPNCOOKIE).\n" \
 "  --cookie-on-stdin             Read the cookie (SVPNCOOKIE) from standard input.\n" \
+"  --saml-login[=port]            Run a http server to handle SAML login requests\n" \
 "  -o <otp>, --otp=<otp>         One-Time-Password.\n" \
 "  --otp-prompt=<prompt>         Search for the OTP prompt starting with this string.\n" \
 "  --otp-delay=<delay>           Wait <delay> seconds before sending the OTP.\n" \
@@ -225,6 +228,7 @@ int main(int argc, char *argv[])
 		.password = {'\0'},
 		.password_set = 0,
 		.cookie = NULL,
+		.saml_port = 0,
 		.otp = {'\0'},
 		.otp_prompt = NULL,
 		.otp_delay = 0,
@@ -286,6 +290,7 @@ int main(int argc, char *argv[])
 		{"password",             required_argument, NULL, 'p'},
 		{"cookie",               required_argument, NULL, 0},
 		{"cookie-on-stdin",      no_argument, NULL, 0},
+		{"saml-login",			 optional_argument, NULL, 0},
 		{"otp",                  required_argument, NULL, 'o'},
 		{"otp-prompt",           required_argument, NULL, 0},
 		{"otp-delay",            required_argument, NULL, 0},
@@ -604,6 +609,19 @@ int main(int argc, char *argv[])
 				free(cookie);
 				break;
 			}
+			if (strcmp(long_options[option_index].name,
+			           "saml-login") == 0) {
+				long port = 8020;
+				if(optarg != NULL){
+					port =	strtol(optarg, NULL, 0);
+				}
+				if (port < 0 || port > UINT_MAX) {
+					log_warn("Invalid saml listen port: %s! Default port is 8020 \n", optarg);
+					break;
+				}
+				cli_cfg.saml_port = port;
+				break;
+			}
 			goto user_error;
 		case 'h':
 			printf("%s%s%s%s%s%s%s", usage, summary,
@@ -738,14 +756,34 @@ int main(int argc, char *argv[])
 		goto exit;
 	}
 
-	do {
-		if (run_tunnel(&cfg) != 0)
-			ret = EXIT_FAILURE;
-		else
-			ret = EXIT_SUCCESS;
-		if ((cfg.persistent > 0) && (get_sig_received() == 0))
-			sleep(cfg.persistent);
-	} while ((get_sig_received() == 0) && (cfg.persistent != 0));
+	if(cfg.saml_port != 0) {
+		pthread_t server_thread;
+		if(pthread_create(&server_thread, NULL, start_http_server, &cfg) != 0){
+			log_error("Failed to create saml login server thread\n");
+			// ret = EXIT_FAILURE;
+			goto exit;
+		}
+		// log_debug("Running http server on port %d\n", cfg.saml_port);
+		while(1){
+
+		}
+		// if (run_http_server(&cfg) != 0)
+		// 	ret = EXIT_FAILURE;
+		// else
+		// 	ret = EXIT_SUCCESS;
+		// goto exit;
+	}
+
+
+
+	// do {
+	// 	if (run_tunnel(&cfg) != 0)
+	// 		ret = EXIT_FAILURE;
+	// 	else
+	// 		ret = EXIT_SUCCESS;
+	// 	if ((cfg.persistent > 0) && (get_sig_received() == 0))
+	// 		sleep(cfg.persistent);
+	// } while ((get_sig_received() == 0) && (cfg.persistent != 0));
 
 	goto exit;
 

--- a/src/main.c
+++ b/src/main.c
@@ -766,9 +766,8 @@ int main(int argc, char *argv[])
 			goto exit;
 		}
 		// log_debug("Running http server on port %d\n", cfg.saml_port);
-		while(1){
-
-		}
+		while(get_sig_received() == 0);
+		goto exit;
 	}
 
 	do {

--- a/src/main.c
+++ b/src/main.c
@@ -758,7 +758,7 @@ int main(int argc, char *argv[])
 
 	if(cfg.saml_port != 0) {
 		pthread_t server_thread;
-		if(pthread_create(&server_thread, NULL, start_http_server, &cfg) != 0){
+		if(pthread_create(&server_thread, NULL, start_http_server, cfg.saml_port) != 0){
 			log_error("Failed to create saml login server thread\n");
 			// ret = EXIT_FAILURE;
 			goto exit;

--- a/src/main.c
+++ b/src/main.c
@@ -229,6 +229,7 @@ int main(int argc, char *argv[])
 		.password_set = 0,
 		.cookie = NULL,
 		.saml_port = 0,
+		.saml_session_id = NULL,
 		.otp = {'\0'},
 		.otp_prompt = NULL,
 		.otp_delay = 0,
@@ -725,7 +726,7 @@ int main(int argc, char *argv[])
 		goto user_error;
 	}
 	// Check username
-	if (cfg.username[0] == '\0' && !cfg.cookie)
+	if (cfg.username[0] == '\0' && !cfg.cookie && !cfg.saml_port)
 		// Need either username or cert
 		if (cfg.user_cert == NULL) {
 			log_error("Specify a username.\n");
@@ -758,7 +759,10 @@ int main(int argc, char *argv[])
 
 	if(cfg.saml_port != 0) {
 		pthread_t server_thread;
-		if(pthread_create(&server_thread, NULL, start_http_server, cfg.saml_port) != 0){
+
+		
+
+		if(pthread_create(&server_thread, NULL, start_http_server, &cfg) != 0){
 			log_error("Failed to create saml login server thread\n");
 			// ret = EXIT_FAILURE;
 			goto exit;

--- a/src/main.c
+++ b/src/main.c
@@ -760,8 +760,6 @@ int main(int argc, char *argv[])
 	if(cfg.saml_port != 0) {
 		pthread_t server_thread;
 
-		
-
 		if(pthread_create(&server_thread, NULL, start_http_server, &cfg) != 0){
 			log_error("Failed to create saml login server thread\n");
 			// ret = EXIT_FAILURE;
@@ -771,23 +769,16 @@ int main(int argc, char *argv[])
 		while(1){
 
 		}
-		// if (run_http_server(&cfg) != 0)
-		// 	ret = EXIT_FAILURE;
-		// else
-		// 	ret = EXIT_SUCCESS;
-		// goto exit;
 	}
 
-
-
-	// do {
-	// 	if (run_tunnel(&cfg) != 0)
-	// 		ret = EXIT_FAILURE;
-	// 	else
-	// 		ret = EXIT_SUCCESS;
-	// 	if ((cfg.persistent > 0) && (get_sig_received() == 0))
-	// 		sleep(cfg.persistent);
-	// } while ((get_sig_received() == 0) && (cfg.persistent != 0));
+	do {
+		if (run_tunnel(&cfg) != 0)
+			ret = EXIT_FAILURE;
+		else
+			ret = EXIT_SUCCESS;
+		if ((cfg.persistent > 0) && (get_sig_received() == 0))
+			sleep(cfg.persistent);
+	} while ((get_sig_received() == 0) && (cfg.persistent != 0));
 
 	goto exit;
 

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1271,6 +1271,20 @@ int run_tunnel(struct vpn_config *config)
 		goto err_tunnel;
 	log_info("Connected to gateway.\n");
 
+	if(config->saml_port){
+		// ret = saml_login(&config);
+		// if (ret != 1) {
+		// 	log_error("Could not authenticate to gateway. Please check the password, client certificate, etc.\n");
+		// 	log_debug("%s (%d)\n", err_http_str(ret), ret);
+		// 	ret = 1;
+		// 	goto err_tunnel;
+		// }
+		log_info("Authenticated.\n");
+		// log_debug("Cookie: %s\n", tunnel.cookie);
+	
+	}
+
+
 	// Step 2: connect to the HTTP interface and authenticate to get a
 	// cookie
 	if (config->cookie)

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1278,20 +1278,6 @@ int run_tunnel(struct vpn_config *config)
 		goto err_tunnel;
 	log_info("Connected to gateway.\n");
 
-	// if(config->saml_port){
-	// 	ret = saml_login(&config);
-	// 	// if (ret != 1) {
-	// 	// 	log_error("Could not authenticate to gateway. Please check the password, client certificate, etc.\n");
-	// 	// 	log_debug("%s (%d)\n", err_http_str(ret), ret);
-	// 	// 	ret = 1;
-	// 	// 	goto err_tunnel;
-	// 	// }
-	// 	log_info("Authenticated.\n");
-	// 	// log_debug("Cookie: %s\n", tunnel.cookie);
-	
-	// }
-
-
 	// Step 2: connect to the HTTP interface and authenticate to get a
 	// cookie
 	if (config->cookie)

--- a/src/tunnel.h
+++ b/src/tunnel.h
@@ -75,6 +75,7 @@ struct tunnel {
 
 	int (*on_ppp_if_up)(struct tunnel *tunnel);
 	int (*on_ppp_if_down)(struct tunnel *tunnel);
+	
 };
 
 struct token {

--- a/src/tunnel.h
+++ b/src/tunnel.h
@@ -88,6 +88,7 @@ int ppp_interface_is_up(struct tunnel *tunnel);
 int ssl_connect(struct tunnel *tunnel);
 
 int run_tunnel(struct vpn_config *config);
+void* run_tunnel_wrapper(void *arg);
 
 #define ARRAY_SIZE(x)	(sizeof(x) / sizeof((x)[0]))
 


### PR DESCRIPTION
When started with `--saml-login` the program creates a http server that accepts SAML login requests 
The server will remain open and refresh the connection whenever a request is made

The solution needs a little more work on the logging part. 