### PR TITLE
Patch certificate login error for FortiOS 7.4.4

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -651,7 +651,7 @@ int auth_log_in(struct tunnel *tunnel)
 	tunnel->cookie[0] = '\0';
 
 	if (username[0] == '\0' && tunnel->config->password[0] == '\0') {
-		snprintf(data, sizeof(data), "cert=&nup=1");
+		snprintf(data, sizeof(data), "");
 		ret = http_request(tunnel, "GET", "/remote/login",
 		                   data, &res, &response_size);
 	} else {


### PR DESCRIPTION
Hi,

After I encounter an issue on my Fortigate following FortiOS upgrade from 7.2.8 to 7.4.4 (see the issue I openned: [here](https://github.com/adrienverge/openfortivpn/issues/1233)). 
My investigation leads me to think that now Fortigate > 7.2.4 doesn't support any content when issuing login request on "/remote/login" and so "Content-length" must be 0. This is confirmed by the debug logs on the firewall saying `do_http_validate:447 Content-Length (11) on uri (/remote/login) not allowed` and by observing Forticlient requests content on Windows using Burp proxy that have no content.

So I'm proposing this pull request to fix the issue on newer Fortigate version where GET request on "/remote/login" is now sending nothing instead of "cert=&nup=1".

This has been tested on a Fortigate 500E running FortiOS 7.4.4.

BR,

A.