### PR TITLE
Address GCC warning

### DIFF
--- a/src/userinput.c
+++ b/src/userinput.c
@@ -370,7 +370,6 @@ void read_password(const char *pinentry, const char *hint,
 char *read_from_stdin(size_t count)
 {
 	char *buf;
-	char *output;
 	ssize_t bytes_read;
 
 	assert(count < SIZE_MAX - 1);


### PR DESCRIPTION
```
src/userinput.c: In function ‘read_from_stdin’:
src/userinput.c:373:15: warning: unused variable ‘output’ [-Wunused-variable]
  373 |         char *output;
      |               ^~~~~~
```