### PR TITLE
vdprintf() → vsnprintf()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -166,7 +166,11 @@ write \
 ], [], AC_MSG_ERROR([Required function not found]))
 
 # Checks for optional functions.
-AC_CHECK_FUNCS([pthread_mutexattr_setrobust])
+AC_CHECK_FUNCS([ \
+pthread_mutexattr_setrobust \
+vdprintf \
+])
+
 # Use PKG_CHECK_MODULES compiler/linker flags
 save_openssl_CPPFLAGS="${CPPFLAGS}"
 save_openssl_LIBS="${LIBS}"

--- a/src/userinput.c
+++ b/src/userinput.c
@@ -167,6 +167,22 @@ static int pinentry_read(int from, char **retstr)
 	return -1;
 }
 
+#ifndef HAVE_VDPRINTF
+static int vdprintf(int fd, const char *format, va_list ap)
+{
+	char buffer[2049];
+	int size = vsnprintf(buffer, sizeof(buffer), format, ap);
+
+	if (size < 0)
+		return size;
+
+	if (size >= sizeof(buffer)) // silently discard beyond the buffer size
+		size = sizeof(buffer) - 1;
+
+	return (int) write(fd, buffer, size);
+}
+#endif
+
 static int pinentry_exchange(int to, int from, char **retstr,
                              const char *format, ...)
 {


### PR DESCRIPTION
Support older mac0S versions that lack vdprintf().

Fixes #1223.