### PR TITLE
Clear OTP after initial run. Fixes #1244

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -745,6 +745,7 @@ int main(int argc, char *argv[])
 			ret = EXIT_SUCCESS;
 		if ((cfg.persistent > 0) && (get_sig_received() == 0))
 			sleep(cfg.persistent);
+		cfg.otp[0] = '\0'; // clear OTP for next run
 	} while ((get_sig_received() == 0) && (cfg.persistent != 0));
 
 	goto exit;


### PR DESCRIPTION
When `--persistent=>0` the OTP should be cleared from the configuration, because it's a one-time password as the name suggests and is probably not valid anymore.

Should there be an option to keep the OTP valid until a certain amount of time has lapsed, since TOTPs may still be valid?