### PR TITLE
SSL: avoid to leak ssl context on logged out in loop.

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1445,6 +1445,7 @@ err_tunnel:
 	} else {
 		auth_log_out(&tunnel);
 		log_info("Logged out.\n");
+		ssl_disconnect(&tunnel);
 	}
 
 	// explicitly free the buffer allocated for split routes of the ipv4 configuration


### PR DESCRIPTION
 * Closes #1263.
 * If we go out of run_tunnel we should always ensure to reset the ssl context to avoid any file exhaustion for the process.