### PR TITLE
비밀번호 만료 및 변경 처리 지원 추가

### DIFF
--- a/src/http.h
+++ b/src/http.h
@@ -30,6 +30,7 @@
 #define ERR_HTTP_BAD_RES_CODE	-5
 #define ERR_HTTP_PERMISSION	-6
 #define ERR_HTTP_NO_COOKIE	-7
+#define ERR_HTTP_PASSWORD_EXPIRED	-8
 
 /*
  * URL-encodes a string for HTTP requests.
@@ -59,6 +60,8 @@ static inline const char *err_http_str(int code)
 		return "Permission denied";
 	else if (code == ERR_HTTP_NO_COOKIE)
 		return "No cookie given";
+	else if (code == ERR_HTTP_PASSWORD_EXPIRED)
+		return "Password expired or change required";
 	return "unknown";
 }
 
@@ -70,5 +73,6 @@ int auth_log_out(struct tunnel *tunnel);
 int auth_request_vpn_allocation(struct tunnel *tunnel);
 int auth_get_config(struct tunnel *tunnel);
 int auth_set_cookie(struct tunnel *tunnel, const char *line);
+int auth_change_password(struct tunnel *tunnel, const char *old_password, const char *new_password);
 
 #endif

--- a/src/tunnel.h
+++ b/src/tunnel.h
@@ -73,6 +73,13 @@ struct tunnel {
 
 	struct ipv4_config ipv4;
 
+	/* Password change context (saved from OTP + password change flow) */
+	char pwd_change_magic[64];
+	char pwd_change_reqid[64];
+	char pwd_change_grpid[128];
+	char pwd_change_username[64];
+	int has_pwd_change_context;
+
 	int (*on_ppp_if_up)(struct tunnel *tunnel);
 	int (*on_ppp_if_down)(struct tunnel *tunnel);
 };


### PR DESCRIPTION
## 요약
이 PR은 2FA/OTP 흐름을 포함하여 VPN 인증 중 비밀번호 만료 및 비밀번호 변경 요구사항을 처리하는 포괄적인 지원을 추가합니다.

## 변경 사항
- HTTP 401 응답에서 비밀번호 만료/변경 프롬프트 감지
- 비밀번호 변경 페이지에서 HTML 폼 필드(magic, reqid, grpid) 파싱
- 여러 엔드포인트를 지원하는 `auth_change_password()` 함수 구현
- `ERR_HTTP_PASSWORD_EXPIRED` 에러 코드 추가
- OTP 인증 후 비밀번호 변경 처리
- 사용자에게 새 비밀번호 및 확인 프롬프트 표시
- OTP 흐름을 위한 터널 구조체에 비밀번호 변경 컨텍스트 저장
- 비밀번호 변경 성공 후 자동으로 재인증

## 동기
이를 통해 openfortivpn이 주기적인 비밀번호 변경을 요구하는 FortiGate 게이트웨이를 인증 실패 없이 처리할 수 있습니다.

## 테스트 계획
- 비밀번호 만료가 활성화된 FortiGate 게이트웨이에 대해 테스트
- OTP + 비밀번호 변경 흐름 검증
- 비밀번호 변경 후 성공적인 재인증 확인