### PR TITLE
Speed up SAML Auth: Open the SAML URL and close the tab automatically

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -46,6 +46,8 @@ const struct vpn_config invalid_cfg = {
 	.password_set = 0,
 	.cookie = NULL,
 	.saml_port = 0,
+	.saml_auto_open = -1,
+	.saml_instant_close = -1,
 	.saml_session_id = {'\0'},
 	.otp = {'\0'},
 	.otp_prompt = NULL,
@@ -427,6 +429,24 @@ int load_config(struct vpn_config *cfg, const char *filename)
 				goto err_free;
 			}
 			cfg->saml_port = (uint16_t)port;
+		} else if (strcmp(key, "saml-auto-open") == 0) {
+			int saml_auto_open = strtob(val);
+
+			if (saml_auto_open < 0) {
+				log_warn("Bad saml-auto-open in configuration file: \"%s\".\n",
+				         val);
+				continue;
+			}
+			cfg->saml_auto_open = saml_auto_open;
+		} else if (strcmp(key, "saml-instant-close") == 0) {
+			int saml_instant_close = strtob(val);
+
+			if (saml_instant_close < 0) {
+				log_warn("Bad saml-instant-close in configuration file: \"%s\".\n",
+				         val);
+				continue;
+			}
+			cfg->saml_instant_close = saml_instant_close;
 		} else if (strcmp(key, "user-key") == 0) {
 			free(cfg->user_key);
 			cfg->user_key = strdup(val);
@@ -546,6 +566,10 @@ void merge_config(struct vpn_config *dst, struct vpn_config *src)
 	}
 	if (src->saml_port != 0)
 		dst->saml_port = src->saml_port;
+	if (src->saml_auto_open != invalid_cfg.saml_auto_open)
+		dst->saml_auto_open = src->saml_auto_open;
+	if (src->saml_instant_close != invalid_cfg.saml_instant_close)
+		dst->saml_instant_close = src->saml_instant_close;
 	if (src->pinentry) {
 		free(dst->pinentry);
 		dst->pinentry = src->pinentry;

--- a/src/config.h
+++ b/src/config.h
@@ -75,6 +75,8 @@ struct vpn_config {
 	char			otp[OTP_SIZE + 1];
 	char			*cookie;
 	uint16_t		saml_port;
+	int			saml_auto_open;
+	int			saml_instant_close;
 	char			saml_session_id[MAX_SAML_SESSION_ID_LENGTH + 1];
 	char			*otp_prompt;
 	unsigned int		otp_delay;

--- a/src/http_server.c
+++ b/src/http_server.c
@@ -27,6 +27,7 @@
 #include <unistd.h>
 
 #include <ctype.h>
+#include <stdlib.h>
 #include <string.h>
 
 static void print_url(const struct vpn_config *cfg)
@@ -79,6 +80,54 @@ static void print_url(const struct vpn_config *cfg)
 	         encoded_realm);
 
 	log_info("Authenticate at '%s'\n", url);
+
+	if (cfg->saml_auto_open && url) {
+		log_info("Opening URL in default browser...\n");
+#if defined(__APPLE__)
+		// When running with sudo, use the original user's browser settings
+		const char *sudo_user = getenv("SUDO_USER");
+		if (sudo_user && sudo_user[0] != '\0') {
+			char *cmd = malloc(strlen(url) + strlen(sudo_user) + 32);
+			if (cmd) {
+				sprintf(cmd, "sudo -u %s open '%s'", sudo_user, url);
+				system(cmd);
+				free(cmd);
+			}
+		} else {
+			char *cmd = malloc(strlen(url) + 16);
+			if (cmd) {
+				sprintf(cmd, "open '%s'", url);
+				system(cmd);
+				free(cmd);
+			}
+		}
+#elif defined(_WIN32)
+		char *cmd = malloc(strlen(url) + 16);
+		if (cmd) {
+			sprintf(cmd, "start '%s'", url);
+			system(cmd);
+			free(cmd);
+		}
+#else
+		// When running with sudo, use the original user's browser settings
+		const char *sudo_user = getenv("SUDO_USER");
+		if (sudo_user && sudo_user[0] != '\0') {
+			char *cmd = malloc(strlen(url) + strlen(sudo_user) + 48);
+			if (cmd) {
+				sprintf(cmd, "sudo -u %s xdg-open '%s' 2>/dev/null", sudo_user, url);
+				system(cmd);
+				free(cmd);
+			}
+		} else {
+			char *cmd = malloc(strlen(url) + 32);
+			if (cmd) {
+				sprintf(cmd, "xdg-open '%s' 2>/dev/null", url);
+				system(cmd);
+				free(cmd);
+			}
+		}
+#endif
+	}
 
 end:
 	free(url);
@@ -136,7 +185,7 @@ end:
 	free(replyHeaderBuffer);
 }
 
-static int process_request(int new_socket, char *id)
+static int process_request(int new_socket, char *id, const struct vpn_config *cfg)
 {
 	log_info("Processing HTTP SAML request\n");
 
@@ -210,13 +259,22 @@ static int process_request(int new_socket, char *id)
 		return -1;
 	}
 
-	send_status_response(new_socket,
-	                     "SAML session id received from Fortinet server. VPN will be established...<br>\r\n"
-	                     "You may close this browser tab now.<br>\r\n"
-	                     "<script>\r\n"
-	                     "window.setTimeout(() => { window.close(); }, 5000);\r\n"
-	                     "document.write(\"<br>This window will close automatically in 5 seconds.\");\r\n"
-	                     "</script>\r\n");
+	if (cfg->saml_instant_close) {
+		send_status_response(new_socket,
+		                     "SAML session id received from Fortinet server. VPN will be established...<br>\r\n"
+		                     "You may close this browser tab now.<br>\r\n"
+		                     "<script>\r\n"
+		                     "window.close();\r\n"
+		                     "</script>\r\n");
+	} else {
+		send_status_response(new_socket,
+		                     "SAML session id received from Fortinet server. VPN will be established...<br>\r\n"
+		                     "You may close this browser tab now.<br>\r\n"
+		                     "<script>\r\n"
+		                     "window.setTimeout(() => { window.close(); }, 5000);\r\n"
+		                     "document.write(\"<br>This window will close automatically in 5 seconds.\");\r\n"
+		                     "</script>\r\n");
+	}
 	return 0;
 }
 
@@ -299,7 +357,7 @@ int wait_for_http_request(struct vpn_config *config)
 			continue;
 		}
 
-		int result = process_request(new_socket, config->saml_session_id);
+		int result = process_request(new_socket, config->saml_session_id, config);
 
 		close(new_socket);
 		if (result == 0)

--- a/src/main.c
+++ b/src/main.c
@@ -79,6 +79,7 @@
 #define usage \
 "Usage: openfortivpn [<host>[:<port>]] [-u <user>] [-p <pass>]\n" \
 "                    [--cookie=<cookie>] [--cookie-on-stdin] [--saml-login]\n" \
+"                    [--saml-auto-open] [--saml-instant-close]\n" \
 "                    [--otp=<otp>] [--otp-delay=<delay>] [--otp-prompt=<prompt>]\n" \
 "                    [--pinentry=<program>] [--realm=<realm>]\n" \
 "                    [--ifname=<ifname>] [--set-routes=<0|1>]\n" \
@@ -119,6 +120,10 @@ PPPD_USAGE \
 "  --cookie=<cookie>             A valid session cookie (SVPNCOOKIE).\n" \
 "  --cookie-on-stdin             Read the cookie (SVPNCOOKIE) from standard input.\n" \
 "  --saml-login[=port]           Run a http server to handle SAML login requests\n" \
+"  --saml-auto-open              Automatically open the SAML authentication URL\n" \
+"                                in the default browser.\n" \
+"  --saml-instant-close          Close the browser tab immediately after SAML\n" \
+"                                authentication instead of waiting 5 seconds.\n" \
 "  -o <otp>, --otp=<otp>         One-Time-Password.\n" \
 "  --otp-prompt=<prompt>         Search for the OTP prompt starting with this string.\n" \
 "  --otp-delay=<delay>           Wait <delay> seconds before sending the OTP.\n" \
@@ -228,6 +233,8 @@ int main(int argc, char *argv[])
 		.password_set = 0,
 		.cookie = NULL,
 		.saml_port = 0,
+		.saml_auto_open = 0,
+		.saml_instant_close = 0,
 		.saml_session_id = {'\0'},
 		.otp = {'\0'},
 		.otp_prompt = NULL,
@@ -291,6 +298,8 @@ int main(int argc, char *argv[])
 		{"cookie",               required_argument, NULL, 0},
 		{"cookie-on-stdin",      no_argument,       NULL, 0},
 		{"saml-login",           optional_argument, NULL, 0},
+		{"saml-auto-open",       no_argument, &cli_cfg.saml_auto_open, 1},
+		{"saml-instant-close",   no_argument, &cli_cfg.saml_instant_close, 1},
 		{"otp",                  required_argument, NULL, 'o'},
 		{"otp-prompt",           required_argument, NULL, 0},
 		{"otp-delay",            required_argument, NULL, 0},


### PR DESCRIPTION
## Problem

When using SAML login (`--saml-login`), the user has to do two manual steps:
1. Click the URL in the output of `openfortivpn` so it opens in the browser.
2. Close the tab after successfull authentication (only auto-closes after 5 seconds)

I wanted SAML login without those two manual steps

## Solution

I added two options:

* `--saml-auto-open` automatically opens the URL in the user's default browser. Also detects if run with `sudo` and opens the browser for the original user. Uses `xdg-open` on Linux and `open` on macOS.
* `--saml-instant-close` instantly closes the browser tab after successfull SAML login with `window.close();`, doesn't wait 5 seconds.

Example usage:
```
sudo openfortivpn vpn.example.com --saml-login --saml-auto-open --saml-instant-close
```

It's quite convenient and could also be the default, at least `--saml-auto-open`, but for now it's just two extra command line arguments.