### PR TITLE
Check authentication result (return value)

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -64,6 +64,7 @@ struct x509_digest {
 #define OTP_SIZE	64
 #define REALM_SIZE	63
 #define PEM_PASSPHRASE_SIZE	31
+#define AUTH_RET_SIZE	3	/* Numeric value (e.g. "0", "1", "6") */
 
 /*
  * RFC 6265 does not limit the size of cookies:

--- a/src/http.c
+++ b/src/http.c
@@ -637,6 +637,7 @@ int auth_log_in(struct tunnel *tunnel)
 	char username[3 * USERNAME_SIZE + 1];
 	char password[3 * PASSWORD_SIZE + 1];
 	char realm[3 * REALM_SIZE + 1];
+	char auth_ret_text[AUTH_RET_SIZE + 1];
 	char reqid[32] = { '\0' };
 	char polid[32] = { '\0' };
 	char group[128] = { '\0' };
@@ -713,6 +714,28 @@ int auth_log_in(struct tunnel *tunnel)
 
 	if (ret != 1)
 		goto end;
+
+	ret = get_value_from_response(res, "ret=", auth_ret_text, sizeof(auth_ret_text));
+	if (ret == 1) {
+		int auth_ret = strtol(auth_ret_text, NULL, 10);
+
+		switch (auth_ret) {
+		case 0:
+			log_error("Authentication failed\n");
+			ret = ERR_HTTP_PERMISSION;
+			goto end;
+		case 1:
+			log_debug("Authentication succeeded\n");
+			break;
+		case 6:
+			log_error("Gateway replied to authentication with an unsupported challenge\n");
+			ret = ERR_HTTP_PERMISSION;
+			goto end;
+		default:
+			log_warn("Unknown authentication result: %d\n", auth_ret);
+			break;
+		}
+	}
 
 	/* Probably one-time password required */
 	if (strncmp(res, "HTTP/1.1 401 Authorization Required\r\n", 37) == 0) {


### PR DESCRIPTION
```
Authentication replies from gateway include a "ret" value that provides
info about authentication result.

Examples:
ret=0,redir=/remote/login?&err=sslvpn_login_password_expired&lang=en
ret=0,redir=/remote/login?&err=sslvpn_login_permission_denied&lang=en
ret=1,redir=/remote/hostcheck_install?auth_type=1&user=0123456789ABCDEF&&grpname=0123456789ABCDEF012345&portal=0123456789ABCDEF0123456789&rip=1.1.1.1&realm=
ret=6,actionurl=/remote/logincheck,magic=1-12345678,reqid=0,grpid=1,pid=249,is_chal_rsp=1,pass_renew=1,allow_cancel=1,chal_msg=Your password will expire in 3 days. Would you like to change it?

Extract & use that value to determine authentication status.
```