### PR TITLE
Fix support for --pppd-plugin (passing plugin to pppd)

### DIFF
--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -357,6 +357,10 @@ static int pppd_run(struct tunnel *tunnel)
 			}
 		}
 		if (tunnel->config->pppd_plugin) {
+			if (ofv_append_varr(&pppd_args, "plugin")) {
+				free(pppd_args.data);
+				return 1;
+			}
 			if (ofv_append_varr(&pppd_args, tunnel->config->pppd_plugin)) {
 				free(pppd_args.data);
 				return 1;


### PR DESCRIPTION
```
Running pppd with plugin specified requires "plugin <plugin>" syntax.

While removing support for deprecated --plugin option the "plugin" part
was accidentally dropped. This introduced regression: --pppd-plugin
doesn't work anymore.

This change fixes:
NetworkManager[22657]: DEBUG:  Starting IO through the tunnel
NetworkManager[22657]: DEBUG:  pppd_read thread
NetworkManager[22657]: DEBUG:  ssl_read thread
NetworkManager[22657]: DEBUG:  ssl_write thread
NetworkManager[22657]: DEBUG:  if_config thread
NetworkManager[22659]: /usr/sbin/pppd: unrecognized option '/usr/lib64/pppd/2.4.7/nm-fortisslvpn-pppd-plugin.so'
NetworkManager[22659]: pppd version 2.4.7
NetworkManager[22659]: Usage: /usr/sbin/pppd [ options ], where options are:
NetworkManager[22659]:         <device>        Communicate over the named device
NetworkManager[22659]:         <speed>                Set the baud rate to <speed>
NetworkManager[22659]:         <loc>:<rem>        Set the local and/or remote interface IP
NetworkManager[22659]:                         addresses.  Either one may be omitted.
NetworkManager[22659]:         asyncmap <n>        Set the desired async map to hex <n>
NetworkManager[22659]:         auth                Require authentication from peer
NetworkManager[22659]:         connect <p>     Invoke shell command <p> to set up the serial line
NetworkManager[22659]:         crtscts                Use hardware RTS/CTS flow control
NetworkManager[22659]:         defaultroute        Add default route through interface
NetworkManager[22659]:         file <f>        Take options from file <f>
NetworkManager[22659]:         modem                Use modem control lines
NetworkManager[22659]:         mru <n>                Set MRU value to <n> for negotiation
NetworkManager[22659]: See pppd(8) for more options.
pppd[22659]: unrecognized option '/usr/lib64/pppd/2.4.7/nm-fortisslvpn-pppd-plugin.so'
```