### PR TITLE
Tun

### DIFF
--- a/etc/NetworkManager/dispatcher.d/30-pppVPN-rules.sh
+++ b/etc/NetworkManager/dispatcher.d/30-pppVPN-rules.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Sample script to add in the /etc/NetworkManager/dispatcher.d folder.
+# Allowing you to properly configure additionnal routes if needed
+# There might be better way to do this, but I'm not aware of them in my specific case.
+
+
+# The UUID of the connection profile we want to target. Use it if the UUID is fixed in your case.
+#TARGET_CONNECTION_UUID="a1b2c3d4-e5f6-7890-1234-56789abcdef0"
+
+# The interface name (if UUID is not fixed). don't forget to use the --tun-ifname=pppVPN to your config file.
+TARGET_INTERFACE="pppVPN"
+
+# The interface name (e.g., ppp0, enp3s0) is the first argument
+INTERFACE="$1"
+# The action (e.g., "up", "down") is the second argument
+ACTION="$2"
+
+# Check if the script is being run for our target connection
+#if [ "$CONNECTION_UUID" = "$TARGET_CONNECTION_UUID"  ]; then
+if [ "$INTERFACE" = "$TARGET_INTERFACE" ]; then
+    case "$ACTION" in
+        up)
+            # This code runs when the connection comes up
+            logger "NetworkManager Dispatcher: Applying custom rules for $INTERFACE"
+            # Add specific ressources route rules here (more easy than the +ipv4.route using the via which could be random):
+            #ip route add 10.10.10.0/24 dev $TARGET_INTERFACE scope link
+            #ip route add 10.10.20.0/24 dev $TARGET_INTERFACE scope link
+            #ip route add 10.10.30.120/32 dev $TARGET_INTERFACE scope link
+            ;;
+        down)
+            # This code runs when the connection goes down
+            logger "NetworkManager Dispatcher: Removing custom rules for $INTERFACE"
+            # if using the dev $TARGET_INTERFACE nothing to do, if not, you should remove your rules here
+            ;;
+    esac
+fi
+
+true

--- a/src/config.c
+++ b/src/config.c
@@ -296,6 +296,18 @@ int load_config(struct vpn_config *cfg, const char *filename)
 		} else if (strcmp(key, "realm") == 0) {
 			strncpy(cfg->realm, val, REALM_SIZE);
 			cfg->realm[REALM_SIZE] = '\0';
+		} else if (strcmp(key, "tun") == 0) {
+			long tun = strtol(val, NULL, 0);
+
+			if (tun < 0 || tun > 1) {
+				log_warn("Bad tun option in configuration file: \"%ld\".\n",
+				         tun);
+				continue;
+			}
+			cfg->tun = tun;
+		} else if (strcmp(key, "tun-ifname") == 0) {
+			free(cfg->tun_ifname);
+			cfg->tun_ifname = strdup(val);
 		} else if (strcmp(key, "set-dns") == 0) {
 			int set_dns = strtob(val);
 

--- a/src/config.c
+++ b/src/config.c
@@ -54,6 +54,7 @@ const struct vpn_config invalid_cfg = {
 	.pinentry = NULL,
 	.realm = {'\0'},
 	.tun = -1,
+	.tun_ifname = NULL,
 	.iface_name = {'\0'},
 	.sni = {'\0'},
 	.set_routes = -1,
@@ -498,6 +499,7 @@ void destroy_vpn_config(struct vpn_config *cfg)
 	free(cfg->otp_prompt);
 	free(cfg->pinentry);
 	free(cfg->cookie);
+	free(cfg->tun_ifname);
 #if HAVE_USR_SBIN_PPPD
 	free(cfg->pppd_log);
 	free(cfg->pppd_plugin);
@@ -553,6 +555,10 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 	}
 	if (src->tun != invalid_cfg.tun)
 		dst->tun = src->tun;
+	if (src->tun_ifname) {
+		free(dst->tun_ifname);
+		dst->tun_ifname = src->tun_ifname;
+	}
 	if (src->realm[0])
 		strcpy(dst->realm, src->realm);
 	if (src->iface_name[0])

--- a/src/config.h
+++ b/src/config.h
@@ -99,6 +99,7 @@ struct vpn_config {
 	int			no_ftm_push;
 	char			*pinentry;
 	int			tun;
+	char			*tun_ifname;
 	char			iface_name[IF_NAMESIZE];
 	char			realm[REALM_SIZE + 1];
 

--- a/src/main.c
+++ b/src/main.c
@@ -81,7 +81,7 @@
 "                    [--cookie=<cookie>] [--cookie-on-stdin] [--saml-login]\n" \
 "                    [--otp=<otp>] [--otp-delay=<delay>] [--otp-prompt=<prompt>]\n" \
 "                    [--pinentry=<program>] [--realm=<realm>]\n" \
-"                    [--tun=<0|1>] [--ifname=<ifname>] [--set-routes=<0|1>]\n" \
+"                    [--tun=<0|1>] [--tun-ifname=<ifname>] [--ifname=<ifname>] [--set-routes=<0|1>]\n" \
 "                    [--half-internet-routes=<0|1>] [--set-dns=<0|1>]\n" \
 PPPD_USAGE \
 "                    " RESOLVCONF_USAGE "[--ca-file=<file>]\n" \
@@ -126,6 +126,8 @@ PPPD_USAGE \
 "  --pinentry=<program>          Use the program to supply a secret instead of asking for it.\n" \
 "  --realm=<realm>               Use specified authentication realm.\n" \
 "  --tun=[01]                    Create a TUN device and use internal PPP code (experimental).\n" \
+"  --tun-ifname=<ifname>         Choose the tunX interface name to ease custom scripts routing\n" \
+"                                handling (experimental).\n" \
 "  --ifname=<interface>          Bind to interface.\n" \
 "  --set-routes=[01]             Set if openfortivpn should configure routes\n" \
 "                                when tunnel is up.\n"               \
@@ -297,6 +299,7 @@ int main(int argc, char *argv[])
 		{"otp-delay",            required_argument, NULL, 0},
 		{"no-ftm-push",          no_argument, &cli_cfg.no_ftm_push, 1},
 		{"tun",                  required_argument, NULL, 0},
+		{"tun-ifname",           required_argument, NULL, 0},
 		{"ifname",               required_argument, NULL, 0},
 		{"set-routes",	         required_argument, NULL, 0},
 		{"sni",                  required_argument, NULL, 0},
@@ -520,6 +523,12 @@ int main(int argc, char *argv[])
 					break;
 				}
 				cli_cfg.tun = tun;
+				break;
+			}
+			if (strcmp(long_options[option_index].name,
+			           "tun-ifname") == 0) {
+				free(cli_cfg.tun_ifname);
+				cli_cfg.tun_ifname = strdup(optarg);
 				break;
 			}
 			if (strcmp(long_options[option_index].name,

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -1570,6 +1570,13 @@ err_start_tunnel:
 	if (!config->tun) {
 		ret = pppd_terminate(&tunnel);
 		log_info("Terminated %s.\n", PPP_DAEMON);
+	} else {
+		if (tunnel.pppd_pty > 0)
+			if (tun_close(tunnel.pppd_pty))
+				log_error("Cannot properly close tun interface (%d)",
+				          errno);
+		tunnel.pppd_pty = -1;
+		log_info("Closing tun interface.\n");
 	}
 err_tunnel:
 	log_info("Closed connection to gateway.\n");

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -262,6 +262,10 @@ static int tun_setup(struct tunnel *tunnel)
 		.ifr_flags = IFF_TUN | IFF_NO_PI,
 	};
 
+	/* Renamme the interface by default if asked to do so */
+	if (tunnel->config->tun_ifname)
+		strncpy(ifreq.ifr_name, tunnel->config->tun_ifname, IFNAMSIZ - 1);
+
 	tun_fd = tun_open(&ifreq);
 	if (tun_fd < 0) {
 		log_error("tun_open failed: %s\n", strerror(errno));


### PR DESCRIPTION
* Adding some features to the tun pull request:
  * capacity to rename the tun interface
  * sample file for dispatch.d to allow easy setup additional routes.
  * allow to use the tun / tun-ifname in a openfortivpn.conf file.
  *  Fixes the persistent=X case properly.

Still missing: conditional compilation to HAVE_LINUX_IF_TUN_H to avoid breaking BSD / MacOS builds with the tun interface code ...

NOTE: to get it works, if not using the set-routes=1 option (aka set-routes=0 or no-routes) you should consider the #1297 too !