### PR TITLE
macOS: register VPN DNS via SystemConfiguration framework

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,7 @@ AC_CONFIG_SRCDIR([src/main.c])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 
 # Checks for programs.
+AC_CANONICAL_HOST
 AC_PROG_CC
 AC_PROG_MKDIR_P
 AC_PROG_SED

--- a/configure.ac
+++ b/configure.ac
@@ -180,6 +180,22 @@ LIBS="${OPENSSL_LIBS} ${LIBS}"
 CPPFLAGS="${save_openssl_CPPFLAGS}"
 LIBS="${save_openssl_LIBS}"
 
+# Link macOS DNS frameworks and expose a feature macro for SCDynamicStore support.
+AC_MSG_CHECKING([for macOS SystemConfiguration framework])
+case "$host_os" in
+	darwin*)
+		AC_DEFINE([HAVE_SYSTEMCONFIGURATION], [1],
+		          [Define to 1 on macOS for SCDynamicStore DNS support])
+		LIBS="$LIBS -framework SystemConfiguration -framework CoreFoundation"
+		AC_MSG_RESULT([yes])
+		;;
+	*)
+		AC_DEFINE([HAVE_SYSTEMCONFIGURATION], [0],
+		          [Define to 0 when macOS SystemConfiguration is unavailable])
+		AC_MSG_RESULT([no])
+		;;
+esac
+
 # Specialised checks for particular features.
 # When cross compile, don't run the tests.
 AC_ARG_WITH([rt_dst],

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -37,6 +37,11 @@
 #include <stdint.h>
 #include <string.h>
 
+#if HAVE_SYSTEMCONFIGURATION
+#include <SystemConfiguration/SCDynamicStore.h>
+#include <CoreFoundation/CoreFoundation.h>
+#endif
+
 #define IPV4_GET_ROUTE_BUFFER_CHUNK_SIZE 65536
 #define SHOW_ROUTE_BUFFER_SIZE 128
 
@@ -1436,3 +1441,134 @@ err_close:
 		         strerror(errno));
 	return ret;
 }
+
+#if HAVE_SYSTEMCONFIGURATION
+/*
+ * On macOS, DNS is managed by configd via SCDynamicStore, not /etc/resolv.conf.
+ * We register a supplemental resolver with SupplementalMatchDomains set to [""]
+ * (empty string = match all domains), so all DNS queries are sent to the VPN
+ * nameservers. The search domain is also set for short hostname resolution.
+ */
+
+#define OPENFORTIVPN_DNS_KEY \
+	CFSTR("State:/Network/Service/openfortivpn/DNS")
+
+int ipv4_set_dns_scf(struct tunnel *tunnel)
+{
+	SCDynamicStoreRef store = NULL;
+	CFMutableDictionaryRef dns_dict = NULL;
+	CFMutableArrayRef servers = NULL;
+	CFStringRef suffix = NULL;
+	CFArrayRef domains = NULL;
+	CFArrayRef match_all = NULL;
+	int ret = 1;
+
+	store = SCDynamicStoreCreate(NULL, CFSTR("openfortivpn"), NULL, NULL);
+	if (!store) {
+		log_warn("SCDynamicStore could not be opened.\n");
+		return 1;
+	}
+
+	dns_dict = CFDictionaryCreateMutable(NULL, 0,
+		&kCFTypeDictionaryKeyCallBacks,
+		&kCFTypeDictionaryValueCallBacks);
+	if (!dns_dict)
+		goto out;
+
+	/* Nameservers */
+	servers = CFArrayCreateMutable(NULL, 2, &kCFTypeArrayCallBacks);
+	if (!servers)
+		goto out;
+
+	if (tunnel->ipv4.ns1_addr.s_addr) {
+		CFStringRef s = CFStringCreateWithCString(NULL,
+			inet_ntoa(tunnel->ipv4.ns1_addr),
+			kCFStringEncodingASCII);
+		if (s) {
+			CFArrayAppendValue(servers, s);
+			CFRelease(s);
+		}
+	}
+	if (tunnel->ipv4.ns2_addr.s_addr) {
+		CFStringRef s = CFStringCreateWithCString(NULL,
+			inet_ntoa(tunnel->ipv4.ns2_addr),
+			kCFStringEncodingASCII);
+		if (s) {
+			CFArrayAppendValue(servers, s);
+			CFRelease(s);
+		}
+	}
+	if (CFArrayGetCount(servers) > 0)
+		CFDictionarySetValue(dns_dict, CFSTR("ServerAddresses"), servers);
+
+	/* Search domain for short hostname resolution */
+	if (tunnel->ipv4.dns_suffix) {
+		suffix = CFStringCreateWithCString(NULL,
+			tunnel->ipv4.dns_suffix, kCFStringEncodingUTF8);
+		if (suffix) {
+			domains = CFArrayCreate(NULL,
+				(const void **)&suffix, 1,
+				&kCFTypeArrayCallBacks);
+			if (domains)
+				CFDictionarySetValue(dns_dict,
+					CFSTR("SearchDomains"), domains);
+		}
+	}
+
+	if (CFDictionaryGetCount(dns_dict) == 0) {
+		log_debug("No DNS data to write to SCDynamicStore.\n");
+		ret = 0;
+		goto out;
+	}
+
+	/* Empty string = match all domains, so all queries use VPN DNS */
+	CFStringRef empty = CFSTR("");
+	match_all = CFArrayCreate(NULL,
+		(const void **)&empty, 1, &kCFTypeArrayCallBacks);
+	if (match_all)
+		CFDictionarySetValue(dns_dict,
+			CFSTR("SupplementalMatchDomains"), match_all);
+
+	if (SCDynamicStoreSetValue(store, OPENFORTIVPN_DNS_KEY, dns_dict)) {
+		log_info("DNS configuration written to macOS System Configuration.\n");
+		ret = 0;
+	} else {
+		log_warn("Could not write DNS to SCDynamicStore.\n");
+	}
+
+out:
+	if (match_all)
+		CFRelease(match_all);
+	if (domains)
+		CFRelease(domains);
+	if (suffix)
+		CFRelease(suffix);
+	if (servers)
+		CFRelease(servers);
+	if (dns_dict)
+		CFRelease(dns_dict);
+	if (store)
+		CFRelease(store);
+	return ret;
+}
+
+int ipv4_clear_dns_scf(void)
+{
+	SCDynamicStoreRef store;
+	int ret = 1;
+
+	store = SCDynamicStoreCreate(NULL, CFSTR("openfortivpn"), NULL, NULL);
+	if (!store) {
+		log_warn("SCDynamicStore could not be opened.\n");
+		return 1;
+	}
+
+	if (SCDynamicStoreRemoveValue(store, OPENFORTIVPN_DNS_KEY))
+		ret = 0;
+	else
+		log_warn("Could not remove DNS from SCDynamicStore.\n");
+
+	CFRelease(store);
+	return ret;
+}
+#endif

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -1445,13 +1445,26 @@ err_close:
 #if HAVE_SYSTEMCONFIGURATION
 /*
  * On macOS, DNS is managed by configd via SCDynamicStore, not /etc/resolv.conf.
- * We register a supplemental resolver with SupplementalMatchDomains set to [""]
- * (empty string = match all domains), so all DNS queries are sent to the VPN
- * nameservers. The search domain is also set for short hostname resolution.
+ *
+ * We register a supplemental resolver under our own key with
+ * SupplementalMatchDomains set to [""] (empty string = match all domains).
+ * This routes all DNS queries to the VPN nameservers without binding them to
+ * a specific network interface, so they are reachable over the ppp0 split
+ * routes even though ppp0 is not the primary interface.
+ *
+ * macOS only applies SearchDomains for short hostname expansion from the
+ * primary (non-supplemental) resolver, which is tied to the primary network
+ * interface. To enable "ping host" → "host.corp" expansion, we add
+ * SearchDomains to the primary service's static DNS configuration
+ * (Setup: prefix). This key is stable across DHCP renewals. The original
+ * value is saved and fully restored on disconnect.
  */
 
 #define OPENFORTIVPN_DNS_KEY \
 	CFSTR("State:/Network/Service/openfortivpn/DNS")
+
+static CFStringRef saved_primary_dns_key = NULL;
+static CFDictionaryRef saved_primary_dns = NULL;
 
 int ipv4_set_dns_scf(struct tunnel *tunnel)
 {
@@ -1475,15 +1488,13 @@ int ipv4_set_dns_scf(struct tunnel *tunnel)
 	if (!dns_dict)
 		goto out;
 
-	/* Nameservers */
 	servers = CFArrayCreateMutable(NULL, 2, &kCFTypeArrayCallBacks);
 	if (!servers)
 		goto out;
 
 	if (tunnel->ipv4.ns1_addr.s_addr) {
 		CFStringRef s = CFStringCreateWithCString(NULL,
-			inet_ntoa(tunnel->ipv4.ns1_addr),
-			kCFStringEncodingASCII);
+			inet_ntoa(tunnel->ipv4.ns1_addr), kCFStringEncodingASCII);
 		if (s) {
 			CFArrayAppendValue(servers, s);
 			CFRelease(s);
@@ -1491,8 +1502,7 @@ int ipv4_set_dns_scf(struct tunnel *tunnel)
 	}
 	if (tunnel->ipv4.ns2_addr.s_addr) {
 		CFStringRef s = CFStringCreateWithCString(NULL,
-			inet_ntoa(tunnel->ipv4.ns2_addr),
-			kCFStringEncodingASCII);
+			inet_ntoa(tunnel->ipv4.ns2_addr), kCFStringEncodingASCII);
 		if (s) {
 			CFArrayAppendValue(servers, s);
 			CFRelease(s);
@@ -1501,7 +1511,6 @@ int ipv4_set_dns_scf(struct tunnel *tunnel)
 	if (CFArrayGetCount(servers) > 0)
 		CFDictionarySetValue(dns_dict, CFSTR("ServerAddresses"), servers);
 
-	/* Search domain for short hostname resolution */
 	if (tunnel->ipv4.dns_suffix) {
 		suffix = CFStringCreateWithCString(NULL,
 			tunnel->ipv4.dns_suffix, kCFStringEncodingUTF8);
@@ -1521,7 +1530,7 @@ int ipv4_set_dns_scf(struct tunnel *tunnel)
 		goto out;
 	}
 
-	/* Empty string = match all domains, so all queries use VPN DNS */
+	/* Empty string = match all — unbound queries follow the routing table */
 	CFStringRef empty = CFSTR("");
 	match_all = CFArrayCreate(NULL,
 		(const void **)&empty, 1, &kCFTypeArrayCallBacks);
@@ -1529,11 +1538,60 @@ int ipv4_set_dns_scf(struct tunnel *tunnel)
 		CFDictionarySetValue(dns_dict,
 			CFSTR("SupplementalMatchDomains"), match_all);
 
-	if (SCDynamicStoreSetValue(store, OPENFORTIVPN_DNS_KEY, dns_dict)) {
-		log_info("DNS configuration written to macOS System Configuration.\n");
-		ret = 0;
-	} else {
+	if (!SCDynamicStoreSetValue(store, OPENFORTIVPN_DNS_KEY, dns_dict)) {
 		log_warn("Could not write DNS to SCDynamicStore.\n");
+		goto out;
+	}
+	log_info("DNS configuration written to macOS System Configuration.\n");
+	ret = 0;
+
+	/*
+	 * Add SearchDomains to the primary service's static (Setup:) DNS
+	 * entry so that the system resolver expands short hostnames.
+	 * We save the original value and restore it on disconnect.
+	 */
+	if (domains) {
+		CFDictionaryRef global_ipv4 = SCDynamicStoreCopyValue(store,
+			CFSTR("State:/Network/Global/IPv4"));
+		if (global_ipv4) {
+			CFStringRef uuid = CFDictionaryGetValue(global_ipv4,
+				CFSTR("PrimaryService"));
+			if (uuid) {
+				saved_primary_dns_key = CFStringCreateWithFormat(
+					NULL, NULL,
+					CFSTR("Setup:/Network/Service/%@/DNS"),
+					uuid);
+				if (saved_primary_dns_key) {
+					saved_primary_dns = SCDynamicStoreCopyValue(
+						store, saved_primary_dns_key);
+
+					CFMutableDictionaryRef new_dns;
+					if (saved_primary_dns)
+						new_dns = CFDictionaryCreateMutableCopy(
+							NULL, 0, saved_primary_dns);
+					else
+						new_dns = CFDictionaryCreateMutable(
+							NULL, 0,
+							&kCFTypeDictionaryKeyCallBacks,
+							&kCFTypeDictionaryValueCallBacks);
+
+					if (new_dns) {
+						CFDictionarySetValue(new_dns,
+							CFSTR("SearchDomains"),
+							domains);
+						if (!SCDynamicStoreSetValue(store,
+								saved_primary_dns_key,
+								new_dns))
+							log_warn("Could not add "
+								"SearchDomains to "
+								"primary service "
+								"DNS.\n");
+						CFRelease(new_dns);
+					}
+				}
+			}
+			CFRelease(global_ipv4);
+		}
 	}
 
 out:
@@ -1567,6 +1625,19 @@ int ipv4_clear_dns_scf(void)
 		ret = 0;
 	else
 		log_warn("Could not remove DNS from SCDynamicStore.\n");
+
+	if (saved_primary_dns_key) {
+		if (saved_primary_dns) {
+			SCDynamicStoreSetValue(store, saved_primary_dns_key,
+				saved_primary_dns);
+			CFRelease(saved_primary_dns);
+			saved_primary_dns = NULL;
+		} else {
+			SCDynamicStoreRemoveValue(store, saved_primary_dns_key);
+		}
+		CFRelease(saved_primary_dns_key);
+		saved_primary_dns_key = NULL;
+	}
 
 	CFRelease(store);
 	return ret;

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -38,7 +38,7 @@
 #include <string.h>
 
 #if HAVE_SYSTEMCONFIGURATION
-#include <SystemConfiguration/SCDynamicStore.h>
+#include <SystemConfiguration/SystemConfiguration.h>
 #include <CoreFoundation/CoreFoundation.h>
 #endif
 
@@ -1444,36 +1444,36 @@ err_close:
 
 #if HAVE_SYSTEMCONFIGURATION
 /*
- * On macOS, DNS is managed by configd via SCDynamicStore, not /etc/resolv.conf.
+ * macOS DNS via SCDynamicStore
  *
- * We register a supplemental resolver under our own key with
- * SupplementalMatchDomains set to [""] (empty string = match all domains).
- * This routes all DNS queries to the VPN nameservers without binding them to
- * a specific network interface, so they are reachable over the ppp0 split
- * routes even though ppp0 is not the primary interface.
+ * macOS ignores /etc/resolv.conf — DNS is managed by configd through
+ * SCDynamicStore.  We register a supplemental resolver under our own key.
  *
- * macOS only applies SearchDomains for short hostname expansion from the
- * primary (non-supplemental) resolver, which is tied to the primary network
- * interface. To enable "ping host" → "host.corp" expansion, we add
- * SearchDomains to the primary service's static DNS configuration
- * (Setup: prefix). This key is stable across DHCP renewals. The original
- * value is saved and fully restored on disconnect.
+ * When dns_suffix is available (e.g. "corp.com"):
+ *   Split-DNS — only *.corp.com queries go to the VPN nameservers.
+ *   configd automatically adds "corp.com" to the default resolver's
+ *   search domain list, so "ping host" expands to "host.corp.com".
+ *   Non-matching queries (google.com) keep using normal DNS.
+ *
+ * When dns_suffix is NOT available but DNS servers are provided:
+ *   Full-tunnel DNS — SupplementalMatchDomains is set to "" (empty
+ *   string = match all domains) so every query goes to the VPN.
+ *   Note: configd does not add search domains in this mode, so short
+ *   hostname expansion will not work.  This is a macOS limitation.
+ *
+ * Cleanup is a single key removal.  If the process crashes, only the
+ * supplemental entry is orphaned — normal DNS continues to work since
+ * the primary service is never modified.
  */
 
 #define OPENFORTIVPN_DNS_KEY \
 	CFSTR("State:/Network/Service/openfortivpn/DNS")
-
-static CFStringRef saved_primary_dns_key = NULL;
-static CFDictionaryRef saved_primary_dns = NULL;
 
 int ipv4_set_dns_scf(struct tunnel *tunnel)
 {
 	SCDynamicStoreRef store = NULL;
 	CFMutableDictionaryRef dns_dict = NULL;
 	CFMutableArrayRef servers = NULL;
-	CFStringRef suffix = NULL;
-	CFArrayRef domains = NULL;
-	CFArrayRef match_all = NULL;
 	int ret = 1;
 
 	store = SCDynamicStoreCreate(NULL, CFSTR("openfortivpn"), NULL, NULL);
@@ -1485,16 +1485,14 @@ int ipv4_set_dns_scf(struct tunnel *tunnel)
 	dns_dict = CFDictionaryCreateMutable(NULL, 0,
 		&kCFTypeDictionaryKeyCallBacks,
 		&kCFTypeDictionaryValueCallBacks);
-	if (!dns_dict)
-		goto out;
-
 	servers = CFArrayCreateMutable(NULL, 2, &kCFTypeArrayCallBacks);
-	if (!servers)
+	if (!dns_dict || !servers)
 		goto out;
 
 	if (tunnel->ipv4.ns1_addr.s_addr) {
 		CFStringRef s = CFStringCreateWithCString(NULL,
-			inet_ntoa(tunnel->ipv4.ns1_addr), kCFStringEncodingASCII);
+			inet_ntoa(tunnel->ipv4.ns1_addr),
+			kCFStringEncodingASCII);
 		if (s) {
 			CFArrayAppendValue(servers, s);
 			CFRelease(s);
@@ -1502,105 +1500,59 @@ int ipv4_set_dns_scf(struct tunnel *tunnel)
 	}
 	if (tunnel->ipv4.ns2_addr.s_addr) {
 		CFStringRef s = CFStringCreateWithCString(NULL,
-			inet_ntoa(tunnel->ipv4.ns2_addr), kCFStringEncodingASCII);
+			inet_ntoa(tunnel->ipv4.ns2_addr),
+			kCFStringEncodingASCII);
 		if (s) {
 			CFArrayAppendValue(servers, s);
 			CFRelease(s);
 		}
 	}
-	if (CFArrayGetCount(servers) > 0)
-		CFDictionarySetValue(dns_dict, CFSTR("ServerAddresses"), servers);
-
-	if (tunnel->ipv4.dns_suffix) {
-		suffix = CFStringCreateWithCString(NULL,
-			tunnel->ipv4.dns_suffix, kCFStringEncodingUTF8);
-		if (suffix) {
-			domains = CFArrayCreate(NULL,
-				(const void **)&suffix, 1,
-				&kCFTypeArrayCallBacks);
-			if (domains)
-				CFDictionarySetValue(dns_dict,
-					CFSTR("SearchDomains"), domains);
-		}
-	}
-
-	if (CFDictionaryGetCount(dns_dict) == 0) {
-		log_debug("No DNS data to write to SCDynamicStore.\n");
+	if (CFArrayGetCount(servers) == 0) {
+		log_debug("No DNS servers to configure.\n");
 		ret = 0;
 		goto out;
 	}
-
-	/* Empty string = match all — unbound queries follow the routing table */
-	CFStringRef empty = CFSTR("");
-	match_all = CFArrayCreate(NULL,
-		(const void **)&empty, 1, &kCFTypeArrayCallBacks);
-	if (match_all)
-		CFDictionarySetValue(dns_dict,
-			CFSTR("SupplementalMatchDomains"), match_all);
-
-	if (!SCDynamicStoreSetValue(store, OPENFORTIVPN_DNS_KEY, dns_dict)) {
-		log_warn("Could not write DNS to SCDynamicStore.\n");
-		goto out;
-	}
-	log_info("DNS configuration written to macOS System Configuration.\n");
-	ret = 0;
+	CFDictionarySetValue(dns_dict, CFSTR("ServerAddresses"), servers);
 
 	/*
-	 * Add SearchDomains to the primary service's static (Setup:) DNS
-	 * entry so that the system resolver expands short hostnames.
-	 * We save the original value and restore it on disconnect.
+	 * Split-DNS vs Full-tunnel:
+	 *   suffix present  → SupplementalMatchDomains: ["corp.com"]
+	 *   suffix absent   → SupplementalMatchDomains: [""]
 	 */
-	if (domains) {
-		CFDictionaryRef global_ipv4 = SCDynamicStoreCopyValue(store,
-			CFSTR("State:/Network/Global/IPv4"));
-		if (global_ipv4) {
-			CFStringRef uuid = CFDictionaryGetValue(global_ipv4,
-				CFSTR("PrimaryService"));
-			if (uuid) {
-				saved_primary_dns_key = CFStringCreateWithFormat(
-					NULL, NULL,
-					CFSTR("Setup:/Network/Service/%@/DNS"),
-					uuid);
-				if (saved_primary_dns_key) {
-					saved_primary_dns = SCDynamicStoreCopyValue(
-						store, saved_primary_dns_key);
+	CFStringRef match_domain;
+	if (tunnel->ipv4.dns_suffix)
+		match_domain = CFStringCreateWithCString(NULL,
+			tunnel->ipv4.dns_suffix, kCFStringEncodingUTF8);
+	else
+		match_domain = CFStringCreateCopy(NULL, CFSTR(""));
 
-					CFMutableDictionaryRef new_dns;
-					if (saved_primary_dns)
-						new_dns = CFDictionaryCreateMutableCopy(
-							NULL, 0, saved_primary_dns);
-					else
-						new_dns = CFDictionaryCreateMutable(
-							NULL, 0,
-							&kCFTypeDictionaryKeyCallBacks,
-							&kCFTypeDictionaryValueCallBacks);
-
-					if (new_dns) {
-						CFDictionarySetValue(new_dns,
-							CFSTR("SearchDomains"),
-							domains);
-						if (!SCDynamicStoreSetValue(store,
-								saved_primary_dns_key,
-								new_dns))
-							log_warn("Could not add "
-								"SearchDomains to "
-								"primary service "
-								"DNS.\n");
-						CFRelease(new_dns);
-					}
-				}
-			}
-			CFRelease(global_ipv4);
+	if (match_domain) {
+		CFArrayRef match_domains = CFArrayCreate(NULL,
+			(const void **)&match_domain, 1,
+			&kCFTypeArrayCallBacks);
+		if (match_domains) {
+			CFDictionarySetValue(dns_dict,
+				CFSTR("SupplementalMatchDomains"),
+				match_domains);
+			CFRelease(match_domains);
 		}
+		CFRelease(match_domain);
+	}
+
+	if (SCDynamicStoreSetValue(store, OPENFORTIVPN_DNS_KEY, dns_dict)) {
+		if (tunnel->ipv4.dns_suffix)
+			log_info("Split-DNS for '%s' written to macOS System "
+			         "Configuration.\n",
+			         tunnel->ipv4.dns_suffix);
+		else
+			log_info("Full-tunnel DNS written to macOS System "
+			         "Configuration.\n");
+		ret = 0;
+	} else {
+		log_warn("Could not write DNS to SCDynamicStore.\n");
 	}
 
 out:
-	if (match_all)
-		CFRelease(match_all);
-	if (domains)
-		CFRelease(domains);
-	if (suffix)
-		CFRelease(suffix);
 	if (servers)
 		CFRelease(servers);
 	if (dns_dict)
@@ -1613,7 +1565,6 @@ out:
 int ipv4_clear_dns_scf(void)
 {
 	SCDynamicStoreRef store;
-	int ret = 1;
 
 	store = SCDynamicStoreCreate(NULL, CFSTR("openfortivpn"), NULL, NULL);
 	if (!store) {
@@ -1621,25 +1572,8 @@ int ipv4_clear_dns_scf(void)
 		return 1;
 	}
 
-	if (SCDynamicStoreRemoveValue(store, OPENFORTIVPN_DNS_KEY))
-		ret = 0;
-	else
-		log_warn("Could not remove DNS from SCDynamicStore.\n");
-
-	if (saved_primary_dns_key) {
-		if (saved_primary_dns) {
-			SCDynamicStoreSetValue(store, saved_primary_dns_key,
-				saved_primary_dns);
-			CFRelease(saved_primary_dns);
-			saved_primary_dns = NULL;
-		} else {
-			SCDynamicStoreRemoveValue(store, saved_primary_dns_key);
-		}
-		CFRelease(saved_primary_dns_key);
-		saved_primary_dns_key = NULL;
-	}
-
+	SCDynamicStoreRemoveValue(store, OPENFORTIVPN_DNS_KEY);
 	CFRelease(store);
-	return ret;
+	return 0;
 }
 #endif

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -94,4 +94,11 @@ int ipv4_restore_routes(struct tunnel *tunnel);
 int ipv4_add_nameservers_to_resolv_conf(struct tunnel *tunnel);
 int ipv4_del_nameservers_from_resolv_conf(struct tunnel *tunnel);
 
+#if HAVE_SYSTEMCONFIGURATION
+
+int ipv4_set_dns_scf(struct tunnel *tunnel);
+int ipv4_clear_dns_scf(void);
+
+#endif
+
 #endif

--- a/src/tunnel.c
+++ b/src/tunnel.c
@@ -135,6 +135,9 @@ static int on_ppp_if_up(struct tunnel *tunnel)
 	if (tunnel->config->set_dns) {
 		log_info("Adding VPN nameservers...\n");
 		ipv4_add_nameservers_to_resolv_conf(tunnel);
+		#if HAVE_SYSTEMCONFIGURATION
+		ipv4_set_dns_scf(tunnel);
+		#endif
 	}
 
 	log_info("Tunnel is up and running.\n");
@@ -162,6 +165,9 @@ static int on_ppp_if_down(struct tunnel *tunnel)
 	if (tunnel->config->set_dns) {
 		log_info("Removing VPN nameservers...\n");
 		ipv4_del_nameservers_from_resolv_conf(tunnel);
+		#if HAVE_SYSTEMCONFIGURATION
+		ipv4_clear_dns_scf();
+		#endif
 	}
 
 	return 0;


### PR DESCRIPTION
## Problem

On macOS, `/etc/resolv.conf` is only a compatibility layer. The actual DNS
resolution uses the SystemConfiguration framework (`configd` / `SCDynamicStore`).
VPN nameservers written to `/etc/resolv.conf` are ignored by most applications
(`ping`, `curl`, browsers, etc.).

This is a long-standing issue reported in #534.

## Solution: Split-DNS via Supplemental Resolver

We register a supplemental resolver in `SCDynamicStore` under
`State:/Network/Service/openfortivpn/DNS`.

### When `dns_suffix` is available (e.g. "corp.com") — Split-DNS

`SupplementalMatchDomains` is set to the actual domain suffix:

```
State:/Network/Service/openfortivpn/DNS = {
    ServerAddresses: [x.x.x.x, x.x.x.x]
    SupplementalMatchDomains: ["corp.com"]
}
```

This gives us two things for free:
- **DNS routing**: only `*.corp.com` queries go to the VPN nameservers
- **Search domain**: configd automatically adds "corp.com" to the default
  resolver's search list, so `ping host` expands to `host.corp.com`

Non-matching queries (e.g. `google.com`) continue to use normal DNS
(home router / ISP). This is the **preferred mode**.

### When `dns_suffix` is NOT available — Full-tunnel DNS

`SupplementalMatchDomains` is set to `[""]` (empty string = match all):

```
State:/Network/Service/openfortivpn/DNS = {
    ServerAddresses: [x.x.x.x, x.x.x.x]
    SupplementalMatchDomains: [""]
}
```

All DNS queries go through the VPN. Short hostname expansion does **not**
work in this mode — this is a macOS configd limitation (see below).

## Why not modify the primary service's DNS?

I explored several alternative approaches before settling on this design:

### Approach 1: `Setup:/Network/Service/<UUID>/DNS` injection 

I injected `SearchDomains` into the primary network service's `Setup:` DNS
key. This worked but had serious drawbacks:

- **Crash safety**: `Setup:` keys are persistent (stored on disk). If
  openfortivpn crashes, the injected search domains remain permanently
  in the user's Wi-Fi/Ethernet DNS configuration until manual cleanup.
- **Modifies another service**: We were editing a service we don't own.
- **Complexity**: Required save/restore logic with static state variables.

### Approach 2: Writing to the PPP service's `State:/Network/Service/<UUID>/DNS`

pppd creates a real network service with PPP + IPv4 entries. We tried writing
DNS to that same service UUID. However, because ppp0 is not the primary
interface (split routing), configd classifies it as a **scoped resolver** —
it only handles queries that are already routed through ppp0, not general DNS.

### Approach 3: `State:/Network/Global/DNS` direct write

Writes are accepted but configd's IPMonitor plugin overwrites this key from
its own calculations, and the mDNSResponder notification chain doesn't fire,
so `scutil --dns` shows stale data.

### Why supplemental resolvers can't carry SearchDomains

This is hardcoded in Apple's configd source (`dns-configuration.c`):

1. `add_supplemental()` explicitly strips `SearchDomains` from supplemental resolvers
2. For empty-string match domains, `DomainName` is set to NULL
3. `extract_search_domains()` only reads `SearchDomains` from the default resolver

When `SupplementalMatchDomains` contains a **real domain** (e.g. "corp.com"),
configd adds it to the search list via the `DomainName` field. This is why
split-DNS mode gets search domains "for free" while full-tunnel mode cannot.

**If full-tunnel DNS with search domain support is needed**, the
`Setup:/Network/Service/<UUID>/DNS` injection approach can be re-introduced
as an opt-in feature behind a flag. However, for the common use case (accessing
corporate resources via VPN while keeping normal internet DNS), split-DNS is
the correct and safe solution.

## Changes

- **configure.ac**: Add `AC_CANONICAL_HOST` so `$host_os` is set and the
  `darwin*` case in the SystemConfiguration check matches on macOS
- **src/ipv4.c**: Implement `ipv4_set_dns_scf()` and `ipv4_clear_dns_scf()`
  using SCDynamicStore API with split-DNS / full-tunnel logic
- **src/ipv4.h**: Declare the new functions under `#if HAVE_SYSTEMCONFIGURATION`
- **src/tunnel.c**: Call the new functions from `on_ppp_if_up()` /
  `on_ppp_if_down()`

## Testing

Tested on macOS Tahoe 26.3.1 with FortiGate gateway:

```
$ scutil --dns   # after connecting (split-DNS mode)
resolver #N
  domain   : corp.com
  nameserver[0] : x.x.x.x
  nameserver[1] : x.x.x.x
  flags    : Supplemental, Request A records

$ ping host                        # expands via search domain to host.corp.com ✓
$ ping host.corp.com               # resolves via VPN DNS ✓
$ ping google.com                  # uses normal DNS, not VPN ✓
```

DNS entry is cleaned up on disconnect with a single key removal.

Closes #534