### PR TITLE
Show gateway error message

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -142,6 +142,41 @@ static const char *find_header(const char *res, const char *header,
 
 
 /*
+ * The gateway may embed the reason for refusing a connection in an HTML
+ * comment such as:
+ *     <!--sslvpnerrmsg=Permission denied.-->
+ *     <!--sslvpnerrmsgkey=sslvpn_login_permission_denied-->
+ * Show it to the user, otherwise it is only visible in the debug details.
+ */
+static void log_gateway_error_message(const char *response, uint32_t size)
+{
+	static const char prefix[] = "<!--sslvpnerrmsg";
+	const char *start, *end;
+	size_t remaining;
+
+	if (response == NULL)
+		return;
+
+	start = memmem(response, size, prefix, sizeof(prefix) - 1);
+	if (start == NULL)
+		return;
+	remaining = size - (start - response);
+
+	start = memchr(start, '=', remaining);
+	if (start == NULL)
+		return;
+	start++;
+	remaining = size - (start - response);
+
+	end = memmem(start, remaining, "-->", 3);
+	if (end == NULL || end == start || end - start > 256)
+		return;
+
+	log_error("Remote message: %.*s\n", (int)(end - start), start);
+}
+
+
+/*
  * Receives data from the HTTP server.
  *
  * @param[out] response  if not NULL, this pointer is set to reference
@@ -245,6 +280,7 @@ int http_receive(struct tunnel *tunnel,
 	           "<!--sslvpnerrmsgkey=sslvpn_login_permission_denied-->", 53) ||
 	    memmem(buffer, header_size, "permission_denied denied", 24) ||
 	    memmem(buffer, header_size, "Permission denied", 17)) {
+		log_gateway_error_message(buffer, bytes_read);
 		free(buffer);
 		return ERR_HTTP_PERMISSION;
 	}
@@ -665,7 +701,7 @@ int auth_log_in(struct tunnel *tunnel)
 	char token[128], tokenresponse[256], tokenparams[320];
 	char action_url[1024] = { '\0' };
 	char *res = NULL;
-	uint32_t response_size;
+	uint32_t response_size = 0;
 
 	url_encode(username, tunnel->config->username);
 	url_encode(realm, tunnel->config->realm);
@@ -851,6 +887,8 @@ int auth_log_in(struct tunnel *tunnel)
 	}
 
 end:
+	if (ret != 1)
+		log_gateway_error_message(res, response_size);
 	free(res);
 	return ret;
 }

--- a/src/http.c
+++ b/src/http.c
@@ -276,11 +276,17 @@ int http_receive(struct tunnel *tunnel,
 		}
 	}
 
+	/*
+	 * Whenever the gateway embeds a human-readable reason in an HTML
+	 * comment, surface it to the user, even if we don't recognize the
+	 * specific error checked for below.
+	 */
+	log_gateway_error_message(buffer, bytes_read);
+
 	if (memmem(&buffer[header_size], bytes_read - header_size,
 	           "<!--sslvpnerrmsgkey=sslvpn_login_permission_denied-->", 53) ||
 	    memmem(buffer, header_size, "permission_denied denied", 24) ||
 	    memmem(buffer, header_size, "Permission denied", 17)) {
-		log_gateway_error_message(buffer, bytes_read);
 		free(buffer);
 		return ERR_HTTP_PERMISSION;
 	}
@@ -701,7 +707,7 @@ int auth_log_in(struct tunnel *tunnel)
 	char token[128], tokenresponse[256], tokenparams[320];
 	char action_url[1024] = { '\0' };
 	char *res = NULL;
-	uint32_t response_size = 0;
+	uint32_t response_size;
 
 	url_encode(username, tunnel->config->username);
 	url_encode(realm, tunnel->config->realm);
@@ -887,8 +893,6 @@ int auth_log_in(struct tunnel *tunnel)
 	}
 
 end:
-	if (ret != 1)
-		log_gateway_error_message(res, response_size);
 	free(res);
 	return ret;
 }


### PR DESCRIPTION
The gateway may embed the reason for refusing a connection in an HTML comment, e.g. <!--sslvpnerrmsg=Permission denied.-->. This message was only visible with -vv. Extract it and log it as an error so users see why authentication failed, along with the usual generic error message.

(Note: This simple code has been created using Claude Code - my C skills are too rusty already)