### PR TITLE
Clear otp after each run

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -474,6 +474,7 @@ static int try_otp_auth(struct tunnel *tunnel, const char *buffer,
 	const char *s = buffer;
 	char *d = data;
 	const char *p = NULL;
+	int ret;
 	/* Length-check for destination buffer */
 #define SPACE_AVAILABLE(sz) (sizeof(data) - (d - data) >= (sz))
 	/* Get the form action */
@@ -616,7 +617,9 @@ static int try_otp_auth(struct tunnel *tunnel, const char *buffer,
 	if (!SPACE_AVAILABLE(1))
 		return -1;
 	*d++ = '\0';
-	return http_request(tunnel, "POST", path, data, res, response_size);
+	ret = http_request(tunnel, "POST", path, data, res, response_size);
+	memset(tunnel->config->otp, '\0', OTP_SIZE + 1); // clear OTP for next run
+	return ret;
 #undef SPACE_AVAILABLE
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -781,7 +781,6 @@ int main(int argc, char *argv[])
 			ret = EXIT_SUCCESS;
 		if ((cfg.persistent > 0) && (get_sig_received() == 0))
 			sleep(cfg.persistent);
-		cfg.otp[0] = '\0'; // clear OTP for next run
 	} while ((get_sig_received() == 0) && (cfg.persistent != 0));
 
 	goto exit;


### PR DESCRIPTION
Rework 52148b7 to clear the otp just after it is used.

Also, clear it completely with memset().