### PR TITLE
Extract & log authentication challenge message

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -46,6 +46,7 @@ struct x509_digest {
 #define REALM_SIZE	63
 #define PEM_PASSPHRASE_SIZE	31
 #define AUTH_RET_SIZE	3	/* Numeric value (e.g. "0", "1", "6") */
+#define CHAL_MSG_SIZE	128	/* E.g. "Your password will expire in 3 days. Would you like to change it?" */
 
 /*
  * RFC 6265 does not limit the size of cookies:

--- a/src/http.c
+++ b/src/http.c
@@ -718,6 +718,7 @@ int auth_log_in(struct tunnel *tunnel)
 	ret = get_value_from_response(res, "ret=", auth_ret_text, sizeof(auth_ret_text));
 	if (ret == 1) {
 		int auth_ret = strtol(auth_ret_text, NULL, 10);
+		char chal_msg[CHAL_MSG_SIZE + 1];
 
 		switch (auth_ret) {
 		case 0:
@@ -729,6 +730,12 @@ int auth_log_in(struct tunnel *tunnel)
 			break;
 		case 6:
 			log_error("Gateway replied to authentication with an unsupported challenge\n");
+
+			ret = get_value_from_response(res, "chal_msg=", chal_msg,
+						      sizeof(chal_msg));
+			if (ret == 1)
+				log_info("Challenge message: \"%s\"\n", chal_msg);
+
 			ret = ERR_HTTP_PERMISSION;
 			goto end;
 		default:


### PR DESCRIPTION
```
When gateway replies with a challenge it (usually?) provides a relevant
message.

Example:
ret=6,actionurl=/remote/logincheck,magic=1-12345678,reqid=0,grpid=1,pid=249,is_chal_rsp=1,pass_renew=1,allow_cancel=1,chal_msg=Your password will expire in 3 days. Would you like to change it?

Extract such messages and log them so user can understand what went
wrong.
```