### PR TITLE
Add support for split DNS

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -899,6 +899,40 @@ static int parse_xml_config(struct tunnel *tunnel, const char *buffer)
 		}
 	}
 
+	// The it could be split-dns instead of global dns
+	val = buffer;
+	while ((val = xml_find('<', "split-dns", val, 2))) {
+		char *domains, *dnsserver1, *dnsserver2;
+
+		domains = xml_get(xml_find(' ', "domains=", val, 1));
+		if (!domains) {
+			log_warn("No domain names for a split-dns\n");
+			continue;
+		}
+
+		dnsserver1 = xml_get(xml_find(' ', "dnsserver1=", val, 1));
+		if (!dnsserver1) {
+			log_warn("No dnsserver1 for a split-dns\n");
+			free(domains);
+			continue;
+		}
+
+		dnsserver2 = xml_get(xml_find(' ', "dnsserver2=", val, 1));
+		if (!dnsserver2) {
+			log_warn("No dnsserver2 for a split-dns\n");
+			free(dnsserver1);
+			free(domains);
+			continue;
+		}
+
+		ipv4_add_split_dns(tunnel, domains, dnsserver1, dnsserver2);
+
+		free(domains);
+		free(dnsserver1);
+		free(dnsserver2);
+
+	}
+
 	// Routes the tunnel wants to push
 	val = xml_find('<', "split-tunnel-info", buffer, 1);
 	while ((val = xml_find('<', "addr", val, 2))) {

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -832,6 +832,23 @@ static void add_text_route(struct tunnel *tunnel, const char *dest,
 }
 #endif
 
+int ipv4_add_split_dns(struct tunnel *tunnel, char *domains, char *server1,
+                             char *server2)
+{
+	char env_var[32]; // strlen("VPN_SPLITDNS_SERVER1_") + strlen("65535") + 1
+
+	sprintf(env_var, "VPN_SPLITDNS_DOMAIN_%d", tunnel->ipv4.split_dns);
+	setenv(env_var, domains, 0);
+	sprintf(env_var, "VPN_SPLITDNS_SERVER1_%d", tunnel->ipv4.split_dns);
+	setenv(env_var, server1, 0);
+	if (server2 != NULL) {
+		sprintf(env_var, "VPN_SPLITDNS_SERVER2_%d", tunnel->ipv4.split_dns);
+		setenv(env_var, server2, 0);
+	}
+	tunnel->ipv4.split_dns++;
+	return 0;
+}
+
 int ipv4_add_split_vpn_route(struct tunnel *tunnel, char *dest, char *mask,
                              char *gateway)
 {

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -66,6 +66,7 @@ struct ipv4_config {
 	int		dns_suffix_was_there; // was the dns suffix already there?
 	int		split_routes;
 	int		route_to_vpn_is_added;
+	int		split_dns;
 
 	struct rtentry	def_rt; // default route
 	struct rtentry	gtw_rt; // route to access VPN gateway
@@ -84,6 +85,9 @@ static inline struct sockaddr_in *cast_addr(struct sockaddr *addr)
 #define route_iface(route) ((route)->rt_dev)
 
 struct tunnel;
+
+int ipv4_add_split_dns(struct tunnel *tunnel, char *domains, char *server1,
+                             char *server2);
 
 int ipv4_add_split_vpn_route(struct tunnel *tunnel, char *dest, char *mask,
                              char *gateway);


### PR DESCRIPTION
Forti can send multiple split dns config in xml:

    <split-dns domains='office.intra,dmz.intra' dnsserver1='10.10.20.5' dnsserver2='10.10.20.6' /><split-dns domains='others.intra' dnsserver1='172.28.1.30' dnsserver2='172.28.1.31' />

This means, use one dns server for domain A+B, and use another dns server for domain C.

This patch parse the /remote/fortisslvpn_xml response to get the split-dns configuration, and pass the info to envs, same logic as ip4 routes.