### PR TITLE
fix config file name in service configuration

### DIFF
--- a/lib/systemd/system/openfortivpn@.service.in
+++ b/lib/systemd/system/openfortivpn@.service.in
@@ -9,7 +9,7 @@ Documentation=https://github.com/adrienverge/openfortivpn/wiki
 [Service]
 Type=notify
 PrivateTmp=true
-ExecStart=@BINDIR@/openfortivpn -c @SYSCONFDIR@/openfortivpn/%I.conf
+ExecStart=@BINDIR@/openfortivpn -c @SYSCONFDIR@/openfortivpn/%I
 Restart=on-failure
 OOMScoreAdjust=-100
 


### PR DESCRIPTION
The config path is `etc/openfortivpn/config`
The service does not start because it tries to load `etc/openfortivpn/config.conf`