### PR TITLE
OSSL Providers always. OSSL Engine support with OSSL < 3.0 only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ The pkcs11-engine from libp11 needs to be compiled with p11-kit-devel installed.
 Check [#464](https://github.com/adrienverge/openfortivpn/issues/464) for a discussion
 of known issues in this area.
 
+Building on Fedora since [this
+update](https://src.fedoraproject.org/rpms/openssl/c/13b583a535e62d12521cfeb5088a68e5811eb6e6?branch=rawhide)
+will NOT include engine support unless `openssl-devel-engine` is installed. Try
+first to use `pkcs11-provider` on OpenSSL >= 3.0.
+
 To make use of your smartcard put at least `pkcs11:` to the user-cert config or commandline
 option. It takes the full or a partial PKCS#11 token URI.
 

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -32,13 +32,13 @@
 #include "userinput.h"
 
 #include <openssl/err.h>
-#ifndef OPENSSL_NO_ENGINE
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
+#ifndef OPENSSL_NO_ENGINE
 #include <openssl/engine.h>
+#endif // OPENSSL_NO_ENGINE
 #else // OPENSSL_VERSION_NUMBER >= 0x30000000L
 #include <openssl/store.h>
-#endif
-#endif
+#endif // OPENSSL_VERSION_NUMBER
 #include <openssl/ui.h>
 #include <openssl/x509v3.h>
 #if HAVE_SYSTEMD
@@ -1092,8 +1092,8 @@ int ssl_connect(struct tunnel *tunnel)
 	}
 #endif
 
-#ifndef OPENSSL_NO_ENGINE
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
+#ifndef OPENSSL_NO_ENGINE
 	/* Use PKCS11 engine for PIV if user-cert config starts with pkcs11 URI: */
 	if (tunnel->config->use_engine > 0) {
 		ENGINE *e;
@@ -1154,6 +1154,7 @@ int ssl_connect(struct tunnel *tunnel)
 			goto err_ssl_context;
 		}
 	} else { /* end PKCS11 engine */
+#endif // OPENSSL_NO_ENGINE
 #else // OPENSSL_VERSION_NUMBER >= 0x30000000L
 	/* OpenSSL 3.0+ provider-based PKCS#11 support */
 	if (tunnel->config->use_engine > 0) {
@@ -1248,7 +1249,6 @@ int ssl_connect(struct tunnel *tunnel)
 		EVP_PKEY_free(pkey);
 	} else { /* end PKCS11 engine */
 #endif // OPENSSL_VERSION_NUMBER >= 0x30000000L
-#endif // OPENSSL_NO_ENGINE
 		if (tunnel->config->user_cert) {
 			if (!SSL_CTX_use_certificate_chain_file(
 			            tunnel->ssl_context, tunnel->config->user_cert)) {
@@ -1275,9 +1275,7 @@ int ssl_connect(struct tunnel *tunnel)
 				goto err_ssl_context;
 			}
 		}
-#ifndef OPENSSL_NO_ENGINE
 	}
-#endif
 
 	tunnel->ssl_handle = SSL_new(tunnel->ssl_context);
 	if (tunnel->ssl_handle == NULL) {


### PR DESCRIPTION
This PR shuffles the Macros for building with OpenSSL Engines/Providers.

Previous behavior:
* choose to build OpenSSL Engine support or not
  * on OpenSSL < 3,  get OpenSSL Engine support
  * on OpenSSL >= 3, get OpenSSL Provider support

Changed behavior:
* always build with OpenSSL Provider support on OpenSSL >= 3
* on OpenSSL < 3
  * choose to build with OpenSSL Engine support or not

In both cases, building with OpenSSL Engine support is no longer reachable on OpenSSL >= 3.0.
In the new case, OpenSSL provider support is OUTSIDE of OPENSSL_NO_ENGINE macros, and provider support will always be included.